### PR TITLE
feat(NodeNetwork): Add multichannel expansion support & single-cycle processing

### DIFF
--- a/src/MayaFlux/Nodes/Network/NodeNetwork.hpp
+++ b/src/MayaFlux/Nodes/Network/NodeNetwork.hpp
@@ -336,6 +336,12 @@ public:
      */
     [[nodiscard]] bool is_processing() const;
 
+    /**
+     * @brief Request a reset from a specific channel
+     * @param channel_id Channel index
+     */
+    void request_reset_from_channel(uint32_t channel_id);
+
 protected:
     //-------------------------------------------------------------------------
     // Protected State (Accessible to subclasses)
@@ -407,6 +413,7 @@ protected:
 
     /// Bitfield of channels this network is registered on
     std::atomic<uint32_t> m_channel_mask { 0 };
+    std::atomic<uint32_t> m_pending_reset_mask { 0 };
 
     /// Per-channel processing state (lock-free atomic flags)
     std::atomic<bool> m_processing_state { false };

--- a/src/MayaFlux/Nodes/NodeGraphManager.hpp
+++ b/src/MayaFlux/Nodes/NodeGraphManager.hpp
@@ -460,11 +460,11 @@ private:
     std::unordered_map<std::string, std::shared_ptr<Network::NodeNetwork>> m_network_registry;
 
     /**
-     * @brief Audio-sink networks (channel-routed)
+     * @brief Audio-sink networks
      * Only populated for networks with OutputMode::AUDIO_SINK
      */
     std::unordered_map<ProcessingToken,
-        std::unordered_map<unsigned int, std::vector<std::shared_ptr<Network::NodeNetwork>>>>
+        std::vector<std::shared_ptr<Network::NodeNetwork>>>
         m_audio_networks;
 
     /**


### PR DESCRIPTION
This PR adds multichannel expansion support to NodeNetwork, ensuring that
audio networks registered on multiple channels are processed only once per
cycle and their results are shared across all channels.

### Highlights

- NodeNetwork now supports coordinated processing across channels.
- Added channel-based reset control using atomic pending-reset bitmask.
- Introduced `request_reset_from_channel()` to align reset logic with
  channel activity.
- Flattened m_audio_networks storage for simplified iteration.
- NodeGraphManager now caches processed buffers and reuses stored results.
- Removes duplicate per-channel process_batch() calls.

### Benefits

- Significant reduction in redundant work for multichannel routing.
- Predictable synchronization and reset semantics across all channels.
- Improved CPU performance with no API changes required by users.

### Scope

- Internal architecture improvement only.
- No breaking API changes.
- Required for robust audio workflow in 0.1.0.

### Linkage
- Fixes #30 
- Part of #29 
