### PR TITLE
feat(Domain): Allow setting domain directly from object

### DIFF
--- a/src/MayaFlux/API/Proxy/Creator.cpp
+++ b/src/MayaFlux/API/Proxy/Creator.cpp
@@ -6,6 +6,7 @@
 #include "MayaFlux/Buffers/AudioBuffer.hpp"
 #include "MayaFlux/Buffers/VKBuffer.hpp"
 #include "MayaFlux/Kakshya/Source/SoundFileContainer.hpp"
+#include "MayaFlux/Nodes/Node.hpp"
 
 namespace MayaFlux {
 
@@ -20,6 +21,12 @@ void register_node(const std::shared_ptr<Nodes::Node>& node, const CreationConte
     } else if (ctx.channels.has_value()) {
         for (uint32_t ch : ctx.channels.value()) {
             register_node(node, token, ch);
+        }
+    } else if (node->get_channel_mask() != 0) {
+        for (uint32_t ch = 0; ch < 32; ++ch) {
+            if (node->get_channel_mask() & (1 << ch)) {
+                register_node(node, token, ch);
+            }
         }
     } else {
         register_node(node, token, 0);
@@ -63,6 +70,20 @@ std::shared_ptr<Kakshya::SoundFileContainer> Creator::load_container(const std::
 std::vector<std::shared_ptr<Buffers::ContainerBuffer>> get_last_created_container_buffers()
 {
     return s_last_created_container_buffers;
+}
+
+std::shared_ptr<Nodes::Node> operator|(const std::shared_ptr<Nodes::Node>& node, Domain d)
+{
+    CreationContext ctx(d);
+    register_node(node, ctx);
+    return node;
+}
+
+std::shared_ptr<Buffers::Buffer> operator|(const std::shared_ptr<Buffers::Buffer>& buffer, Domain d)
+{
+    CreationContext ctx(d);
+    register_buffer(buffer, ctx);
+    return buffer;
 }
 
 } // namespace MayaFlux

--- a/src/MayaFlux/API/Proxy/Creator.hpp
+++ b/src/MayaFlux/API/Proxy/Creator.hpp
@@ -30,6 +30,9 @@ struct CreationContext {
     }
 };
 
+MAYAFLUX_API std::shared_ptr<Nodes::Node> operator|(const std::shared_ptr<Nodes::Node>& node, Domain d);
+MAYAFLUX_API std::shared_ptr<Buffers::Buffer> operator|(const std::shared_ptr<Buffers::Buffer>& buffer, Domain d);
+
 MAYAFLUX_API void register_node(const std::shared_ptr<Nodes::Node>& node, const CreationContext& ctx);
 MAYAFLUX_API void register_buffer(const std::shared_ptr<Buffers::Buffer>& buffer, const CreationContext& ctx);
 MAYAFLUX_API void register_container(const std::shared_ptr<Kakshya::SoundFileContainer>& container, const Domain& domain);


### PR DESCRIPTION
This PR introduces a more expressive syntax for assigning Domains to Nodes
and Buffers using the `|` operator. This removes the need to manually
construct a CreationContext and makes cross-modal node/buffer setup significantly
less verbose.

### What’s Included

- Adds `operator|` overloads for:
  - `std::shared_ptr<Nodes::Node> | Domain`
  - `std::shared_ptr<Buffers::Buffer> | Domain`
- Extends registration logic to support:
  - Explicit domain assignment
  - Channel-mask based routing (node selects its own active channels)
- Updates Creator logic to correctly register nodes/buffers based on
  domain and channel configuration.

### Purpose

This change improves API usability and readability. It allows cleaner,
more expressive code when assigning nodes or buffers to audio/graphics/data
domains, especially in networked or coroutine-driven setups.

### Issues Closed
- Closes #15 
- Part of #14 
