### PR TITLE
fix(windows): Correct install script verification logic & improve installer reliability

### DIFF
--- a/docs/Tutorials/SculptingData/SculptingData.md
+++ b/docs/Tutorials/SculptingData/SculptingData.md
@@ -136,7 +136,7 @@ you can do so fluently without waiting for someone else to provide the building 
   - [Next: The Full Pipeline
     Tutorial](#next-the-full-pipeline-tutorial){#toc-next-the-full-pipeline-tutorial}
 
-## The Simplest First Step
+# Tutorial: The Simplest First Step
 
 Run this code. The file is loaded into memory.
 

--- a/scripts/win64/packages.psd1
+++ b/scripts/win64/packages.psd1
@@ -1,118 +1,113 @@
 @{
     SystemTools        = @{
         CMake    = @{
-            WingetId = "Kitware.CMake"
-            Verify   = { Test-Command "cmake" }
+            WingetId = 'Kitware.CMake'
+            Verify   = 'cmake'  # Command to check
         }
         Git      = @{
-            WingetId = "Git.Git"
-            Verify   = { Test-Command "git" }
+            WingetId = 'Git.Git'
+            Verify   = 'git'
         }
         Ninja    = @{
-            WingetId = "Ninja-build.Ninja"
-            Verify   = { Test-Command "ninja" }
+            WingetId = 'Ninja-build.Ninja'
+            Verify   = 'ninja'
         }
         SevenZip = @{
-            WingetId = "7zip.7zip"
-            Verify   = { Test-Path "${env:ProgramFiles}\7-Zip\7z.exe" }
+            WingetId = '7zip.7zip'
+            Verify   = 'C:\Program Files\7-Zip\7z.exe'  # File path to check
         }
     }
 
     BinaryPackages     = @{
         LLVM      = @{
-            InstallRoot = "C:\Program Files\LLVM_Libs"
-            Url         = "https://github.com/llvm/llvm-project/releases/download/llvmorg-21.1.3/clang+llvm-21.1.3-x86_64-pc-windows-msvc.tar.xz"
-            Verify      = { Test-Path "C:\Program Files\LLVM_Libs\lib\LLVMCore.lib" }
+            InstallRoot = 'C:\Program Files\LLVM_Libs'
+            Url         = 'https://github.com/llvm/llvm-project/releases/download/llvmorg-21.1.3/clang+llvm-21.1.3-x86_64-pc-windows-msvc.tar.xz'
+            Verify      = 'C:\Program Files\LLVM_Libs\lib\LLVMCore.lib'
         }
 
         VulkanSDK = @{
-            InstallRoot = "C:\VulkanSDK"
-            Url         = "https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe"
-            InstallArgs = @("/S")
-            Verify      = {
-                $versionDir = Get-ChildItem "C:\VulkanSDK" -Directory -ErrorAction SilentlyContinue | Select-Object -First 1
-                $versionDir -and (Test-Path "$($versionDir.FullName)\Include\vulkan\vulkan.h")
-            }
+            InstallRoot = 'C:\VulkanSDK'
+            Url         = 'https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe'
+            InstallArgs = @('/S')
+            Verify      = 'C:\VulkanSDK\*\Include\vulkan\vulkan.h'  # Wildcard for version
         }
 
         FFmpeg    = @{
-            InstallRoot = "C:\Program Files\FFmpeg"
-            Url         = "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full-shared.7z"
-            Verify      = { Test-Path "C:\Program Files\FFmpeg\bin\ffmpeg.exe" }
+            InstallRoot = 'C:\Program Files\FFmpeg'
+            Url         = 'https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full-shared.7z'
+            Verify      = 'C:\Program Files\FFmpeg\bin\ffmpeg.exe'
         }
 
         GLFW      = @{
-            InstallRoot = "C:\Program Files\GLFW"
-            Url         = "https://github.com/glfw/glfw/releases/download/3.4/glfw-3.4.bin.WIN64.zip"
-            Verify      = { Test-Path "C:\Program Files\GLFW\include\GLFW\glfw3.h" }
+            InstallRoot = 'C:\Program Files\GLFW'
+            Url         = 'https://github.com/glfw/glfw/releases/download/3.4/glfw-3.4.bin.WIN64.zip'
+            Verify      = 'C:\Program Files\GLFW\include\GLFW\glfw3.h'
         }
     }
 
     HeaderOnlyPackages = @{
         Eigen3    = @{
-            InstallRoot = "C:\Program Files\Eigen3"
-            Url         = "https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.zip"
-            Verify      = { Test-Path "C:\Program Files\Eigen3\Eigen\Dense" }
+            InstallRoot = 'C:\Program Files\Eigen3'
+            Url         = 'https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.zip'
+            Verify      = 'C:\Program Files\Eigen3\Eigen\Dense'
         }
 
-        GLM       = @{
-            InstallRoot   = "C:\Program Files\glm"
-            Url           = "https://github.com/g-truc/glm/releases/download/1.0.2/glm-1.0.2.zip"
-            HeaderSubpath = "glm"
-            Verify        = { Test-Path "C:\Program Files\glm\include\glm\glm.hpp" }
+        GLM = @{
+            InstallRoot   = 'C:\Program Files\glm'
+            Url           = 'https://github.com/g-truc/glm/releases/download/1.0.2/glm-1.0.2.zip'
+            HeaderSubpath = 'glm'
+            TargetSubdir  = 'glm'
+            Verify        = 'C:\Program Files\glm\include\glm\glm.hpp'
         }
 
         STB       = @{
-            InstallRoot   = "C:\Program Files\stb"
-            Url           = "https://github.com/nothings/stb/archive/master.zip"
-            HeaderPattern = "*.h"
-            TargetSubdir  = "include\stb"
-            Verify        = { Test-Path "C:\Program Files\stb\include\stb\stb_image.h" }
+            InstallRoot   = 'C:\Program Files\stb'
+            Url           = 'https://github.com/nothings/stb/archive/master.zip'
+            HeaderPattern = '*.h'
+            TargetSubdir  = 'stb'
+            Verify        = 'C:\Program Files\stb\include\stb\stb_image.h'
         }
 
         MagicEnum = @{
-            InstallRoot   = "C:\Program Files\magic_enum"
-            Url           = "https://github.com/Neargye/magic_enum/archive/refs/tags/v0.9.5.zip"
-            HeaderSubpath = "include"
-            Verify        = { Test-Path "C:\Program Files\magic_enum\include\magic_enum.hpp" }
+            InstallRoot   = 'C:\Program Files\magic_enum'
+            Url           = 'https://github.com/Neargye/magic_enum/archive/refs/tags/v0.9.5.zip'
+            HeaderSubpath = 'include\magic_enum'
+            Verify        = 'C:\Program Files\magic_enum\include\magic_enum.hpp'
         }
     }
 
     SourcePackages     = @{
         RtAudio = @{
-            InstallRoot  = "C:\Program Files\RtAudio"
-            GitUrl       = "https://github.com/thestk/rtaudio.git"
-            GitBranch    = "6.0.1"
-            Verify       = { Test-Path "C:\Program Files\RtAudio\include\rtaudio\RtAudio.h" }
+            InstallRoot  = 'C:\Program Files\RtAudio'
+            GitUrl       = 'https://github.com/thestk/rtaudio.git'
+            GitBranch    = '6.0.1'
+            Verify       = 'C:\Program Files\RtAudio\include\rtaudio\RtAudio.h'
             CMakeOptions = @{
-                CMAKE_BUILD_TYPE      = "Release"
-                RTAUDIO_BUILD_TESTING = "OFF"
-                RTAUDIO_API_WASAPI    = "ON"
-                RTAUDIO_API_DS        = "ON"
+                CMAKE_BUILD_TYPE      = 'Release'
+                RTAUDIO_BUILD_TESTING = 'OFF'
+                RTAUDIO_API_WASAPI    = 'ON'
+                RTAUDIO_API_DS        = 'ON'
             }
-            Generator    = "Visual Studio 17 2022"
+            Generator    = 'Visual Studio 17 2022'
         }
 
         LibXml2 = @{
-            InstallRoot = "C:\Program Files\LibXml2"
-            Url         = "https://download.gnome.org/sources/libxml2/2.15/libxml2-2.15.0.tar.xz"
-            Verify      = { Test-Path "C:\Program Files\LibXml2\include\libxml\xmlversion.h" }
+            InstallRoot = 'C:\Program Files\LibXml2'
+            Url         = 'https://download.gnome.org/sources/libxml2/2.15/libxml2-2.15.0.tar.xz'
+            Verify      = 'C:\Program Files\LibXml2\include\libxml\xmlversion.h.in'
             HeadersOnly = $true
         }
     }
 
     SpecialPackages    = @{
         VisualStudio = @{
-            Verify  = {
-                $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-                Test-Path $vswhere
-            }
-            Message = "Visual Studio with C++ workload required. Download from https://visualstudio.microsoft.com/"
+            Verify  = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe'
+            Message = 'Visual Studio with C++ workload required. Download from https://visualstudio.microsoft.com/'
         }
     }
 
     MayaFlux           = @{
-        InstallRoot    = "C:\MayaFlux"
-        Subdirectories = @("include", "lib", "bin")
+        InstallRoot    = 'C:\MayaFlux'
+        Subdirectories = @('include', 'lib', 'bin')
     }
 }

--- a/src/MayaFlux/EnumUtils.hpp
+++ b/src/MayaFlux/EnumUtils.hpp
@@ -1,6 +1,12 @@
 #pragma once
 
+#if __has_include("magic_enum/magic_enum.hpp")
 #include "magic_enum/magic_enum.hpp"
+#elif __has_include("magic_enum.hpp")
+#include "magic_enum.hpp"
+#else
+#error "magic_enum.hpp not found"
+#endif
 
 namespace MayaFlux::Utils {
 


### PR DESCRIPTION
This hotfix resolves issues in the Windows setup scripts where installer
validation blocks were incorrectly evaluated, causing the scripts to always
return success regardless of installation state. This resulted in tools being
re-downloaded or incorrectly marked as installed.

### Key Fixes
- Replaced eval-based scriptblock execution with explicit `Test-Path` /
  command-based checks.
- Improved verification logic for system tools, binary packages, header-only
  packages, and source builds.
- Fixed archive extraction heuristics and improved Vulkan SDK handling.
- Added clearer installation logs and build failure detection.
- Resolved path and include resolution issues in EnumUtils.hpp fallback logic.

### Affected Areas
- `install_package.ps1`, `packages.psd1` — Windows dependency installation
- Vulkan SDK environment variable setup
- Extraction logic for header-only distributions
- Updated documentation: renamed "The Simplest First Step" header

### Result
The installation pipeline is now deterministic, verifiable, and safe to use
without false positives. End-users should experience fewer failed builds and
no silent installer failures.
