### PR TITLE
Windows Main-Thread Dispatch & Event Loop

### DIFF
--- a/src/MayaFlux/Core/Engine.hpp
+++ b/src/MayaFlux/Core/Engine.hpp
@@ -346,6 +346,10 @@ private:
 #ifdef MAYAFLUX_PLATFORM_MACOS
     void run_macos_event_loop();
 #endif
+
+#ifdef MAYAFLUX_PLATFORM_WINDOWS
+    void run_windows_event_loop();
+#endif
 };
 
 } // namespace MayaFlux::Core

--- a/src/MayaFlux/Parallel.hpp
+++ b/src/MayaFlux/Parallel.hpp
@@ -109,8 +109,18 @@ bool dispatch_main_async_with_timeout(std::chrono::milliseconds timeout_ms, Func
 
 #elif defined(MAYAFLUX_PLATFORM_WINDOWS)
 
-inline DWORD g_MainThreadId = 0;
+inline DWORD g_MainThreadId = 0; /// < Main thread ID, must be set at startup
 
+/**
+ * @brief Execute a function on the main thread asynchronously (Windows only)
+ * @tparam Func Callable type
+ * @tparam Args Argument types
+ * @param func Function to execute
+ * @param args Arguments to forward to the function
+ *
+ * Posts a message to the main thread's message queue to execute the function.
+ * Use this for GLFW operations that must execute on the main thread.
+ */
 template <typename Func, typename... Args>
 void dispatch_main_async(Func&& func, Args&&... args)
 {


### PR DESCRIPTION
This PR implements a platform-specific dispatch mechanism for Windows to match existing macOS functionality. It ensures that operations requiring the main thread (specifically GLFW windowing and event polling) can be scheduled from background tasks via `dispatch_main_async`.

### Changes

#### `Parallel.hpp`

* **Added Windows Support:** Defined `MAYAFLUX_WM_DISPATCH` using `WM_USER`.
* **`dispatch_main_async`:** Implemented using `PostThreadMessage`. It heap-allocates a `std::function` wrapper, posts the pointer as `LPARAM`, and relies on the main loop to clean up the memory.
* **`dispatch_main_sync`:** Currently a passthrough to `std::invoke` to avoid deadlock risks during Vulkan surface creation, consistent with the current architecture's safety requirements.

#### `Engine.cpp` / `Engine.hpp`

* **Thread Capture:** Added `g_MainThreadId` initialization in `Engine::Init` to ensure background threads know which thread handles the message pump.
* **`run_windows_event_loop`:** * Implemented a standard Win32 `PeekMessage` pump.
* Added a handler for `MAYAFLUX_WM_DISPATCH` to execute and delete incoming tasks.
* Integrated a 1ms sleep to prevent the idle loop from consuming 100% CPU while waiting for messages.


* **Shutdown Logic:** * `request_shutdown` now posts `WM_QUIT` to the main thread to break the message loop gracefully.
* Implemented a side-thread for `std::cin.get()` on Windows to allow CLI-based termination without blocking the message pump.



### Verification Results

* **macOS:** Behavior remains unchanged.
* **Windows:** `dispatch_main_async` calls now successfully reach the main thread's message loop.
* **Linux:** Continues to use direct execution as the default behavior.

---
