### PR TITLE
fix(AudioBuffer): Add setup_processor redirect

### DIFF
--- a/src/MayaFlux/Buffers/AudioBuffer.hpp
+++ b/src/MayaFlux/Buffers/AudioBuffer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Buffer.hpp"
+#include "MayaFlux/Core/ProcessingTokens.hpp"
 
 namespace MayaFlux::Buffers {
 
@@ -71,6 +72,16 @@ public:
      * called on uninitialized buffers before use.
      */
     virtual void setup(uint32_t channel, uint32_t num_samples);
+
+    /**
+     * @brief Sets up audio processors for the specified processing token
+     * @param token Processing token indicating the domain
+     *
+     * This is useful to avoid calling shared_from_this() in constructors of
+     * derived classes. Derived audio buffer types can override this method
+     * to attach audio-specific processors based on the processing token.
+     */
+    virtual void setup_processors(ProcessingToken token) { }
 
     /**
      * @brief Adjusts the audio buffer's sample capacity

--- a/src/MayaFlux/Buffers/Managers/BufferAccessControl.cpp
+++ b/src/MayaFlux/Buffers/Managers/BufferAccessControl.cpp
@@ -150,6 +150,7 @@ void BufferAccessControl::add_audio_buffer(
     auto& unit = m_unit_manager.get_or_create_audio_unit(token);
     auto processing_chain = unit.get_chain(channel);
     buffer->set_channel_id(channel);
+    buffer->setup_processors(token);
 
     if (auto buf_chain = buffer->get_processing_chain()) {
         if (buf_chain != processing_chain) {

--- a/src/MayaFlux/Buffers/Node/NodeBuffer.cpp
+++ b/src/MayaFlux/Buffers/Node/NodeBuffer.cpp
@@ -208,17 +208,16 @@ NodeBuffer::NodeBuffer(uint32_t channel_id, uint32_t num_samples, std::shared_pt
     , m_source_node(std::move(source))
     , m_clear_before_process(clear_before_process)
 {
+}
+
+void NodeBuffer::setup_processors(ProcessingToken /*token*/)
+{
     m_default_processor = create_default_processor();
+    m_default_processor->on_attach(shared_from_this());
 }
 
 void NodeBuffer::process_default()
 {
-    if (!m_attached) {
-        if (m_default_processor) {
-            m_default_processor->on_attach(shared_from_this());
-        }
-        m_attached = true;
-    }
     if (m_clear_before_process) {
         clear();
     }

--- a/src/MayaFlux/Buffers/Node/NodeBuffer.hpp
+++ b/src/MayaFlux/Buffers/Node/NodeBuffer.hpp
@@ -141,6 +141,8 @@ public:
      */
     NodeBuffer(uint32_t channel_id, uint32_t num_samples, std::shared_ptr<Nodes::Node> source, bool clear_before_process = true);
 
+    void setup_processors(ProcessingToken token) override;
+
     /**
      * @brief Sets whether to reset the buffer before processing node output
      * @param value true to reset before processing, false to interpolate with existing content
@@ -182,7 +184,6 @@ private:
      * @brief Whether to reset the buffer before adding node output
      */
     bool m_clear_before_process;
-
-    bool m_attached {};
 };
+
 }


### PR DESCRIPTION
This change introduces a virtual `setup_processors(ProcessingToken)` method in `AudioBuffer`, allowing processor setup to be deferred until after buffer construction. This prevents unsafe `shared_from_this()` calls inside constructors and aligns with proper lifecycle management.

### Key changes

* New `setup_processors()` hook invoked from `BufferAccessControl::add_audio_buffer`
* `NodeBuffer` now overrides this method instead of performing attachment in constructor
* Removed legacy `m_attached` path and redundant attach logic

### Result

Safer initialization flow, cleaner extensibility for derived buffers, and correct processor attachment timing.
