### PR TITLE
fix(windows): use _mm_pause()

### DIFF
--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -106,7 +106,14 @@
 #endif
 
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
-    #define MF_PAUSE_INSTRUCTION() __builtin_ia32_pause()
+
+    #if defined(_MSC_VER)
+        #include <immintrin.h>
+        #define MF_PAUSE_INSTRUCTION() _mm_pause()
+    #else
+        #define MF_PAUSE_INSTRUCTION() __builtin_ia32_pause()
+    #endif
+
 #elif defined(__aarch64__) || defined(_M_ARM64)
     #define MF_PAUSE_INSTRUCTION() __asm__ __volatile__("yield")
 #else


### PR DESCRIPTION
The current __builtin_ia32_pause() does not work on windows. Inlcude immintrin.h and use _mm_pause()