### PR TITLE
Simplify Quick Process API — Remove Variant Dispatch & Enable `auto` Lambdas

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -324,9 +324,11 @@ jobs:
             "-B", "build",
             "-G", "Visual Studio 17 2022",
             "-A", "x64",
+            "-DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}",
+            "-DCMAKE_CONFIGURATION_TYPES=${{ env.BUILD_TYPE }}",
             "-DCMAKE_CXX_STANDARD=23",
             "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON",
-            "-DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT }}\scripts\buildsystems\vcpkg.cmake"
+            "-DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT }}\scripts\buildsystems\vcpkg.cmake",
             "-DCMAKE_CXX_FLAGS_RELEASE=/O2 /DNDEBUG /Z7",
             "-DCMAKE_EXE_LINKER_FLAGS=/DEBUG:FASTLINK"
           )

--- a/.github/workflows/distribution/macos/section.md
+++ b/.github/workflows/distribution/macos/section.md
@@ -1,55 +1,53 @@
-## 🪟 Windows Specific
+## 🍎 macOS Specific
 
 ### System Requirements
-- **OS**: Windows 10/11 64-bit
-- **Architecture**: x86_64
-- **Dependencies**: Visual Studio 2022 Build Tools
+- **OS**: macOS 14 (Sonoma) or later
+- **Architecture**: ARM64 (Apple Silicon)
+- **Dependencies**: Homebrew (for runtime dependencies)
 
 ### Installation & Dependencies
-- **Package Manager**: vcpkg (automatically managed)
-- **Required**: Visual Studio 2022 Build Tools
-- **Optional**: Vulkan SDK for development
+```bash
+brew install rtaudio ffmpeg shaderc googletest pkg-config cmake \
+             eigen onedpl magic_enum fmt glfw glm llvm vulkan-sdk
+```
 
 ### Technical Details
-- **Build**: MSVC 2022 with C++23 support
-- **Architecture**: x64
-- **LLVM**: Pre-built LLVM 21.1.3 for JIT compilation
-- **Vulkan**: Vulkan SDK with Windows drivers
-- **Audio**: RtAudio with WASAPI backend
+- **Build**: System Clang (Apple Clang) with C++23 support
+- **Architecture**: ARM64 (Apple Silicon optimized)
+- **LLVM**: Homebrew LLVM for JIT compilation
+- **Vulkan**: MoltenVK (Vulkan over Metal) for graphics
+- **Audio**: RtAudio with CoreAudio backend
 
 ### Distribution Contents
 ```
-MayaFlux-{{VERSION}}-windows-x64/
-├── bin/              # Executables & DLLs
-│   ├── lila_server.exe
-│   └── [runtime DLLs]
-├── lib/              # Import libraries
-│   ├── MayaFluxLib.lib
-│   └── Lila.lib
+MayaFlux-{{VERSION}}-macos-arm64/
+├── bin/              # Executables
+│   └── lila_server
+├── lib/              # Dynamic libraries
+│   ├── libMayaFluxLib.dylib
+│   └── libLila.dylib
 ├── include/          # Headers
 │   ├── MayaFlux/
 │   └── Lila/
 ├── share/            # Runtime data
 │   └── MayaFlux/runtime/
-├── README_Windows.md
-└── verify.bat
+├── README.md
+└── verify_components.sh
 ```
 
-### Common Windows Issues
-**"DLL not found" errors**
-- Ensure all required Visual C++ Redistributables are installed
-- Check that all DLLs are present in the `bin/` directory
-- Verify PATH includes the directory containing the DLLs
+### Common macOS Issues
+**"Library not found" errors**
+- Verify all Homebrew dependencies are installed
+- Run `brew doctor` to check for issues
+- Ensure DYLD_LIBRARY_PATH includes library locations
 
 **Lila JIT compilation failures**
-- Verify LLVM is properly installed and in PATH
-- Check that the DIA SDK is available (should be with Visual Studio)
+- Ensure Homebrew LLVM is installed and in PATH
+- Verify no conflicting LLVM installations
+- Check system integrity with `codesign` verification
 
 **GPU initialization errors**
-- Update graphics drivers
-- Verify Vulkan SDK installation
-
-**Application won't start**
-- Check Windows Event Viewer for error details
-- Ensure all runtime dependencies are available
+- Update macOS to latest version
+- Verify Metal support: `system_profiler SPDisplaysDataType`
+- Check Vulkan SDK installation
 

--- a/.github/workflows/distribution/windows/section.md
+++ b/.github/workflows/distribution/windows/section.md
@@ -1,53 +1,55 @@
-## 🍎 macOS Specific
+## 🪟 Windows Specific
 
 ### System Requirements
-- **OS**: macOS 14 (Sonoma) or later
-- **Architecture**: ARM64 (Apple Silicon)
-- **Dependencies**: Homebrew (for runtime dependencies)
+- **OS**: Windows 10/11 64-bit
+- **Architecture**: x86_64
+- **Dependencies**: Visual Studio 2022 Build Tools
 
 ### Installation & Dependencies
-```bash
-brew install rtaudio ffmpeg shaderc googletest pkg-config cmake \
-             eigen onedpl magic_enum fmt glfw glm llvm vulkan-sdk
-```
+- **Package Manager**: vcpkg (automatically managed)
+- **Required**: Visual Studio 2022 Build Tools
+- **Optional**: Vulkan SDK for development
 
 ### Technical Details
-- **Build**: System Clang (Apple Clang) with C++23 support
-- **Architecture**: ARM64 (Apple Silicon optimized)
-- **LLVM**: Homebrew LLVM for JIT compilation
-- **Vulkan**: MoltenVK (Vulkan over Metal) for graphics
-- **Audio**: RtAudio with CoreAudio backend
+- **Build**: MSVC 2022 with C++23 support
+- **Architecture**: x64
+- **LLVM**: Pre-built LLVM 21.1.3 for JIT compilation
+- **Vulkan**: Vulkan SDK with Windows drivers
+- **Audio**: RtAudio with WASAPI backend
 
 ### Distribution Contents
 ```
-MayaFlux-{{VERSION}}-macos-arm64/
-├── bin/              # Executables
-│   └── lila_server
-├── lib/              # Dynamic libraries
-│   ├── libMayaFluxLib.dylib
-│   └── libLila.dylib
+MayaFlux-{{VERSION}}-windows-x64/
+├── bin/              # Executables & DLLs
+│   ├── lila_server.exe
+│   └── [runtime DLLs]
+├── lib/              # Import libraries
+│   ├── MayaFluxLib.lib
+│   └── Lila.lib
 ├── include/          # Headers
 │   ├── MayaFlux/
 │   └── Lila/
 ├── share/            # Runtime data
 │   └── MayaFlux/runtime/
-├── README.md
-└── verify_components.sh
+├── README_Windows.md
+└── verify.bat
 ```
 
-### Common macOS Issues
-**"Library not found" errors**
-- Verify all Homebrew dependencies are installed
-- Run `brew doctor` to check for issues
-- Ensure DYLD_LIBRARY_PATH includes library locations
+### Common Windows Issues
+**"DLL not found" errors**
+- Ensure all required Visual C++ Redistributables are installed
+- Check that all DLLs are present in the `bin/` directory
+- Verify PATH includes the directory containing the DLLs
 
 **Lila JIT compilation failures**
-- Ensure Homebrew LLVM is installed and in PATH
-- Verify no conflicting LLVM installations
-- Check system integrity with `codesign` verification
+- Verify LLVM is properly installed and in PATH
+- Check that the DIA SDK is available (should be with Visual Studio)
 
 **GPU initialization errors**
-- Update macOS to latest version
-- Verify Metal support: `system_profiler SPDisplaysDataType`
-- Check Vulkan SDK installation
+- Update graphics drivers
+- Verify Vulkan SDK installation
+
+**Application won't start**
+- Check Windows Event Viewer for error details
+- Ensure all runtime dependencies are available
 

--- a/src/MayaFlux/API/Graph.cpp
+++ b/src/MayaFlux/API/Graph.cpp
@@ -12,6 +12,18 @@
 
 namespace MayaFlux {
 
+namespace internal {
+    std::shared_ptr<Buffers::BufferProcessor> attach_quick_process_audio(Buffers::AudioProcessingFunction processor, const std::shared_ptr<Buffers::AudioBuffer>& buffer)
+    {
+        return get_buffer_manager()->attach_quick_process(std::move(processor), buffer, Buffers::ProcessingToken::AUDIO_BACKEND);
+    }
+
+    std::shared_ptr<Buffers::BufferProcessor> attach_quick_process_graphics(Buffers::GraphicsProcessingFunction processor, const std::shared_ptr<Buffers::VKBuffer>& buffer)
+    {
+        return get_buffer_manager()->attach_quick_process(std::move(processor), buffer, Buffers::ProcessingToken::GRAPHICS_BACKEND);
+    }
+}
+
 //-------------------------------------------------------------------------
 // Node Graph Management
 //-------------------------------------------------------------------------
@@ -138,12 +150,7 @@ void unregister_node_network(const std::shared_ptr<Nodes::Network::NodeNetwork>&
 // Audio Processing
 //-------------------------------------------------------------------------
 
-std::shared_ptr<Buffers::BufferProcessor> attach_quick_process(Buffers::BufferProcessingFunction processor, const std::shared_ptr<Buffers::AudioBuffer>& buffer)
-{
-    return get_buffer_manager()->attach_quick_process(std::move(processor), buffer, Buffers::ProcessingToken::AUDIO_BACKEND);
-}
-
-std::shared_ptr<Buffers::BufferProcessor> attach_quick_process(Buffers::BufferProcessingFunction processor, unsigned int channel_id)
+std::shared_ptr<Buffers::BufferProcessor> attach_quick_process(Buffers::AudioProcessingFunction processor, unsigned int channel_id)
 {
     return get_buffer_manager()->attach_quick_process(std::move(processor), Buffers::ProcessingToken::AUDIO_BACKEND, channel_id);
 }

--- a/src/MayaFlux/Buffers/BufferManager.cpp
+++ b/src/MayaFlux/Buffers/BufferManager.cpp
@@ -289,14 +289,21 @@ void BufferManager::set_final_processor(
 // ============================================================================
 
 std::shared_ptr<BufferProcessor> BufferManager::attach_quick_process(
-    BufferProcessingFunction processor,
+    AudioProcessingFunction processor,
     const std::shared_ptr<Buffer>& buffer, ProcessingToken token)
 {
     return m_processor_control->attach_quick_process(std::move(processor), buffer, token);
 }
 
 std::shared_ptr<BufferProcessor> BufferManager::attach_quick_process(
-    BufferProcessingFunction processor,
+    GraphicsProcessingFunction processor,
+    const std::shared_ptr<Buffer>& buffer, ProcessingToken token)
+{
+    return m_processor_control->attach_quick_process(std::move(processor), buffer, token);
+}
+
+std::shared_ptr<BufferProcessor> BufferManager::attach_quick_process(
+    AudioProcessingFunction processor,
     ProcessingToken token,
     uint32_t channel)
 {
@@ -304,7 +311,14 @@ std::shared_ptr<BufferProcessor> BufferManager::attach_quick_process(
 }
 
 std::shared_ptr<BufferProcessor> BufferManager::attach_quick_process(
-    BufferProcessingFunction processor,
+    AudioProcessingFunction processor,
+    ProcessingToken token)
+{
+    return m_processor_control->attach_quick_process(std::move(processor), token);
+}
+
+std::shared_ptr<BufferProcessor> BufferManager::attach_quick_process(
+    GraphicsProcessingFunction processor,
     ProcessingToken token)
 {
     return m_processor_control->attach_quick_process(std::move(processor), token);

--- a/src/MayaFlux/Buffers/BufferManager.hpp
+++ b/src/MayaFlux/Buffers/BufferManager.hpp
@@ -356,16 +356,24 @@ public:
     // =========================================================================
 
     std::shared_ptr<BufferProcessor> attach_quick_process(
-        BufferProcessingFunction processor,
+        AudioProcessingFunction processor,
         const std::shared_ptr<Buffer>& buffer, ProcessingToken token = ProcessingToken::AUDIO_BACKEND);
 
     std::shared_ptr<BufferProcessor> attach_quick_process(
-        BufferProcessingFunction processor,
+        GraphicsProcessingFunction processor,
+        const std::shared_ptr<Buffer>& buffer, ProcessingToken token = ProcessingToken::GRAPHICS_BACKEND);
+
+    std::shared_ptr<BufferProcessor> attach_quick_process(
+        AudioProcessingFunction processor,
         ProcessingToken token,
         uint32_t channel);
 
     std::shared_ptr<BufferProcessor> attach_quick_process(
-        BufferProcessingFunction processor,
+        AudioProcessingFunction processor,
+        ProcessingToken token);
+
+    std::shared_ptr<BufferProcessor> attach_quick_process(
+        GraphicsProcessingFunction processor,
         ProcessingToken token);
 
     // =========================================================================

--- a/src/MayaFlux/Buffers/BufferSpec.hpp
+++ b/src/MayaFlux/Buffers/BufferSpec.hpp
@@ -43,9 +43,4 @@ using AudioProcessingFunction = std::function<void(const std::shared_ptr<AudioBu
  */
 using GraphicsProcessingFunction = std::function<void(const std::shared_ptr<VKBuffer>&)>;
 
-// ============================================================================
-// Variant Type for Unified Dispatcher
-// ============================================================================
-
-using BufferProcessingFunction = std::variant<AudioProcessingFunction, GraphicsProcessingFunction>;
 }

--- a/src/MayaFlux/Buffers/Managers/BufferProcessingControl.hpp
+++ b/src/MayaFlux/Buffers/Managers/BufferProcessingControl.hpp
@@ -196,8 +196,12 @@ public:
      * Quick processes are simple lambda-based processors for one-off transformations.
      */
     std::shared_ptr<BufferProcessor> attach_quick_process(
-        BufferProcessingFunction processor,
+        AudioProcessingFunction processor,
         const std::shared_ptr<Buffer>& buffer, ProcessingToken token = ProcessingToken::AUDIO_BACKEND);
+
+    std::shared_ptr<BufferProcessor> attach_quick_process(
+        GraphicsProcessingFunction processor,
+        const std::shared_ptr<Buffer>& buffer, ProcessingToken token = ProcessingToken::GRAPHICS_BACKEND);
 
     /**
      * @brief Creates and attaches a quick processing function to an audio token/channel
@@ -207,7 +211,7 @@ public:
      * @return Shared pointer to the created processor
      */
     std::shared_ptr<BufferProcessor> attach_quick_process(
-        BufferProcessingFunction processor,
+        AudioProcessingFunction processor,
         ProcessingToken token,
         uint32_t channel);
 
@@ -218,7 +222,11 @@ public:
      * @return Shared pointer to the created processor
      */
     std::shared_ptr<BufferProcessor> attach_quick_process(
-        BufferProcessingFunction processor,
+        AudioProcessingFunction processor,
+        ProcessingToken token);
+
+    std::shared_ptr<BufferProcessor> attach_quick_process(
+        GraphicsProcessingFunction processor,
         ProcessingToken token);
 
     // =========================================================================

--- a/src/MayaFlux/Buffers/Managers/QuickProcess.hpp
+++ b/src/MayaFlux/Buffers/Managers/QuickProcess.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "MayaFlux/Buffers/BufferProcessor.hpp"
+#include "MayaFlux/Buffers/BufferSpec.hpp"
+
+namespace MayaFlux::Buffers {
+
+template <typename FuncType>
+class QuickProcess : public BufferProcessor {
+public:
+    QuickProcess(FuncType function)
+        : m_function(std::move(function))
+    {
+    }
+
+    void processing_function(std::shared_ptr<Buffer> buffer) override
+    {
+        if constexpr (std::is_same_v<FuncType, AudioProcessingFunction>) {
+            if (auto audio_buf = std::dynamic_pointer_cast<AudioBuffer>(buffer)) {
+                m_function(audio_buf);
+            }
+        } else {
+            if (auto vk_buf = std::dynamic_pointer_cast<VKBuffer>(buffer)) {
+                m_function(vk_buf);
+            }
+        }
+    }
+
+    void on_attach(std::shared_ptr<Buffer> /*buffer*/) override
+    {
+        if constexpr (std::is_same_v<FuncType, AudioProcessingFunction>) {
+            m_processing_token = ProcessingToken::AUDIO_BACKEND;
+        } else {
+            m_processing_token = ProcessingToken::GRAPHICS_BACKEND;
+        }
+    }
+
+    [[nodiscard]] bool is_compatible_with(std::shared_ptr<Buffer> buffer) const override
+    {
+        if constexpr (std::is_same_v<FuncType, AudioProcessingFunction>) {
+            return std::dynamic_pointer_cast<AudioBuffer>(buffer) != nullptr;
+        } else {
+            return std::dynamic_pointer_cast<VKBuffer>(buffer) != nullptr;
+        }
+    }
+
+private:
+    FuncType m_function;
+};
+
+}

--- a/src/MayaFlux/Kriya/BufferOperation.cpp
+++ b/src/MayaFlux/Kriya/BufferOperation.cpp
@@ -168,7 +168,7 @@ BufferOperation BufferOperation::fuse_containers(std::vector<std::shared_ptr<Kak
 
 BufferOperation BufferOperation::modify_buffer(
     std::shared_ptr<Buffers::AudioBuffer> buffer,
-    Buffers::BufferProcessingFunction modifier)
+    Buffers::AudioProcessingFunction modifier)
 {
     BufferOperation op(OpType::MODIFY);
     op.m_target_buffer = std::move(buffer);

--- a/src/MayaFlux/Kriya/BufferOperation.hpp
+++ b/src/MayaFlux/Kriya/BufferOperation.hpp
@@ -289,7 +289,7 @@ namespace Kriya {
          */
         static BufferOperation modify_buffer(
             std::shared_ptr<Buffers::AudioBuffer> buffer,
-            Buffers::BufferProcessingFunction modifier);
+            Buffers::AudioProcessingFunction modifier);
 
         /**
          * @brief Create a fusion operation for multiple AudioBuffer sources.
@@ -422,7 +422,7 @@ namespace Kriya {
         bool m_is_streaming {};
 
         TransformationFunction m_transformer;
-        Buffers::BufferProcessingFunction m_buffer_modifier;
+        Buffers::AudioProcessingFunction m_buffer_modifier;
 
         std::shared_ptr<Buffers::AudioBuffer> m_target_buffer;
         std::shared_ptr<Kakshya::DynamicSoundStream> m_target_container;


### PR DESCRIPTION

This PR refactors the `attach_quick_process()` API by removing the `std::variant`–based dispatcher and replacing it with strongly typed overloads for audio and graphics processors. It also introduces template forwarding overloads, allowing developers to use `auto` in quick-processing lambdas without manually specifying function types or wrappers.

### **Key Improvements**

* **Removed** `BufferProcessingFunction` variant and runtime dispatch
* **Added** typed overloads for `AudioProcessingFunction` and `GraphicsProcessingFunction`
* **Introduced** template overloads enabling clean usage with `auto` lambdas
* **Added** `QuickProcess<FuncType>` class template for compile-time dispatch
* **Simplified call sites and reduced boilerplate**

### **Result**

Developers can now write quick process functions naturally and clearly:

```cpp
attach_quick_process([&](auto buf) { /* process */ }, audioBuffer);
```

with no manual typing or variant wrapping.

### **Benefits**

* Better API ergonomics and DX
* More expressive and self-documenting C++
* Zero runtime overhead from variant visitation
* Aligns with ongoing API surface cleanup for 0.1.0

### Linkage
- Fixes #38 
- Part of #14 