### PR TITLE
fix(NodeGraphManager): Use pre and post process hooks for node networks

### DIFF
--- a/src/MayaFlux/Core/ProcessingArchitecture.cpp
+++ b/src/MayaFlux/Core/ProcessingArchitecture.cpp
@@ -103,6 +103,11 @@ double NodeProcessingHandle::process_sample(uint32_t channel)
     return m_manager->process_sample(m_token, channel);
 }
 
+std::vector<std::vector<double>> NodeProcessingHandle::process_audio_networks(uint32_t num_samples, uint32_t channel)
+{
+    return m_manager->process_audio_networks(m_token, num_samples, channel);
+}
+
 TaskSchedulerHandle::TaskSchedulerHandle(
     std::shared_ptr<Vruta::TaskScheduler> task_manager,
     Vruta::ProcessingToken token)

--- a/src/MayaFlux/Core/ProcessingArchitecture.hpp
+++ b/src/MayaFlux/Core/ProcessingArchitecture.hpp
@@ -150,6 +150,8 @@ public:
 
     double process_sample(uint32_t channel);
 
+    std::vector<std::vector<double>> process_audio_networks(uint32_t num_samples, uint32_t channel = 0);
+
     /** @brief Create node with automatic token assignment */
     template <typename NodeType, typename... Args>
     std::shared_ptr<NodeType> create_node(Args&&... args)


### PR DESCRIPTION
This hotfix adds the missing audio-network processing entry points and
replaces the fragmented, partially duplicated audio-network logic with a
unified, thread-safe execution path. These changes were discovered as
necessary while validating documentation and 0.1.0 tutorials.

### What’s Included

#### 1. Public API: process_audio_networks()
- Adds `process_audio_networks(num_samples, channel)` to
  `NodeProcessingHandle`.
- Allows external systems (AudioSubsystem, tests, future schedulers) to
  request all network outputs for a given token/channel.
- Provides a consistent mechanism for evaluating audio networks outside
  of `process_sample()`.

#### 2. Unified Audio Network Processing in NodeGraphManager
- Introduces:
  - `preprocess_networks(token)`
  - `process_token` handles non audio token processing
  - `process_audio_networks(token, num_samples, channel)`
  - `postprocess_networks(token, channel)`
  - `reset_audio_network_state(token, channel)`
- Adds atomic guards via `m_token_network_processing` to prevent
  re-entrant execution across frames.
- Ensures correct mark_processing / mark_processed bookkeeping.
- Replaces old per-cycle duplication with consistent per-channel logic.

#### 3. AudioSubsystem Integration
- Collects audio-network outputs for each channel during buffer processing.
- Mixes each network’s buffer into the output before normalization.
- Ensures networks contribute correctly to final audio across all channels.

#### 4. Cleanup & Correct Logging
- Removes the legacy inline audio-network loop.
- Switches MF_PRINT to MF_INFO for network-addition logs.
- Preserves normalization semantics (only node roots count toward the coef).

### Priority
These issues surfaced while writing user-facing documentation: audio-network
examples did not behave as described due to the lack of accessible processing
paths. The fix is minimal, isolated, and required to complete the 0.1.0 API
for audio networks.

### Notes
- Fixes #23 

- No breaking API changes.
- No modifications to node or network user code required.
- This completes the minimal viable audio-network pipeline for 0.1.0.
