### PR TITLE
fix(Shaders): Reinstate pipeline/descriptor ordering broken by ShaderProcessor refactor

### DIFF
--- a/src/MayaFlux/Buffers/Shaders/RenderProcessor.hpp
+++ b/src/MayaFlux/Buffers/Shaders/RenderProcessor.hpp
@@ -90,6 +90,8 @@ protected:
     void execute_shader(const std::shared_ptr<VKBuffer>& buffer) override;
     void initialize_descriptors(const std::shared_ptr<VKBuffer>& buffer) override;
 
+    bool on_before_execute(Portal::Graphics::CommandBufferID cmd_id, const std::shared_ptr<VKBuffer>& buffer) override;
+
     void cleanup() override;
 
 private:

--- a/src/MayaFlux/Buffers/Shaders/ShaderProcessor.cpp
+++ b/src/MayaFlux/Buffers/Shaders/ShaderProcessor.cpp
@@ -42,11 +42,16 @@ void ShaderProcessor::processing_function(std::shared_ptr<Buffer> buffer)
         return;
     }
 
+    if (!on_before_execute(m_last_command_buffer, vk_buffer)) {
+        MF_RT_DEBUG(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "on_before_execute() reported failure, skipping shader execution");
+        return;
+    }
+
     if (!m_initialized) {
         initialize_shader();
         initialize_pipeline(vk_buffer);
         m_initialized = true;
-        m_needs_descriptor_rebuild = true;
     }
 
     if (m_needs_pipeline_rebuild) {
@@ -313,7 +318,7 @@ void ShaderProcessor::on_shader_loaded(Portal::Graphics::ShaderID) { }
 void ShaderProcessor::on_pipeline_created(Portal::Graphics::ComputePipelineID) { }
 void ShaderProcessor::on_before_descriptors_create() { }
 void ShaderProcessor::on_descriptors_created() { }
-void ShaderProcessor::on_before_execute(Portal::Graphics::CommandBufferID, const std::shared_ptr<VKBuffer>&) { }
+bool ShaderProcessor::on_before_execute(Portal::Graphics::CommandBufferID, const std::shared_ptr<VKBuffer>&) { return true; }
 void ShaderProcessor::on_after_execute(Portal::Graphics::CommandBufferID, const std::shared_ptr<VKBuffer>&) { }
 
 //==============================================================================

--- a/src/MayaFlux/Buffers/Shaders/ShaderProcessor.hpp
+++ b/src/MayaFlux/Buffers/Shaders/ShaderProcessor.hpp
@@ -409,10 +409,11 @@ protected:
      * @brief Called before each process callback
      * @param cmd Command buffer
      * @param buffer Currently processing buffer
+     * @return True to proceed with execution, false to skip
      *
      * Override to update push constants or dynamic descriptors.
      */
-    virtual void on_before_execute(Portal::Graphics::CommandBufferID cmd_id, const std::shared_ptr<VKBuffer>& buffer);
+    virtual bool on_before_execute(Portal::Graphics::CommandBufferID cmd_id, const std::shared_ptr<VKBuffer>& buffer);
 
     /**
      * @brief Called after each process callback


### PR DESCRIPTION
During the recent refactor that unified shader execution into
`ShaderProcessor::processing_function()` with per-processor
`execute_shader()` overrides, several processors lost implicit ordering
guarantees that previously lived in their own `processing_function`
implementations.

`RenderProcessor` was particularly sensitive to this, relying on:
- pipeline creation order
- descriptor allocation timing
- window registration checks
- push-constant availability before execution

These assumptions were silently broken by the refactor.

---

### What this PR fixes

- Restores correct pipeline configuration and descriptor binding order
  for `RenderProcessor`
- Separates **pipeline creation** from **descriptor initialization**
  again where required
- Introduces `on_before_execute()` as a boolean guard to allow processors
  to abort execution safely (e.g. missing window registration)
- Moves descriptor rebuild logic out of pipeline creation, restoring the
  original execution flow without reintroducing per-class processing loops

This preserves the new unified shader architecture while allowing
specialized processors to reassert required ordering.

---

### Issue context

This is a regression introduced by an internal refactor and immediately
corrected. There is no user-facing API change, behavioral ambiguity, or
design discussion required.

---

### Notes

- No public API changes
- No shader interface changes
- No behavior changes beyond restoring pre-refactor semantics