### PR TITLE
fix(linux): LileCoding and dependencies

### DIFF
--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -38,45 +38,62 @@ install_arch() {
         "rtaudio"
         "glfw"
         "glm"
-        "stb"
         "eigen"
-        "vulkan-devel"
+        "spirv-headers"
+        "spirv-tools"
+        "vulkan-headers"
+        "vulkan-icd-loader"
+        "vulkan-tools"
+        "vulkan-utility-libraries"
+        "vulkan-validation-layers"
         "ffmpeg"
-        "doxygen"
-        "git"
+        "stb"
     )
-    
     echo -e "${YELLOW}Installing: ${PACKAGES[*]}${NC}"
     sudo pacman -Syu --noconfirm "${PACKAGES[@]}"
     
     # magic_enum and eigen are header-only, available via AUR or manual
     echo -e "${YELLOW}Note: magic_enum is header-only library.${NC}"
     echo -e "${YELLOW}Install via: yay -S magic_enum${NC}"
+    echo -e "${YELLOW}Or via: paru -S magic_enum${NC}"
 }
 
 install_fedora() {
     echo -e "${BLUE}Installing dependencies for Fedora...${NC}"
     
     PACKAGES=(
-        "llvm-devel"
-        "llvm-libs"
-        "clang"
-        "clang-tools-extra"
-        "cmake"
-        "pkg-config"
+        "gcc-c++" 
+        "clang" 
+        "llvm" 
+        "llvm-devel" 
+        "llvm-libs" 
+        "clang-devel" 
+        "cmake" 
+        "ninja-build"
+        "pkgconfig"
         "rtaudio-devel"
-        "glfw-devel"
-        "vulkan-devel"
-        "ffmpeg-devel"
-        "doxygen"
+        "glfw-devel" 
+        "glm-devel"
+        "eigen3-devel"
+        "spirv-headers-devel"
+        "spirv-tools"
+        "vulkan-headers"
+        "vulkan-loader"
+        "vulkan-loader-devel"
+        "vulkan-tools"
+        "vulkan-validation-layers"
+        "ffmpeg-free-devel"
+        "stb-devel"
+        "magic_enum-devel"
+        "tbb-devel"
+        "gtest-devel"
+        "libshaderc-devel"
+        "wayland-devel"
         "git"
     )
     
     echo -e "${YELLOW}Installing: ${PACKAGES[*]}${NC}"
     sudo dnf install -y "${PACKAGES[@]}"
-    
-    echo -e "${YELLOW}Installing magic_enum and eigen (header-only)...${NC}"
-    sudo dnf install -y magic_enum-devel eigen3-devel
 }
 
 install_ubuntu() {
@@ -86,28 +103,39 @@ install_ubuntu() {
     sudo apt-get update
     
     PACKAGES=(
-        "llvm"
-        "llvm-dev"
-        "clang"
-        "clang-tools"
         "cmake"
-        "pkg-config"
-        "librtaudio-dev"
-        "libglfw3-dev"
-        "vulkan-tools"
-        "libvulkan-dev"
-        "libvulkan1"
-        "ffmpeg"
-        "libffmpeg-ocaml-dev"
-        "doxygen"
         "git"
+        "gcc"
+        "g++"
+        "pkg-config"
+        "llvm-21"
+        "llvm-21-dev"
+        "clang-21"
+        "libclang-21-dev"
+        "libtbb-dev"
+        "vulkan-validationlayers"
+        "vulkan-tools"
+        "vulkan-utility-libraries-dev"
+        "libvulkan-dev"
+        "libvulkan1" 
+        "wayland-protocols"
+        "libglfw3-dev"
+        "libglfw3-wayland"
+        "glslc"
+        "libshaderc-dev"
+        "libglm-dev"
+        "libeigen3-dev"
+        "libmagicenum-dev"
+        "libstb-dev"
+        "librtaudio-dev"
+        "ffmpeg"
+        "libavcodec-dev"
+        "libavformat-dev"
+        "libswscale-dev"
     )
     
     echo -e "${YELLOW}Installing: ${PACKAGES[*]}${NC}"
     sudo apt-get install -y "${PACKAGES[@]}"
-    
-    echo -e "${YELLOW}Installing magic_enum and eigen (header-only)...${NC}"
-    sudo apt-get install -y libmagic-enum-dev libeigen3-dev
 }
 
 install_opensuse() {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,11 +22,6 @@ else()
     )
 endif()
 
-if(UNIX AND NOT APPLE)
-    target_link_options(lila_server PRIVATE -no-pie)
-    target_compile_options(lila_server PRIVATE -fno-pie -mcmodel=large)
-endif()
-
 add_executable(project_launcher main.cpp ${HEADERS} ${USER_SOURCES})
 set_target_properties(project_launcher PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}

--- a/src/Lila/CMakeLists.txt
+++ b/src/Lila/CMakeLists.txt
@@ -29,7 +29,7 @@ if(WIN32)
 endif()
 
 target_include_directories(Lila PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}/..  # For #include "Lila/..."
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
     ${LLVM_INCLUDE_DIRS}
     ${CLANG_INCLUDE_DIRS}
 )
@@ -107,9 +107,12 @@ else()
     )
 endif()
 
-if(UNIX AND NOT APPLE)
-    target_compile_options(Lila PRIVATE -mcmodel=large)
+if (UNIX AND NOT APPLE)
+    target_link_libraries(Lila PUBLIC
+        -Wl,--no-as-needed
+        MayaFluxLib
+        -Wl,--as-needed
+    )
+else()
+    target_link_libraries(Lila PUBLIC MayaFluxLib)
 endif()
-
-target_link_libraries(Lila PUBLIC MayaFluxLib)
-

--- a/src/Lila/ClangInterpreter.cpp
+++ b/src/Lila/ClangInterpreter.cpp
@@ -58,6 +58,12 @@ bool ClangInterpreter::initialize()
     m_impl->compile_flags.emplace_back("-std=c++23");
     m_impl->compile_flags.emplace_back("-DMAYASIMPLE");
 
+#ifdef MAYAFLUX_PLATFORM_WINDOWS
+    m_impl->compile_flags.emplace_back("-mcmodel=large");
+    m_impl->compile_flags.emplace_back("-fPIC");
+    m_impl->compile_flags.emplace_back("-fPIE");
+#endif
+
     std::string pch_dir;
     if (std::filesystem::exists(MayaFlux::Config::PCH_RUNTIME_PATH)) {
         pch_dir = MayaFlux::Config::RUNTIME_DATA_DIR;
@@ -83,9 +89,9 @@ bool ClangInterpreter::initialize()
         LILA_DEBUG(Emitter::INTERPRETER,
             std::string("Using clang resource dir: ") + resource_dir);
     } else {
-        m_impl->compile_flags.emplace_back("-resource-dir=/usr/lib/clang/20");
+        m_impl->compile_flags.emplace_back("-resource-dir=/usr/lib/clang/21");
         LILA_WARN(Emitter::INTERPRETER,
-            "Using default clang resource dir: /usr/lib/clang/20");
+            "Using default clang resource dir: /usr/lib/clang/21");
     }
 
     auto system_includes = MayaFlux::Platform::SystemConfig::get_system_includes();


### PR DESCRIPTION
Reflect package requirements in setup scripts from ci & package manager scripts.

Ubuntu: Ensure MayaFlux linkage for lila i.e without --as-needed flag.

Fedora: Remove PIC only from JIT and not from entire Lila library.