### PR TITLE
Polyphonic Sampling Infrastructure

### DIFF
--- a/src/MayaFlux/API/Chronie.cpp
+++ b/src/MayaFlux/API/Chronie.cpp
@@ -249,7 +249,7 @@ uint64_t seconds_to_samples(double seconds)
     if (get_context().is_running()) {
         sample_rate = get_context().get_stream_info().sample_rate;
     }
-    return static_cast<uint64_t>(seconds * sample_rate);
+    return static_cast<uint64_t>(seconds * (double)sample_rate);
 }
 
 uint64_t seconds_to_blocks(double seconds)
@@ -274,6 +274,16 @@ uint64_t samples_to_blocks(uint64_t samples)
     }
 
     return Vruta::samples_to_blocks(samples, block_size);
+}
+
+double samples_to_seconds(uint64_t samples)
+{
+    uint64_t sample_rate = 48000;
+    if (get_context().is_running()) {
+        sample_rate = get_context().get_stream_info().sample_rate;
+    }
+
+    return static_cast<double>(samples) / (double)sample_rate;
 }
 
 void on_network_message(

--- a/src/MayaFlux/API/Chronie.hpp
+++ b/src/MayaFlux/API/Chronie.hpp
@@ -348,6 +348,13 @@ MAYAFLUX_API uint64_t seconds_to_blocks(double seconds);
 MAYAFLUX_API uint64_t samples_to_blocks(uint64_t samples);
 
 /**
+ * @brief Converts a number of audio samples to the equivalent time duration in seconds
+ * @param samples Number of audio samples
+ * @return Time duration in seconds based on the current sample rate
+ */
+MAYAFLUX_API double samples_to_seconds(uint64_t samples);
+
+/**
  * @brief Schedule an on_message handler with an existing NetworkSource
  * @param source   Shared NetworkSource; coroutine frame takes co-ownership
  * @param callback Invoked with each received message

--- a/src/MayaFlux/API/Rigs.cpp
+++ b/src/MayaFlux/API/Rigs.cpp
@@ -12,8 +12,7 @@
 
 namespace MayaFlux {
 
-template <size_t N>
-std::shared_ptr<Kriya::SamplingPipeline<N>> create_sampler(
+std::shared_ptr<Kriya::SamplingPipeline> create_sampler(
     const std::string& filepath, uint32_t num_samples, bool truncate,
     uint32_t channel)
 {
@@ -29,18 +28,11 @@ std::shared_ptr<Kriya::SamplingPipeline<N>> create_sampler(
     auto& sched = *get_scheduler();
     const uint32_t buf_size = Config::get_buffer_size();
 
-    auto sampler = std::make_shared<Kriya::SamplingPipeline<N>>(
+    auto sampler = std::make_shared<Kriya::SamplingPipeline>(
         std::move(stream), mgr, sched, channel, buf_size);
 
     sampler->build();
     return sampler;
 }
-
-template std::shared_ptr<Kriya::SamplingPipeline<2>>
-create_sampler<2>(const std::string&, uint32_t, bool, uint32_t);
-template std::shared_ptr<Kriya::SamplingPipeline<4>>
-create_sampler<4>(const std::string&, uint32_t, bool, uint32_t);
-template std::shared_ptr<Kriya::SamplingPipeline<8>>
-create_sampler<8>(const std::string&, uint32_t, bool, uint32_t);
 
 } // namespace MayaFlux

--- a/src/MayaFlux/API/Rigs.cpp
+++ b/src/MayaFlux/API/Rigs.cpp
@@ -1,0 +1,46 @@
+#include "Rigs.hpp"
+
+#include "MayaFlux/API/Chronie.hpp"
+#include "MayaFlux/API/Config.hpp"
+#include "MayaFlux/API/Depot.hpp"
+#include "MayaFlux/API/Graph.hpp"
+
+#include "MayaFlux/IO/IOManager.hpp"
+#include "MayaFlux/Kriya/SamplingPipeline.hpp"
+
+#include "MayaFlux/Journal/Archivist.hpp"
+
+namespace MayaFlux {
+
+template <size_t N>
+std::shared_ptr<Kriya::SamplingPipeline<N>> create_sampler(
+    const std::string& filepath, uint32_t num_samples, bool truncate,
+    uint32_t channel)
+{
+    auto stream = get_io_manager()->load_audio_bounded(filepath, num_samples, truncate);
+
+    if (!stream) {
+        MF_ERROR(Journal::Component::API, Journal::Context::FileIO,
+            "create_sampler: failed to load '{}'", filepath);
+        return nullptr;
+    }
+
+    auto& mgr = *get_buffer_manager();
+    auto& sched = *get_scheduler();
+    const uint32_t buf_size = Config::get_buffer_size();
+
+    auto sampler = std::make_shared<Kriya::SamplingPipeline<N>>(
+        std::move(stream), mgr, sched, channel, buf_size);
+
+    sampler->build();
+    return sampler;
+}
+
+template std::shared_ptr<Kriya::SamplingPipeline<2>>
+create_sampler<2>(const std::string&, uint32_t, bool, uint32_t);
+template std::shared_ptr<Kriya::SamplingPipeline<4>>
+create_sampler<4>(const std::string&, uint32_t, bool, uint32_t);
+template std::shared_ptr<Kriya::SamplingPipeline<8>>
+create_sampler<8>(const std::string&, uint32_t, bool, uint32_t);
+
+} // namespace MayaFlux

--- a/src/MayaFlux/API/Rigs.cpp
+++ b/src/MayaFlux/API/Rigs.cpp
@@ -40,4 +40,27 @@ std::shared_ptr<Kriya::SamplingPipeline> create_sampler(
     return sampler;
 }
 
+std::shared_ptr<Kriya::SamplingPipeline> create_sampler_from_stream(
+    std::shared_ptr<Kakshya::DynamicSoundStream> stream,
+    uint32_t channel, uint64_t max_dur_ms)
+{
+    if (!stream)
+        return nullptr;
+
+    auto& mgr = *get_buffer_manager();
+    auto& sched = *get_scheduler();
+    const uint32_t buf_size = Config::get_buffer_size();
+
+    auto sampler = std::make_shared<Kriya::SamplingPipeline>(
+        std::move(stream), mgr, sched, channel, buf_size);
+
+    if (max_dur_ms > 0) {
+        sampler->build_for(max_dur_ms);
+    } else {
+        sampler->build();
+    }
+
+    return sampler;
+}
+
 } // namespace MayaFlux

--- a/src/MayaFlux/API/Rigs.cpp
+++ b/src/MayaFlux/API/Rigs.cpp
@@ -63,4 +63,29 @@ std::shared_ptr<Kriya::SamplingPipeline> create_sampler_from_stream(
     return sampler;
 }
 
+std::vector<std::shared_ptr<Kriya::SamplingPipeline>> create_samplers(
+    const std::string& filepath, uint32_t num_samples, bool truncate,
+    uint64_t max_dur_ms, uint32_t max_channels)
+{
+    auto stream = get_io_manager()->load_audio_bounded(filepath, num_samples, truncate);
+
+    if (!stream) {
+        MF_ERROR(Journal::Component::API, Journal::Context::FileIO,
+            "create_samplers: failed to load '{}'", filepath);
+        return {};
+    }
+
+    const uint32_t ch_count = (max_channels == 0)
+        ? stream->get_num_channels()
+        : std::min(max_channels, stream->get_num_channels());
+
+    std::vector<std::shared_ptr<Kriya::SamplingPipeline>> result;
+    result.reserve(ch_count);
+
+    for (uint32_t i = 0; i < ch_count; ++i)
+        result.push_back(create_sampler_from_stream(stream, i, max_dur_ms));
+
+    return result;
+}
+
 } // namespace MayaFlux

--- a/src/MayaFlux/API/Rigs.cpp
+++ b/src/MayaFlux/API/Rigs.cpp
@@ -14,7 +14,7 @@ namespace MayaFlux {
 
 std::shared_ptr<Kriya::SamplingPipeline> create_sampler(
     const std::string& filepath, uint32_t num_samples, bool truncate,
-    uint32_t channel)
+    uint32_t channel, uint64_t max_dur_ms)
 {
     auto stream = get_io_manager()->load_audio_bounded(filepath, num_samples, truncate);
 
@@ -31,7 +31,12 @@ std::shared_ptr<Kriya::SamplingPipeline> create_sampler(
     auto sampler = std::make_shared<Kriya::SamplingPipeline>(
         std::move(stream), mgr, sched, channel, buf_size);
 
-    sampler->build();
+    if (max_dur_ms > 0) {
+        sampler->build_for(max_dur_ms);
+    } else {
+        sampler->build();
+    }
+
     return sampler;
 }
 

--- a/src/MayaFlux/API/Rigs.hpp
+++ b/src/MayaFlux/API/Rigs.hpp
@@ -34,6 +34,8 @@ namespace Kriya {
  * @param num_samples Number of samples to load from the file (default: 48000 * 5).
  * @param truncate    Truncate stream to num_samples if true (default: true).
  * @param channel     Output channel index (default: 0).
+ * @param max_dur_ms  Optional maximum duration to build the pipeline for (in milliseconds).
+                      Defaults to 0 which is infinite (the pipeline will run until the sampler is destroyed).
  * @return Built SamplingPipeline, or nullptr if the file could not be loaded.
  *
  * @code
@@ -47,6 +49,6 @@ namespace Kriya {
  */
 MAYAFLUX_API std::shared_ptr<Kriya::SamplingPipeline> create_sampler(
     const std::string& filepath, uint32_t num_samples = 48000 * 5, bool truncate = true,
-    uint32_t channel = 0);
+    uint32_t channel = 0, uint64_t max_dur_ms = 0);
 
 } // namespace MayaFlux

--- a/src/MayaFlux/API/Rigs.hpp
+++ b/src/MayaFlux/API/Rigs.hpp
@@ -17,7 +17,6 @@
 namespace MayaFlux {
 
 namespace Kriya {
-    template <size_t N>
     class SamplingPipeline;
 }
 
@@ -25,38 +24,29 @@ namespace Kriya {
  * @brief Construct a built SamplingPipeline from an audio file.
  *
  * Loads the file into a DynamicSoundStream via SoundFileReader::load_bounded,
- * constructs a SamplingPipeline<N> with engine globals (BufferManager,
+ * constructs a SamplingPipeline with engine globals (BufferManager,
  * TaskScheduler, buffer size), calls build(), and returns the result.
  *
  * The returned sampler is ready for play() and play_continuous() calls.
- * All N voice slots are pre-loaded with a full-stream slice; individual
- * slots can be reconfigured via load() or slice() before triggering.
+ * Voice slots are allocated on demand via load().
  *
- * @tparam N    Maximum concurrent voices (default: 4). Must be 2, 4, or 8.
- * @param filepath Path to the audio file (any FFmpeg-supported format).
+ * @param filepath    Path to the audio file (any FFmpeg-supported format).
  * @param num_samples Number of samples to load from the file (default: 48000 * 5).
- * @param channel  Output channel index (default: 0).
+ * @param truncate    Truncate stream to num_samples if true (default: true).
+ * @param channel     Output channel index (default: 0).
  * @return Built SamplingPipeline, or nullptr if the file could not be loaded.
  *
  * @code
  * auto kick = MayaFlux::create_sampler("kick.wav");
- * kick->play(0);
+ * kick->play(0, kick->slice_from_stream());
  *
- * auto pad  = MayaFlux::create_sampler<8>("pad.wav", 1);
- * pad->slice(0).speed = 0.5;
+ * auto pad = MayaFlux::create_sampler("pad.wav");
+ * pad->load(0, pad->slice_from_stream()).speed = 0.5;
  * pad->play_continuous(0);
  * @endcode
  */
-template <size_t N = 4>
-MAYAFLUX_API std::shared_ptr<Kriya::SamplingPipeline<N>> create_sampler(
+MAYAFLUX_API std::shared_ptr<Kriya::SamplingPipeline> create_sampler(
     const std::string& filepath, uint32_t num_samples = 48000 * 5, bool truncate = true,
     uint32_t channel = 0);
-
-extern template MAYAFLUX_API std::shared_ptr<Kriya::SamplingPipeline<2>>
-create_sampler<2>(const std::string&, uint32_t, bool, uint32_t);
-extern template MAYAFLUX_API std::shared_ptr<Kriya::SamplingPipeline<4>>
-create_sampler<4>(const std::string&, uint32_t, bool, uint32_t);
-extern template MAYAFLUX_API std::shared_ptr<Kriya::SamplingPipeline<8>>
-create_sampler<8>(const std::string&, uint32_t, bool, uint32_t);
 
 } // namespace MayaFlux

--- a/src/MayaFlux/API/Rigs.hpp
+++ b/src/MayaFlux/API/Rigs.hpp
@@ -20,6 +20,10 @@ namespace Kriya {
     class SamplingPipeline;
 }
 
+namespace Kakshya {
+    class DynamicSoundStream;
+}
+
 /**
  * @brief Construct a built SamplingPipeline from an audio file.
  *
@@ -49,6 +53,29 @@ namespace Kriya {
  */
 MAYAFLUX_API std::shared_ptr<Kriya::SamplingPipeline> create_sampler(
     const std::string& filepath, uint32_t num_samples = 48000 * 5, bool truncate = true,
+    uint32_t channel = 0, uint64_t max_dur_ms = 0);
+
+/**
+ * @brief Construct a built SamplingPipeline from an existing DynamicSoundStream.
+ *
+ * Allows multiple SamplingPipeline instances to share a single loaded stream,
+ * one per output channel, without re-reading the file. The stream is typically
+ * obtained from a previously created sampler via get_stream(), or loaded
+ * directly via get_io_manager()->load_audio_bounded().
+ *
+ * @code
+ * auto ch0 = MayaFlux::create_sampler("res/audio.wav", 48000 * 5);
+ * auto ch1 = MayaFlux::create_sampler_from_stream(ch0->get_stream(), 1);
+ * auto ch2 = MayaFlux::create_sampler_from_stream(ch0->get_stream(), 2);
+ * @endcode
+ *
+ * @param stream     Loaded DynamicSoundStream to share.
+ * @param channel    Output channel index (default: 0).
+ * @param max_dur_ms Optional maximum duration in milliseconds. 0 for infinite.
+ * @return Built SamplingPipeline, or nullptr if stream is null.
+ */
+MAYAFLUX_API std::shared_ptr<Kriya::SamplingPipeline> create_sampler_from_stream(
+    std::shared_ptr<Kakshya::DynamicSoundStream> stream,
     uint32_t channel = 0, uint64_t max_dur_ms = 0);
 
 } // namespace MayaFlux

--- a/src/MayaFlux/API/Rigs.hpp
+++ b/src/MayaFlux/API/Rigs.hpp
@@ -78,4 +78,28 @@ MAYAFLUX_API std::shared_ptr<Kriya::SamplingPipeline> create_sampler_from_stream
     std::shared_ptr<Kakshya::DynamicSoundStream> stream,
     uint32_t channel = 0, uint64_t max_dur_ms = 0);
 
+/**
+ * @brief Construct one built SamplingPipeline per channel from an audio file.
+ *
+ * Loads the file once into a shared DynamicSoundStream, then constructs one
+ * SamplingPipeline per channel. All pipelines share the same stream with no
+ * redundant IO. max_channels = 0 uses all channels available in the file.
+ *
+ * @code
+ * auto ch = MayaFlux::create_samplers("res/stereo.wav", 48000 * 5);
+ * ch[0]->play(0, ch[0]->slice_from_stream());
+ * ch[1]->play(0, ch[1]->slice_from_stream());
+ * @endcode
+ *
+ * @param filepath     Path to the audio file (any FFmpeg-supported format).
+ * @param num_samples  Number of samples to load (default: 48000 * 5).
+ * @param truncate     Truncate stream to num_samples if true (default: true).
+ * @param max_dur_ms   Optional maximum duration in milliseconds. 0 for infinite.
+ * @param max_channels Maximum channels to create pipelines for. 0 = all available.
+ * @return Vector of built SamplingPipelines, one per channel. Empty on load failure.
+ */
+MAYAFLUX_API std::vector<std::shared_ptr<Kriya::SamplingPipeline>> create_samplers(
+    const std::string& filepath, uint32_t num_samples = 48000 * 5, bool truncate = true,
+    uint64_t max_dur_ms = 0, uint32_t max_channels = 0);
+
 } // namespace MayaFlux

--- a/src/MayaFlux/API/Rigs.hpp
+++ b/src/MayaFlux/API/Rigs.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+/**
+ * @file API/Rigs.hpp
+ * @brief Pre-assembled, purpose-built signal flow configurations.
+ *
+ * Each function in this file constructs, wires, and returns a fully built
+ * pipeline object ready for immediate use. The caller receives a live rig
+ * with no further assembly required: IO, buffering, scheduling, and output
+ * routing are resolved internally using engine globals.
+ *
+ * These are convenience entry points. Direct construction of the underlying
+ * types (SamplingPipeline, BufferPipeline, etc.) remains available for cases
+ * that require non-default configuration before build().
+ */
+
+namespace MayaFlux {
+
+namespace Kriya {
+    template <size_t N>
+    class SamplingPipeline;
+}
+
+/**
+ * @brief Construct a built SamplingPipeline from an audio file.
+ *
+ * Loads the file into a DynamicSoundStream via SoundFileReader::load_bounded,
+ * constructs a SamplingPipeline<N> with engine globals (BufferManager,
+ * TaskScheduler, buffer size), calls build(), and returns the result.
+ *
+ * The returned sampler is ready for play() and play_continuous() calls.
+ * All N voice slots are pre-loaded with a full-stream slice; individual
+ * slots can be reconfigured via load() or slice() before triggering.
+ *
+ * @tparam N    Maximum concurrent voices (default: 4). Must be 2, 4, or 8.
+ * @param filepath Path to the audio file (any FFmpeg-supported format).
+ * @param num_samples Number of samples to load from the file (default: 48000 * 5).
+ * @param channel  Output channel index (default: 0).
+ * @return Built SamplingPipeline, or nullptr if the file could not be loaded.
+ *
+ * @code
+ * auto kick = MayaFlux::create_sampler("kick.wav");
+ * kick->play(0);
+ *
+ * auto pad  = MayaFlux::create_sampler<8>("pad.wav", 1);
+ * pad->slice(0).speed = 0.5;
+ * pad->play_continuous(0);
+ * @endcode
+ */
+template <size_t N = 4>
+MAYAFLUX_API std::shared_ptr<Kriya::SamplingPipeline<N>> create_sampler(
+    const std::string& filepath, uint32_t num_samples = 48000 * 5, bool truncate = true,
+    uint32_t channel = 0);
+
+extern template MAYAFLUX_API std::shared_ptr<Kriya::SamplingPipeline<2>>
+create_sampler<2>(const std::string&, uint32_t, bool, uint32_t);
+extern template MAYAFLUX_API std::shared_ptr<Kriya::SamplingPipeline<4>>
+create_sampler<4>(const std::string&, uint32_t, bool, uint32_t);
+extern template MAYAFLUX_API std::shared_ptr<Kriya::SamplingPipeline<8>>
+create_sampler<8>(const std::string&, uint32_t, bool, uint32_t);
+
+} // namespace MayaFlux

--- a/src/MayaFlux/Buffers/BufferManager.cpp
+++ b/src/MayaFlux/Buffers/BufferManager.cpp
@@ -427,9 +427,9 @@ bool BufferManager::supply_buffer_to(
     const std::shared_ptr<AudioBuffer>& buffer,
     ProcessingToken token,
     uint32_t channel,
-    double mix)
+    double mix, bool force)
 {
-    return m_supply_mixing->supply_audio_buffer_to(buffer, token, channel, mix);
+    return m_supply_mixing->supply_audio_buffer_to(buffer, token, channel, mix, force);
 }
 
 bool BufferManager::remove_supplied_buffer(

--- a/src/MayaFlux/Buffers/BufferManager.hpp
+++ b/src/MayaFlux/Buffers/BufferManager.hpp
@@ -146,6 +146,13 @@ public:
     [[nodiscard]] uint32_t get_buffer_size(ProcessingToken token) const;
 
     /**
+     * @brief Gets the sample rate for a token (audio-specific)
+     * @param token Processing domain
+     * @return Sample rate in Hz
+     */
+    [[nodiscard]] uint64_t get_sample_rate() const { return s_registered_sample_rate; }
+
+    /**
      * @brief Resizes buffers for a token
      * @param token Processing domain
      * @param buffer_size New buffer size

--- a/src/MayaFlux/Buffers/BufferManager.hpp
+++ b/src/MayaFlux/Buffers/BufferManager.hpp
@@ -434,7 +434,7 @@ public:
         const std::shared_ptr<AudioBuffer>& buffer,
         ProcessingToken token,
         uint32_t channel,
-        double mix = 1.0);
+        double mix = 1.0, bool force = false);
 
     bool remove_supplied_buffer(
         const std::shared_ptr<AudioBuffer>& buffer,

--- a/src/MayaFlux/Buffers/Container/SoundContainerBuffer.cpp
+++ b/src/MayaFlux/Buffers/Container/SoundContainerBuffer.cpp
@@ -88,58 +88,18 @@ void SoundStreamReader::processing_function(const std::shared_ptr<Buffer>& buffe
 
 void SoundStreamReader::extract_channel_data(std::span<double> output)
 {
-    if (!m_container) {
+    auto sc = std::dynamic_pointer_cast<Kakshya::SoundStreamContainer>(m_container);
+    if (!sc) {
         std::ranges::fill(output, 0.0);
         return;
     }
 
-    auto sound_container = std::dynamic_pointer_cast<Kakshya::SoundStreamContainer>(m_container);
-    if (!sound_container) {
-        std::ranges::fill(output, 0.0);
-        return;
-    }
+    const auto& pd = sc->get_processed_data();
+    const auto structure = sc->get_structure();
 
-    auto& processed_data = sound_container->get_processed_data();
-    if (processed_data.empty()) {
-        std::ranges::fill(output, 0.0);
-        return;
-    }
-
-    auto structure = sound_container->get_structure();
-
-    if (structure.organization == Kakshya::OrganizationStrategy::INTERLEAVED) {
-        thread_local std::vector<double> temp_storage;
-        auto data_span = Kakshya::extract_from_variant<double>(processed_data[0], temp_storage);
-
-        auto num_channels = structure.get_channel_count();
-        auto samples_to_copy = std::min(static_cast<size_t>(output.size()),
-            static_cast<size_t>(data_span.size() / num_channels));
-
-        for (auto i : std::views::iota(0UZ, samples_to_copy)) {
-            auto interleaved_idx = i * num_channels + m_source_channel;
-            output[i] = (interleaved_idx < data_span.size()) ? data_span[interleaved_idx] : 0.0;
-        }
-
-        if (samples_to_copy < output.size()) {
-            std::ranges::fill(output | std::views::drop(samples_to_copy), 0.0);
-        }
-
-    } else {
-        if (m_source_channel >= processed_data.size()) {
-            std::ranges::fill(output, 0.0);
-            return;
-        }
-
-        thread_local std::vector<double> temp_storage;
-        auto channel_data_span = Kakshya::extract_from_variant<double>(processed_data[m_source_channel], temp_storage);
-
-        auto samples_to_copy = std::min(output.size(), channel_data_span.size());
-        std::ranges::copy_n(channel_data_span.begin(), samples_to_copy, output.begin());
-
-        if (samples_to_copy < output.size()) {
-            std::ranges::fill(output | std::views::drop(samples_to_copy), 0.0);
-        }
-    }
+    Kakshya::extract_processed_data(
+        pd, structure.organization, structure.get_channel_count(),
+        m_source_channel, output);
 }
 
 void SoundStreamReader::on_attach(const std::shared_ptr<Buffer>& buffer)

--- a/src/MayaFlux/Buffers/Container/StreamSliceProcessor.cpp
+++ b/src/MayaFlux/Buffers/Container/StreamSliceProcessor.cpp
@@ -123,6 +123,7 @@ void StreamSliceProcessor<N>::processing_function(const std::shared_ptr<Buffer>&
     }
 }
 
+template class StreamSliceProcessor<2>;
 template class StreamSliceProcessor<4>;
 template class StreamSliceProcessor<8>;
 

--- a/src/MayaFlux/Buffers/Container/StreamSliceProcessor.cpp
+++ b/src/MayaFlux/Buffers/Container/StreamSliceProcessor.cpp
@@ -1,8 +1,7 @@
 #include "StreamSliceProcessor.hpp"
 
 #include "MayaFlux/Buffers/AudioBuffer.hpp"
-
-#include "MayaFlux/Kakshya/Source/DynamicSoundStream.hpp"
+#include "MayaFlux/Kakshya/Utils/ContainerUtils.hpp"
 
 #include "MayaFlux/Journal/Archivist.hpp"
 
@@ -17,7 +16,14 @@ void StreamSliceProcessor<N>::on_attach(const std::shared_ptr<Buffer>& buffer)
             "StreamSliceProcessor requires an AudioBuffer");
         return;
     }
-    m_num_frames = static_cast<uint32_t>(audio->get_data().size());
+    m_frames_per_block = static_cast<uint32_t>(audio->get_num_samples());
+}
+
+template <size_t N>
+void StreamSliceProcessor<N>::on_detach(const std::shared_ptr<Buffer>&)
+{
+    for (size_t i = 0; i < N; ++i)
+        detach_slot(i);
 }
 
 template <size_t N>
@@ -27,15 +33,66 @@ bool StreamSliceProcessor<N>::is_compatible_with(const std::shared_ptr<Buffer>& 
 }
 
 template <size_t N>
+void StreamSliceProcessor<N>::detach_slot(size_t index)
+{
+    auto& slot = m_slots[index];
+    if (slot.proc && slot.slice.stream)
+        slot.proc->on_detach(slot.slice.stream);
+    slot = {};
+}
+
+template <size_t N>
 void StreamSliceProcessor<N>::load(size_t index, Kakshya::StreamSlice slice)
 {
-    if (index >= N)
+    if (m_frames_per_block == 0) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "StreamSliceProcessor::load called before attachment to a buffer -- attach first");
         return;
-    slice.cursor = slice.loop_start;
-    slice.cursor_remainder = 0.0;
+    }
+
+    if (index >= N || !slice.stream)
+        return;
+
+    detach_slot(index);
+
     slice.active = false;
     slice.index = static_cast<uint8_t>(index);
-    m_slices[index] = std::move(slice);
+
+    auto proc = std::make_shared<Kakshya::CursorAccessProcessor>(m_frames_per_block);
+    proc->set_loop_region(slice.start_frame(), slice.end_frame());
+    proc->set_looping(slice.looping);
+
+    if (slice.speed != 1.0)
+        proc->set_speed(slice.speed);
+
+    proc->set_on_end([this, index] {
+        m_slots[index].slice.active = false;
+        if (m_on_end)
+            m_on_end(index);
+    });
+
+    proc->on_attach(slice.stream);
+
+    m_slots[index].slice = std::move(slice);
+    m_slots[index].proc = std::move(proc);
+}
+
+template <size_t N>
+void StreamSliceProcessor<N>::bind(size_t index)
+{
+    if (index >= N || !m_slots[index].proc)
+        return;
+    m_slots[index].proc->reset();
+    m_slots[index].slice.active = true;
+}
+
+template <size_t N>
+void StreamSliceProcessor<N>::unbind(size_t index)
+{
+    if (index >= N || !m_slots[index].proc)
+        return;
+    m_slots[index].proc->stop();
+    m_slots[index].slice.active = false;
 }
 
 template <size_t N>
@@ -45,110 +102,25 @@ void StreamSliceProcessor<N>::processing_function(const std::shared_ptr<Buffer>&
     if (!audio)
         return;
 
+    const uint32_t ch = audio->get_channel_id();
     auto& dst = audio->get_data();
     std::ranges::fill(dst, 0.0);
 
     for (size_t i = 0; i < N; ++i) {
-        auto& s = m_slices[i];
-        if (!s.active || !s.stream)
+        auto& slot = m_slots[i];
+        if (!slot.slice.active || !slot.slice.stream || !slot.proc)
             continue;
 
-        const uint64_t num_channels = s.stream->get_num_channels();
-        const uint64_t elements = m_num_frames;
+        slot.proc->process(slot.slice.stream);
 
-        thread_local std::vector<double> read_buf;
-        if (read_buf.size() != elements)
-            read_buf.assign(elements, 0.0);
+        const auto& pd = slot.slice.stream->get_dynamic_data(slot.proc->get_slot_index());
+        if (pd.empty())
+            continue;
 
-        s.stream->peek_sequential(
-            std::span<double> { read_buf.data(), elements },
-            elements,
-            s.cursor * num_channels);
-
-        for (size_t j = 0; j < elements && j < dst.size(); ++j)
-            dst[j] += read_buf[j] * s.scale;
-
-        advance(s, i);
+        const auto structure = slot.slice.stream->get_structure();
+        Kakshya::extract_processed_data(
+            pd, structure.organization, structure.get_channel_count(), ch, dst);
     }
-}
-
-template <size_t N>
-void StreamSliceProcessor<N>::load(
-    size_t index,
-    std::shared_ptr<Kakshya::DynamicSoundStream> stream)
-{
-    if (index >= N || !stream)
-        return;
-    auto& s = m_slices[index];
-    s.stream = std::move(stream);
-    s.loop_start = 0;
-    s.loop_end = s.stream->get_num_frames();
-    s.cursor = 0;
-    s.cursor_remainder = 0.0;
-    s.active = false;
-}
-
-template <size_t N>
-void StreamSliceProcessor<N>::load(
-    size_t index,
-    std::shared_ptr<Kakshya::DynamicSoundStream> stream,
-    uint64_t loop_start,
-    uint64_t loop_end)
-{
-    if (index >= N || !stream)
-        return;
-    auto& s = m_slices[index];
-    s.stream = std::move(stream);
-    s.loop_start = loop_start;
-    s.loop_end = loop_end;
-    s.cursor = loop_start;
-    s.cursor_remainder = 0.0;
-    s.active = false;
-}
-
-template <size_t N>
-void StreamSliceProcessor<N>::advance(Kakshya::StreamSlice& s, size_t index)
-{
-    const uint64_t num_channels = s.stream->get_num_channels();
-    const double frames_f = static_cast<double>(m_num_frames) / (double)num_channels * s.speed;
-    const auto whole_frames = static_cast<uint64_t>(frames_f);
-    s.cursor_remainder += frames_f - static_cast<double>(whole_frames);
-
-    const auto carry = static_cast<uint64_t>(s.cursor_remainder);
-    s.cursor_remainder -= static_cast<double>(carry);
-    s.cursor += whole_frames + carry;
-
-    const uint64_t loop_end = std::min(s.loop_end, s.stream->get_num_frames());
-
-    if (s.cursor >= loop_end) {
-        if (s.looping) {
-            s.cursor = s.loop_start;
-        } else {
-            s.active = false;
-            s.cursor = s.loop_start;
-            s.cursor_remainder = 0.0;
-            if (m_on_end)
-                m_on_end(index);
-        }
-    }
-}
-
-template <size_t N>
-void StreamSliceProcessor<N>::bind(size_t index)
-{
-    if (index >= N)
-        return;
-    m_slices[index].cursor = m_slices[index].loop_start;
-    m_slices[index].cursor_remainder = 0.0;
-    m_slices[index].active = true;
-}
-
-template <size_t N>
-void StreamSliceProcessor<N>::unbind(size_t index)
-{
-    if (index >= N)
-        return;
-    m_slices[index].active = false;
 }
 
 template class StreamSliceProcessor<4>;

--- a/src/MayaFlux/Buffers/Container/StreamSliceProcessor.cpp
+++ b/src/MayaFlux/Buffers/Container/StreamSliceProcessor.cpp
@@ -7,8 +7,7 @@
 
 namespace MayaFlux::Buffers {
 
-template <size_t N>
-void StreamSliceProcessor<N>::on_attach(const std::shared_ptr<Buffer>& buffer)
+void StreamSliceProcessor::on_attach(const std::shared_ptr<Buffer>& buffer)
 {
     auto audio = std::dynamic_pointer_cast<AudioBuffer>(buffer);
     if (!audio) {
@@ -19,21 +18,18 @@ void StreamSliceProcessor<N>::on_attach(const std::shared_ptr<Buffer>& buffer)
     m_frames_per_block = static_cast<uint32_t>(audio->get_num_samples());
 }
 
-template <size_t N>
-void StreamSliceProcessor<N>::on_detach(const std::shared_ptr<Buffer>&)
+void StreamSliceProcessor::on_detach(const std::shared_ptr<Buffer>&)
 {
-    for (size_t i = 0; i < N; ++i)
+    for (size_t i = 0; i < m_slots.size(); ++i)
         detach_slot(i);
 }
 
-template <size_t N>
-bool StreamSliceProcessor<N>::is_compatible_with(const std::shared_ptr<Buffer>& buffer) const
+bool StreamSliceProcessor::is_compatible_with(const std::shared_ptr<Buffer>& buffer) const
 {
     return std::dynamic_pointer_cast<AudioBuffer>(buffer) != nullptr;
 }
 
-template <size_t N>
-void StreamSliceProcessor<N>::detach_slot(size_t index)
+void StreamSliceProcessor::detach_slot(size_t index)
 {
     auto& slot = m_slots[index];
     if (slot.proc && slot.slice.stream)
@@ -41,8 +37,7 @@ void StreamSliceProcessor<N>::detach_slot(size_t index)
     slot = {};
 }
 
-template <size_t N>
-void StreamSliceProcessor<N>::load(size_t index, Kakshya::StreamSlice slice)
+void StreamSliceProcessor::load(size_t index, Kakshya::StreamSlice slice)
 {
     if (m_frames_per_block == 0) {
         MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
@@ -50,8 +45,17 @@ void StreamSliceProcessor<N>::load(size_t index, Kakshya::StreamSlice slice)
         return;
     }
 
-    if (index >= N || !slice.stream)
+    if (!slice.stream)
         return;
+
+    if (index > m_slots.size()) {
+        MF_WARN(Journal::Component::Buffers, Journal::Context::Configuration,
+            "StreamSliceProcessor::load index {} exceeds slot count {}; use {} for next available",
+            index, m_slots.size(), m_slots.size());
+    }
+
+    if (index >= m_slots.size())
+        m_slots.resize(index + 1);
 
     detach_slot(index);
 
@@ -77,26 +81,31 @@ void StreamSliceProcessor<N>::load(size_t index, Kakshya::StreamSlice slice)
     m_slots[index].proc = std::move(proc);
 }
 
-template <size_t N>
-void StreamSliceProcessor<N>::bind(size_t index)
+void StreamSliceProcessor::bind(size_t index)
 {
-    if (index >= N || !m_slots[index].proc)
+    if (index >= m_slots.size() || !m_slots[index].proc)
         return;
+
     m_slots[index].proc->reset();
     m_slots[index].slice.active = true;
 }
 
-template <size_t N>
-void StreamSliceProcessor<N>::unbind(size_t index)
+void StreamSliceProcessor::unbind(size_t index)
 {
-    if (index >= N || !m_slots[index].proc)
+    if (index >= m_slots.size() || !m_slots[index].proc)
         return;
     m_slots[index].proc->stop();
     m_slots[index].slice.active = false;
 }
 
-template <size_t N>
-void StreamSliceProcessor<N>::processing_function(const std::shared_ptr<Buffer>& buffer)
+bool StreamSliceProcessor::any_active() const
+{
+    return std::ranges::any_of(m_slots, [](const auto& slot) {
+        return slot.slice.active;
+    });
+}
+
+void StreamSliceProcessor::processing_function(const std::shared_ptr<Buffer>& buffer)
 {
     auto audio = std::dynamic_pointer_cast<AudioBuffer>(buffer);
     if (!audio)
@@ -106,8 +115,7 @@ void StreamSliceProcessor<N>::processing_function(const std::shared_ptr<Buffer>&
     auto& dst = audio->get_data();
     std::ranges::fill(dst, 0.0);
 
-    for (size_t i = 0; i < N; ++i) {
-        auto& slot = m_slots[i];
+    for (auto& slot : m_slots) {
         if (!slot.slice.active || !slot.slice.stream || !slot.proc)
             continue;
 
@@ -125,9 +133,5 @@ void StreamSliceProcessor<N>::processing_function(const std::shared_ptr<Buffer>&
             dst[s] += tmp[s];
     }
 }
-
-template class StreamSliceProcessor<2>;
-template class StreamSliceProcessor<4>;
-template class StreamSliceProcessor<8>;
 
 } // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/Container/StreamSliceProcessor.cpp
+++ b/src/MayaFlux/Buffers/Container/StreamSliceProcessor.cpp
@@ -27,6 +27,18 @@ bool StreamSliceProcessor<N>::is_compatible_with(const std::shared_ptr<Buffer>& 
 }
 
 template <size_t N>
+void StreamSliceProcessor<N>::load(size_t index, Kakshya::StreamSlice slice)
+{
+    if (index >= N)
+        return;
+    slice.cursor = slice.loop_start;
+    slice.cursor_remainder = 0.0;
+    slice.active = false;
+    slice.index = static_cast<uint8_t>(index);
+    m_slices[index] = std::move(slice);
+}
+
+template <size_t N>
 void StreamSliceProcessor<N>::processing_function(const std::shared_ptr<Buffer>& buffer)
 {
     auto audio = std::dynamic_pointer_cast<AudioBuffer>(buffer);
@@ -58,6 +70,40 @@ void StreamSliceProcessor<N>::processing_function(const std::shared_ptr<Buffer>&
 
         advance(s, i);
     }
+}
+
+template <size_t N>
+void StreamSliceProcessor<N>::load(
+    size_t index,
+    std::shared_ptr<Kakshya::DynamicSoundStream> stream)
+{
+    if (index >= N || !stream)
+        return;
+    auto& s = m_slices[index];
+    s.stream = std::move(stream);
+    s.loop_start = 0;
+    s.loop_end = s.stream->get_num_frames();
+    s.cursor = 0;
+    s.cursor_remainder = 0.0;
+    s.active = false;
+}
+
+template <size_t N>
+void StreamSliceProcessor<N>::load(
+    size_t index,
+    std::shared_ptr<Kakshya::DynamicSoundStream> stream,
+    uint64_t loop_start,
+    uint64_t loop_end)
+{
+    if (index >= N || !stream)
+        return;
+    auto& s = m_slices[index];
+    s.stream = std::move(stream);
+    s.loop_start = loop_start;
+    s.loop_end = loop_end;
+    s.cursor = loop_start;
+    s.cursor_remainder = 0.0;
+    s.active = false;
 }
 
 template <size_t N>

--- a/src/MayaFlux/Buffers/Container/StreamSliceProcessor.cpp
+++ b/src/MayaFlux/Buffers/Container/StreamSliceProcessor.cpp
@@ -118,8 +118,11 @@ void StreamSliceProcessor<N>::processing_function(const std::shared_ptr<Buffer>&
             continue;
 
         const auto structure = slot.slice.stream->get_structure();
-        Kakshya::extract_processed_data(
-            pd, structure.organization, structure.get_channel_count(), ch, dst);
+        std::vector<double> tmp(dst.size(), 0.0);
+        Kakshya::extract_processed_data(pd, structure.organization, structure.get_channel_count(), ch, tmp);
+
+        for (size_t s = 0; s < dst.size(); ++s)
+            dst[s] += tmp[s];
     }
 }
 

--- a/src/MayaFlux/Buffers/Container/StreamSliceProcessor.cpp
+++ b/src/MayaFlux/Buffers/Container/StreamSliceProcessor.cpp
@@ -1,0 +1,111 @@
+#include "StreamSliceProcessor.hpp"
+
+#include "MayaFlux/Buffers/AudioBuffer.hpp"
+
+#include "MayaFlux/Kakshya/Source/DynamicSoundStream.hpp"
+
+#include "MayaFlux/Journal/Archivist.hpp"
+
+namespace MayaFlux::Buffers {
+
+template <size_t N>
+void StreamSliceProcessor<N>::on_attach(const std::shared_ptr<Buffer>& buffer)
+{
+    auto audio = std::dynamic_pointer_cast<AudioBuffer>(buffer);
+    if (!audio) {
+        MF_RT_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "StreamSliceProcessor requires an AudioBuffer");
+        return;
+    }
+    m_num_frames = static_cast<uint32_t>(audio->get_data().size());
+}
+
+template <size_t N>
+bool StreamSliceProcessor<N>::is_compatible_with(const std::shared_ptr<Buffer>& buffer) const
+{
+    return std::dynamic_pointer_cast<AudioBuffer>(buffer) != nullptr;
+}
+
+template <size_t N>
+void StreamSliceProcessor<N>::processing_function(const std::shared_ptr<Buffer>& buffer)
+{
+    auto audio = std::dynamic_pointer_cast<AudioBuffer>(buffer);
+    if (!audio)
+        return;
+
+    auto& dst = audio->get_data();
+    std::ranges::fill(dst, 0.0);
+
+    for (size_t i = 0; i < N; ++i) {
+        auto& s = m_slices[i];
+        if (!s.active || !s.stream)
+            continue;
+
+        const uint64_t num_channels = s.stream->get_num_channels();
+        const uint64_t elements = m_num_frames;
+
+        thread_local std::vector<double> read_buf;
+        if (read_buf.size() != elements)
+            read_buf.assign(elements, 0.0);
+
+        s.stream->peek_sequential(
+            std::span<double> { read_buf.data(), elements },
+            elements,
+            s.cursor * num_channels);
+
+        for (size_t j = 0; j < elements && j < dst.size(); ++j)
+            dst[j] += read_buf[j] * s.scale;
+
+        advance(s, i);
+    }
+}
+
+template <size_t N>
+void StreamSliceProcessor<N>::advance(Kakshya::StreamSlice& s, size_t index)
+{
+    const uint64_t num_channels = s.stream->get_num_channels();
+    const double frames_f = static_cast<double>(m_num_frames) / (double)num_channels * s.speed;
+    const auto whole_frames = static_cast<uint64_t>(frames_f);
+    s.cursor_remainder += frames_f - static_cast<double>(whole_frames);
+
+    const auto carry = static_cast<uint64_t>(s.cursor_remainder);
+    s.cursor_remainder -= static_cast<double>(carry);
+    s.cursor += whole_frames + carry;
+
+    const uint64_t loop_end = std::min(s.loop_end, s.stream->get_num_frames());
+
+    if (s.cursor >= loop_end) {
+        if (s.looping) {
+            s.cursor = s.loop_start;
+        } else {
+            s.active = false;
+            s.cursor = s.loop_start;
+            s.cursor_remainder = 0.0;
+            if (m_on_end)
+                m_on_end(index);
+        }
+    }
+}
+
+template <size_t N>
+void StreamSliceProcessor<N>::bind(size_t index)
+{
+    if (index >= N)
+        return;
+    m_slices[index].cursor = m_slices[index].loop_start;
+    m_slices[index].cursor_remainder = 0.0;
+    m_slices[index].active = true;
+}
+
+template <size_t N>
+void StreamSliceProcessor<N>::unbind(size_t index)
+{
+    if (index >= N)
+        return;
+    m_slices[index].active = false;
+}
+
+template class StreamSliceProcessor<4>;
+template class StreamSliceProcessor<8>;
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/Container/StreamSliceProcessor.cpp
+++ b/src/MayaFlux/Buffers/Container/StreamSliceProcessor.cpp
@@ -65,6 +65,7 @@ void StreamSliceProcessor::load(size_t index, Kakshya::StreamSlice slice)
     auto proc = std::make_shared<Kakshya::CursorAccessProcessor>(m_frames_per_block);
     proc->set_loop_region(slice.start_frame(), slice.end_frame());
     proc->set_looping(slice.looping);
+    proc->set_loop_count(slice.loop_count);
 
     if (slice.speed != 1.0)
         proc->set_speed(slice.speed);
@@ -94,6 +95,7 @@ void StreamSliceProcessor::unbind(size_t index)
 {
     if (index >= m_slots.size() || !m_slots[index].proc)
         return;
+
     m_slots[index].proc->stop();
     m_slots[index].slice.active = false;
 }

--- a/src/MayaFlux/Buffers/Container/StreamSliceProcessor.hpp
+++ b/src/MayaFlux/Buffers/Container/StreamSliceProcessor.hpp
@@ -62,6 +62,36 @@ public:
      */
     void set_on_end(std::function<void(size_t)> cb) { m_on_end = std::move(cb); }
 
+    /**
+     * @brief Assign a configured StreamSlice to a slot.
+     * Resets cursor to loop_start and deactivates. Preserves all other
+     * fields from the provided slice.
+     * @param index Slot index within the pool.
+     * @param slice Configured StreamSlice to assign.
+     */
+    void load(size_t index, Kakshya::StreamSlice slice);
+
+    /**
+     * @brief Assign a stream to a slot, configuring loop bounds to the full stream.
+     * Resets cursor state. Does not activate the slice.
+     * @param index Slot index within the pool.
+     * @param stream DynamicSoundStream to read from.
+     */
+    void load(size_t index, std::shared_ptr<Kakshya::DynamicSoundStream> stream);
+
+    /**
+     * @brief Assign a stream to a slot with explicit loop bounds.
+     * Resets cursor state. Does not activate the slice.
+     * @param index      Slot index within the pool.
+     * @param stream     DynamicSoundStream to read from.
+     * @param loop_start Start frame.
+     * @param loop_end   End frame.
+     */
+    void load(size_t index,
+        std::shared_ptr<Kakshya::DynamicSoundStream> stream,
+        uint64_t loop_start,
+        uint64_t loop_end);
+
 private:
     std::array<Kakshya::StreamSlice, N> m_slices {};
     std::function<void(size_t)> m_on_end;

--- a/src/MayaFlux/Buffers/Container/StreamSliceProcessor.hpp
+++ b/src/MayaFlux/Buffers/Container/StreamSliceProcessor.hpp
@@ -26,10 +26,7 @@ namespace MayaFlux::Buffers {
  * Inactive slots contribute silence. Active slot outputs are accumulated into
  * the buffer in index order with no further scaling applied here beyond what
  * CursorAccessProcessor produces.
- *
- * @tparam N Maximum number of concurrent slots. Defaults to 4.
  */
-template <size_t N = 4>
 class MAYAFLUX_API StreamSliceProcessor : public BufferProcessor {
 public:
     StreamSliceProcessor() = default;
@@ -51,26 +48,39 @@ public:
      * the slice's stream, and configures the loop region from the slice's
      * Region. Any previously loaded slot processor is detached first.
      * The slot is left inactive; call bind() to start playback.
+     * Grows the slot pool if index exceeds the current size.
      *
-     * @param index Slot index in [0, N).
+     * @param index The slot is left inactive; call bind() to start playback.
      * @param slice StreamSlice describing the stream and region.
      */
     void load(size_t index, Kakshya::StreamSlice slice);
 
     /**
      * @brief Activate a slot, resetting its processor cursor to region start.
-     * @param index Slot index in [0, N).
+     * @param index Slot index
      */
     void bind(size_t index);
 
     /**
      * @brief Deactivate a slot, stopping its processor without resetting the cursor.
-     * @param index Slot index in [0, N).
+     * @param index Slot index.
      */
     void unbind(size_t index);
 
     [[nodiscard]] Kakshya::StreamSlice& slice(size_t index) { return m_slots[index].slice; }
     [[nodiscard]] const Kakshya::StreamSlice& slice(size_t index) const { return m_slots[index].slice; }
+
+    /**
+     * @brief Check if any slot is active.
+     * @return True if any slot is active, false if all are inactive.
+     */
+    [[nodiscard]] bool any_active() const;
+
+    /**
+     * @brief Get the current number of slots.
+     * @return The number of slots currently allocated.
+     */
+    [[nodiscard]] size_t slot_count() const { return m_slots.size(); }
 
     /**
      * @brief Register a callback fired when a slot's one-shot playback ends.
@@ -84,9 +94,9 @@ private:
         std::shared_ptr<Kakshya::CursorAccessProcessor> proc;
     };
 
-    std::array<Slot, N> m_slots {};
+    std::vector<Slot> m_slots;
     std::function<void(size_t)> m_on_end;
-    uint32_t m_frames_per_block { 0 };
+    uint32_t m_frames_per_block {};
 
     void detach_slot(size_t index);
 };

--- a/src/MayaFlux/Buffers/Container/StreamSliceProcessor.hpp
+++ b/src/MayaFlux/Buffers/Container/StreamSliceProcessor.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "MayaFlux/Buffers/BufferProcessor.hpp"
+#include "MayaFlux/Kakshya/Source/StreamSlice.hpp"
+
+namespace MayaFlux::Buffers {
+
+/**
+ * @class StreamSliceProcessor
+ * @brief BufferProcessor that drives a fixed pool of StreamSlices against their
+ *        respective DynamicSoundStreams and mixes the results into the attached
+ *        AudioBuffer each processing cycle.
+ *
+ * Each active StreamSlice is read via peek_sequential using the slice's own
+ * cursor as offset. Results are scaled by StreamSlice::scale and accumulated
+ * into the buffer in index order. Inactive slices contribute silence.
+ *
+ * Cursor advancement, loop wrapping, and deactivation on end are handled here
+ * per slice after each read, keeping StreamSlice as plain data.
+ *
+ * Ownership: StreamSlices are owned by this processor. The DynamicSoundStream
+ * each slice points to is shared and may be referenced by other processors or
+ * slices; it is never written to during processing.
+ *
+ * @tparam N Maximum number of concurrent StreamSlices. Defaults to 4.
+ */
+template <size_t N = 4>
+class MAYAFLUX_API StreamSliceProcessor : public BufferProcessor {
+public:
+    StreamSliceProcessor() = default;
+    ~StreamSliceProcessor() override = default;
+
+    void on_attach(const std::shared_ptr<Buffer>& buffer) override;
+    void processing_function(const std::shared_ptr<Buffer>& buffer) override;
+    [[nodiscard]] bool is_compatible_with(const std::shared_ptr<Buffer>& buffer) const override;
+
+    /**
+     * @brief Bind a slice at the given index, resetting its cursor to loop_start.
+     * No-op if index >= N.
+     * @param index Slot index within the pool.
+     */
+    void bind(size_t index);
+
+    /**
+     * @brief Unbind a slice without resetting its cursor.
+     * @param index Slot index within the pool.
+     */
+    void unbind(size_t index);
+
+    /**
+     * @brief Direct access to a slice for configuration before or between activations.
+     * @param index Slot index within the pool.
+     * @return Reference to the StreamSlice at that index.
+     */
+    [[nodiscard]] Kakshya::StreamSlice& slice(size_t index) { return m_slices[index]; }
+    [[nodiscard]] const Kakshya::StreamSlice& slice(size_t index) const { return m_slices[index]; }
+
+    /**
+     * @brief Register a callback fired when a slice reaches its loop_end without looping.
+     * Called from the processing thread with the slot index.
+     * @param cb Callback receiving the completed slice index.
+     */
+    void set_on_end(std::function<void(size_t)> cb) { m_on_end = std::move(cb); }
+
+private:
+    std::array<Kakshya::StreamSlice, N> m_slices {};
+    std::function<void(size_t)> m_on_end;
+    uint32_t m_num_frames { 0 };
+
+    void advance(Kakshya::StreamSlice& s, size_t index);
+};
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/Container/StreamSliceProcessor.hpp
+++ b/src/MayaFlux/Buffers/Container/StreamSliceProcessor.hpp
@@ -1,28 +1,33 @@
 #pragma once
 
 #include "MayaFlux/Buffers/BufferProcessor.hpp"
+#include "MayaFlux/Kakshya/Processors/CursorAccessProcessor.hpp"
 #include "MayaFlux/Kakshya/Source/StreamSlice.hpp"
 
 namespace MayaFlux::Buffers {
 
 /**
  * @class StreamSliceProcessor
- * @brief BufferProcessor that drives a fixed pool of StreamSlices against their
- *        respective DynamicSoundStreams and mixes the results into the attached
- *        AudioBuffer each processing cycle.
+ * @brief BufferProcessor that drives a pool of independent StreamSlices against
+ *        DynamicSoundStream instances, mixing results into the attached AudioBuffer
+ *        each processing cycle.
  *
- * Each active StreamSlice is read via peek_sequential using the slice's own
- * cursor as offset. Results are scaled by StreamSlice::scale and accumulated
- * into the buffer in index order. Inactive slices contribute silence.
+ * Each slot owns a CursorAccessProcessor responsible for cursor advancement,
+ * loop wrapping, speed scaling, and dynamic slot allocation on the stream.
+ * StreamSlice acts as a region descriptor only -- cursor state is internal to
+ * the per-slot processor. Multiple StreamSliceProcessor instances may reference
+ * the same DynamicSoundStream without contention; each allocates an independent
+ * dynamic slot via DynamicSoundStream::allocate_dynamic_slot().
  *
- * Cursor advancement, loop wrapping, and deactivation on end are handled here
- * per slice after each read, keeping StreamSlice as plain data.
+ * load() must be called after attachment to a buffer. Attachment populates the
+ * frame block size used to construct the per-slot CursorAccessProcessor. Calling
+ * load() before attachment is a no-op with an error log.
  *
- * Ownership: StreamSlices are owned by this processor. The DynamicSoundStream
- * each slice points to is shared and may be referenced by other processors or
- * slices; it is never written to during processing.
+ * Inactive slots contribute silence. Active slot outputs are accumulated into
+ * the buffer in index order with no further scaling applied here beyond what
+ * CursorAccessProcessor produces.
  *
- * @tparam N Maximum number of concurrent StreamSlices. Defaults to 4.
+ * @tparam N Maximum number of concurrent slots. Defaults to 4.
  */
 template <size_t N = 4>
 class MAYAFLUX_API StreamSliceProcessor : public BufferProcessor {
@@ -31,73 +36,59 @@ public:
     ~StreamSliceProcessor() override = default;
 
     void on_attach(const std::shared_ptr<Buffer>& buffer) override;
+    void on_detach(const std::shared_ptr<Buffer>& buffer) override;
     void processing_function(const std::shared_ptr<Buffer>& buffer) override;
     [[nodiscard]] bool is_compatible_with(const std::shared_ptr<Buffer>& buffer) const override;
 
     /**
-     * @brief Bind a slice at the given index, resetting its cursor to loop_start.
-     * No-op if index >= N.
-     * @param index Slot index within the pool.
-     */
-    void bind(size_t index);
-
-    /**
-     * @brief Unbind a slice without resetting its cursor.
-     * @param index Slot index within the pool.
-     */
-    void unbind(size_t index);
-
-    /**
-     * @brief Direct access to a slice for configuration before or between activations.
-     * @param index Slot index within the pool.
-     * @return Reference to the StreamSlice at that index.
-     */
-    [[nodiscard]] Kakshya::StreamSlice& slice(size_t index) { return m_slices[index]; }
-    [[nodiscard]] const Kakshya::StreamSlice& slice(size_t index) const { return m_slices[index]; }
-
-    /**
-     * @brief Register a callback fired when a slice reaches its loop_end without looping.
-     * Called from the processing thread with the slot index.
-     * @param cb Callback receiving the completed slice index.
-     */
-    void set_on_end(std::function<void(size_t)> cb) { m_on_end = std::move(cb); }
-
-    /**
-     * @brief Assign a configured StreamSlice to a slot.
-     * Resets cursor to loop_start and deactivates. Preserves all other
-     * fields from the provided slice.
-     * @param index Slot index within the pool.
-     * @param slice Configured StreamSlice to assign.
+     * @brief Assign a StreamSlice to a slot.
+     *
+     * Must be called after the processor is attached to a buffer, as the
+     * buffer's frame count is required to configure the CursorAccessProcessor.
+     * Calling load() before attachment is a no-op with an error log.
+     *
+     * Constructs a CursorAccessProcessor owned by this slot, attaches it to
+     * the slice's stream, and configures the loop region from the slice's
+     * Region. Any previously loaded slot processor is detached first.
+     * The slot is left inactive; call bind() to start playback.
+     *
+     * @param index Slot index in [0, N).
+     * @param slice StreamSlice describing the stream and region.
      */
     void load(size_t index, Kakshya::StreamSlice slice);
 
     /**
-     * @brief Assign a stream to a slot, configuring loop bounds to the full stream.
-     * Resets cursor state. Does not activate the slice.
-     * @param index Slot index within the pool.
-     * @param stream DynamicSoundStream to read from.
+     * @brief Activate a slot, resetting its processor cursor to region start.
+     * @param index Slot index in [0, N).
      */
-    void load(size_t index, std::shared_ptr<Kakshya::DynamicSoundStream> stream);
+    void bind(size_t index);
 
     /**
-     * @brief Assign a stream to a slot with explicit loop bounds.
-     * Resets cursor state. Does not activate the slice.
-     * @param index      Slot index within the pool.
-     * @param stream     DynamicSoundStream to read from.
-     * @param loop_start Start frame.
-     * @param loop_end   End frame.
+     * @brief Deactivate a slot, stopping its processor without resetting the cursor.
+     * @param index Slot index in [0, N).
      */
-    void load(size_t index,
-        std::shared_ptr<Kakshya::DynamicSoundStream> stream,
-        uint64_t loop_start,
-        uint64_t loop_end);
+    void unbind(size_t index);
+
+    [[nodiscard]] Kakshya::StreamSlice& slice(size_t index) { return m_slots[index].slice; }
+    [[nodiscard]] const Kakshya::StreamSlice& slice(size_t index) const { return m_slots[index].slice; }
+
+    /**
+     * @brief Register a callback fired when a slot's one-shot playback ends.
+     * @param cb Invoked with the slot index. Called from the processing thread.
+     */
+    void set_on_end(std::function<void(size_t)> cb) { m_on_end = std::move(cb); }
 
 private:
-    std::array<Kakshya::StreamSlice, N> m_slices {};
-    std::function<void(size_t)> m_on_end;
-    uint32_t m_num_frames { 0 };
+    struct Slot {
+        Kakshya::StreamSlice slice {};
+        std::shared_ptr<Kakshya::CursorAccessProcessor> proc;
+    };
 
-    void advance(Kakshya::StreamSlice& s, size_t index);
+    std::array<Slot, N> m_slots {};
+    std::function<void(size_t)> m_on_end;
+    uint32_t m_frames_per_block { 0 };
+
+    void detach_slot(size_t index);
 };
 
 } // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/Managers/BufferSupplyMixing.cpp
+++ b/src/MayaFlux/Buffers/Managers/BufferSupplyMixing.cpp
@@ -25,7 +25,7 @@ bool BufferSupplyMixing::supply_audio_buffer_to(
     const std::shared_ptr<AudioBuffer>& buffer,
     ProcessingToken token,
     uint32_t channel,
-    double mix)
+    double mix, bool force)
 {
     if (!buffer) {
         MF_ERROR(Journal::Component::Core, Journal::Context::BufferManagement,
@@ -33,7 +33,7 @@ bool BufferSupplyMixing::supply_audio_buffer_to(
         return false;
     }
 
-    if (buffer->get_channel_id() == channel) {
+    if (buffer->get_channel_id() == channel && !force) {
         MF_WARN(Journal::Component::Core, Journal::Context::BufferManagement,
             "BufferSupplyMixing: Buffer already has the correct channel ID {}", channel);
         return false;

--- a/src/MayaFlux/Buffers/Managers/BufferSupplyMixing.hpp
+++ b/src/MayaFlux/Buffers/Managers/BufferSupplyMixing.hpp
@@ -47,6 +47,9 @@ public:
      * @param token Processing domain
      * @param channel Channel index
      * @param mix Mix level (default: 1.0)
+     * @param force If true, forces supply even if buffer is already registered (default: false)
+                    The guard exists to prevent accidental multiple registrations of the same buffer to the same channel,
+                    which can cause unintended mixing behavior. Setting force to true allows bypassing this guard when intentional.
      * @return True if the buffer was successfully supplied, false otherwise
      *
      * The buffer data is added, mixed, and normalized at the end of the processing
@@ -57,7 +60,7 @@ public:
         const std::shared_ptr<AudioBuffer>& buffer,
         ProcessingToken token,
         uint32_t channel,
-        double mix = 1.0);
+        double mix = 1.0, bool force = false);
 
     /**
      * @brief Removes a previously supplied buffer from a token and channel

--- a/src/MayaFlux/IO/IOManager.cpp
+++ b/src/MayaFlux/IO/IOManager.cpp
@@ -1,6 +1,7 @@
 #include "IOManager.hpp"
 
 #include "MayaFlux/Buffers/BufferManager.hpp"
+#include "MayaFlux/Kakshya/Source/DynamicSoundStream.hpp"
 #include "MayaFlux/Registry/BackendRegistry.hpp"
 #include "MayaFlux/Registry/Service/IOService.hpp"
 
@@ -265,6 +266,35 @@ std::shared_ptr<Kakshya::SoundFileContainer> IOManager::load_audio(const std::st
     m_audio_readers.push_back(std::move(reader));
 
     return sound_container;
+}
+
+std::shared_ptr<Kakshya::DynamicSoundStream> IOManager::load_audio_bounded(
+    const std::string& filepath,
+    uint64_t max_frames,
+    bool truncate)
+{
+    auto reader = std::make_shared<IO::SoundFileReader>();
+
+    if (!reader->can_read(filepath)) {
+        MF_ERROR(Journal::Component::API, Journal::Context::FileIO,
+            "IOManager::load_bounded: unsupported format '{}'", filepath);
+        return nullptr;
+    }
+
+    reader->set_target_sample_rate(m_sample_rate);
+
+    auto stream = reader->load_bounded(filepath, max_frames, truncate);
+    if (!stream) {
+        MF_ERROR(Journal::Component::API, Journal::Context::FileIO,
+            "IOManager::load_bounded: failed for '{}'", filepath);
+        return nullptr;
+    }
+
+    stream->set_memory_layout(Kakshya::MemoryLayout::ROW_MAJOR);
+
+    m_audio_readers.push_back(std::move(reader));
+
+    return stream;
 }
 
 std::shared_ptr<Kakshya::CameraContainer>

--- a/src/MayaFlux/IO/IOManager.hpp
+++ b/src/MayaFlux/IO/IOManager.hpp
@@ -190,6 +190,24 @@ public:
      */
     [[nodiscard]] std::shared_ptr<Kakshya::SoundFileContainer> load_audio(const std::string& filepath, LoadConfig config = {});
 
+    /**
+     * @brief Load an audio file into a fully resident, size-bounded DynamicSoundStream.
+     *
+     * Applies the engine sample rate, ROW_MAJOR layout, and the engine buffer
+     * size as the CursorAccessProcessor block size. The result is ready for use
+     * with StreamSliceProcessor without any further configuration.
+     *
+     * @param filepath   Path to the audio file.
+     * @param max_frames Upper bound on frame count. 0 defaults to 5 s at the
+     *                   engine sample rate inside SoundFileReader::load_bounded.
+     * @param truncate   If true, silently truncate files exceeding max_frames.
+     * @return Configured DynamicSoundStream, or nullptr on failure.
+     */
+    [[nodiscard]] std::shared_ptr<Kakshya::DynamicSoundStream> load_audio_bounded(
+        const std::string& filepath,
+        uint64_t max_frames = 0,
+        bool truncate = false);
+
     // ─────────────────────────────────────────────────────────────────────────
     // Audio — hook
     // ─────────────────────────────────────────────────────────────────────────

--- a/src/MayaFlux/IO/SoundFileReader.cpp
+++ b/src/MayaFlux/IO/SoundFileReader.cpp
@@ -288,7 +288,7 @@ std::vector<Kakshya::DataVariant> SoundFileReader::read_region(const FileRegion&
 std::shared_ptr<Kakshya::DynamicSoundStream> SoundFileReader::load_bounded(
     const std::string& filepath,
     uint64_t max_frames,
-    std::function<void(std::shared_ptr<Kakshya::DynamicSoundStream>)> on_ready)
+    bool truncate)
 {
     if (!can_read(filepath)) {
         set_error("load_bounded: unsupported file: " + filepath);
@@ -319,7 +319,9 @@ std::shared_ptr<Kakshya::DynamicSoundStream> SoundFileReader::load_bounded(
     if (max_frames == 0)
         max_frames = effective_rate * 5;
 
-    if (audio->total_frames > max_frames) {
+    const bool over_limit = audio->total_frames > max_frames;
+
+    if (over_limit && !truncate) {
         set_error(std::format(
             "load_bounded: file has {} frames, exceeds limit of {}",
             audio->total_frames, max_frames));
@@ -327,25 +329,38 @@ std::shared_ptr<Kakshya::DynamicSoundStream> SoundFileReader::load_bounded(
         return nullptr;
     }
 
-    auto data = read_all();
-    close();
-
-    if (data.empty()) {
-        set_error("load_bounded: read_all returned no data");
-        return nullptr;
+    if (over_limit) {
+        MF_WARN(Journal::Component::IO, Journal::Context::FileIO,
+            "load_bounded: {} has {} frames, truncating to {}",
+            filepath, audio->total_frames, max_frames);
     }
+
+    const uint64_t frames_to_load = over_limit ? max_frames : audio->total_frames;
+    const bool planar = (m_audio_options & AudioReadOptions::DEINTERLEAVE) != AudioReadOptions::NONE;
 
     auto stream = std::make_shared<Kakshya::DynamicSoundStream>(
         effective_rate,
         static_cast<uint32_t>(audio->channels));
 
-    stream->set_auto_resize(false);
-    stream->ensure_capacity(audio->total_frames);
-    stream->set_all_data(data);
-    stream->update_processing_state(Kakshya::ProcessingState::READY);
+    stream->get_structure().organization = planar
+        ? Kakshya::OrganizationStrategy::PLANAR
+        : Kakshya::OrganizationStrategy::INTERLEAVED;
 
-    if (on_ready)
-        on_ready(stream);
+    stream->set_auto_resize(false);
+    stream->ensure_capacity(frames_to_load);
+
+    auto data = over_limit
+        ? read_frames(frames_to_load, 0)
+        : read_all();
+
+    close();
+
+    if (data.empty()) {
+        set_error("load_bounded: read returned no data");
+        return nullptr;
+    }
+
+    stream->set_all_data(data);
 
     return stream;
 }

--- a/src/MayaFlux/IO/SoundFileReader.cpp
+++ b/src/MayaFlux/IO/SoundFileReader.cpp
@@ -1,4 +1,5 @@
 #include "SoundFileReader.hpp"
+#include "MayaFlux/Kakshya/Source/DynamicSoundStream.hpp"
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -282,6 +283,71 @@ std::vector<Kakshya::DataVariant> SoundFileReader::read_region(const FileRegion&
     uint64_t end = region.end_coordinates[0];
     uint64_t n = (end > start) ? (end - start) : 1;
     return read_frames(n, start);
+}
+
+std::shared_ptr<Kakshya::DynamicSoundStream> SoundFileReader::load_bounded(
+    const std::string& filepath,
+    uint64_t max_frames,
+    std::function<void(std::shared_ptr<Kakshya::DynamicSoundStream>)> on_ready)
+{
+    if (!can_read(filepath)) {
+        set_error("load_bounded: unsupported file: " + filepath);
+        return nullptr;
+    }
+
+    if (!open(filepath, FileReadOptions::EXTRACT_METADATA)) {
+        set_error("load_bounded: open failed: " + get_last_error());
+        return nullptr;
+    }
+
+    std::shared_ptr<AudioStreamContext> audio;
+    {
+        std::shared_lock lock(m_context_mutex);
+        audio = m_audio;
+    }
+
+    if (!audio || !audio->is_valid()) {
+        set_error("load_bounded: no valid audio stream");
+        close();
+        return nullptr;
+    }
+
+    const uint64_t effective_rate = m_target_sample_rate > 0
+        ? m_target_sample_rate
+        : audio->sample_rate;
+
+    if (max_frames == 0)
+        max_frames = effective_rate * 5;
+
+    if (audio->total_frames > max_frames) {
+        set_error(std::format(
+            "load_bounded: file has {} frames, exceeds limit of {}",
+            audio->total_frames, max_frames));
+        close();
+        return nullptr;
+    }
+
+    auto data = read_all();
+    close();
+
+    if (data.empty()) {
+        set_error("load_bounded: read_all returned no data");
+        return nullptr;
+    }
+
+    auto stream = std::make_shared<Kakshya::DynamicSoundStream>(
+        effective_rate,
+        static_cast<uint32_t>(audio->channels));
+
+    stream->set_auto_resize(false);
+    stream->ensure_capacity(audio->total_frames);
+    stream->set_all_data(data);
+    stream->update_processing_state(Kakshya::ProcessingState::READY);
+
+    if (on_ready)
+        on_ready(stream);
+
+    return stream;
 }
 
 std::vector<Kakshya::DataVariant> SoundFileReader::read_frames(uint64_t num_frames,

--- a/src/MayaFlux/IO/SoundFileReader.hpp
+++ b/src/MayaFlux/IO/SoundFileReader.hpp
@@ -7,6 +7,10 @@
 
 #include "MayaFlux/Kakshya/Source/SoundFileContainer.hpp"
 
+namespace MayaFlux::Kakshya {
+class DynamicSoundStream;
+}
+
 namespace MayaFlux::IO {
 
 /**
@@ -154,6 +158,31 @@ public:
      * @return DataVariant containing region data.
      */
     std::vector<Kakshya::DataVariant> read_region(const FileRegion& region) override;
+
+    /**
+     * @brief Load an audio file into a size-bounded DynamicSoundStream.
+     *
+     * Opens the file, reads up to @p max_frames frames into a fully resident
+     * DynamicSoundStream with auto-resize disabled, then closes the file.
+     * No DataProcessor is configured on the result; the caller owns the
+     * read cursor entirely.
+     *
+     * Returns nullptr if the file cannot be opened, exceeds @p max_frames, or
+     * any read error occurs. Exceeding the frame limit is treated as an error
+     * rather than a silent truncation so callers are aware of the constraint.
+     *
+     * @param filepath     Path to the audio file.
+     * @param max_frames   Upper bound on frame count. Defaults to 5 seconds at
+     *                     the reader's target sample rate, or 48000 * 5 if no
+     *                     target rate has been set.
+     * @param on_ready     Optional callback fired with the populated stream once
+     *                     it transitions to ProcessingState::READY.
+     * @return Populated DynamicSoundStream, or nullptr on failure.
+     */
+    [[nodiscard]] std::shared_ptr<Kakshya::DynamicSoundStream> load_bounded(
+        const std::string& filepath,
+        uint64_t max_frames = 0,
+        std::function<void(std::shared_ptr<Kakshya::DynamicSoundStream>)> on_ready = nullptr);
 
     /**
      * @brief Create a SignalSourceContainer for this file.

--- a/src/MayaFlux/IO/SoundFileReader.hpp
+++ b/src/MayaFlux/IO/SoundFileReader.hpp
@@ -164,25 +164,20 @@ public:
      *
      * Opens the file, reads up to @p max_frames frames into a fully resident
      * DynamicSoundStream with auto-resize disabled, then closes the file.
-     * No DataProcessor is configured on the result; the caller owns the
-     * read cursor entirely.
-     *
-     * Returns nullptr if the file cannot be opened, exceeds @p max_frames, or
-     * any read error occurs. Exceeding the frame limit is treated as an error
-     * rather than a silent truncation so callers are aware of the constraint.
+     * No DataProcessor is configured on the result; that is the caller's
+     * responsibility (see IOManager::configure_audio_processor).
      *
      * @param filepath     Path to the audio file.
      * @param max_frames   Upper bound on frame count. Defaults to 5 seconds at
-     *                     the reader's target sample rate, or 48000 * 5 if no
-     *                     target rate has been set.
-     * @param on_ready     Optional callback fired with the populated stream once
-     *                     it transitions to ProcessingState::READY.
+     *                     the target sample rate.
+     * @param truncate     If true, silently truncate files that exceed max_frames
+     *                     with an MF_WARN. If false, return nullptr on excess.
      * @return Populated DynamicSoundStream, or nullptr on failure.
      */
     [[nodiscard]] std::shared_ptr<Kakshya::DynamicSoundStream> load_bounded(
         const std::string& filepath,
         uint64_t max_frames = 0,
-        std::function<void(std::shared_ptr<Kakshya::DynamicSoundStream>)> on_ready = nullptr);
+        bool truncate = false);
 
     /**
      * @brief Create a SignalSourceContainer for this file.

--- a/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.cpp
+++ b/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.cpp
@@ -1,0 +1,130 @@
+#include "CursorAccessProcessor.hpp"
+
+#include "MayaFlux/Kakshya/Source/DynamicSoundStream.hpp"
+
+#include "MayaFlux/Journal/Archivist.hpp"
+
+namespace MayaFlux::Kakshya {
+
+CursorAccessProcessor::CursorAccessProcessor(uint64_t frames_per_block)
+    : m_frames_per_block(frames_per_block)
+{
+}
+
+void CursorAccessProcessor::on_attach(const std::shared_ptr<SignalSourceContainer>& container)
+{
+    auto stream = std::dynamic_pointer_cast<DynamicSoundStream>(container);
+    if (!stream) {
+        MF_ERROR(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
+            "CursorAccessProcessor requires a DynamicSoundStream");
+        return;
+    }
+
+    m_stream = stream;
+    m_cursor = 0;
+    m_loop_start = 0;
+    m_loop_end = stream->get_num_frames();
+
+    const uint64_t n = m_frames_per_block * stream->get_num_channels();
+    auto& pd = container->get_processed_data();
+    pd.resize(1);
+    pd[0] = std::vector<double>(n, 0.0);
+
+    container->mark_ready_for_processing(true);
+}
+
+void CursorAccessProcessor::on_detach(const std::shared_ptr<SignalSourceContainer>&)
+{
+    m_stream.reset();
+    m_active = false;
+    m_cursor = 0;
+}
+
+void CursorAccessProcessor::process(const std::shared_ptr<SignalSourceContainer>& container)
+{
+    m_is_processing.store(true, std::memory_order_relaxed);
+
+    if (!m_active) {
+        write_silence(container);
+        m_is_processing.store(false, std::memory_order_relaxed);
+        return;
+    }
+
+    auto stream = m_stream.lock();
+    if (!stream) {
+        write_silence(container);
+        m_is_processing.store(false, std::memory_order_relaxed);
+        return;
+    }
+
+    const uint64_t num_channels = stream->get_num_channels();
+    const uint64_t elements = m_frames_per_block * num_channels;
+    const uint64_t loop_end = std::min(m_loop_end, stream->get_num_frames());
+
+    auto& pd = container->get_processed_data();
+    pd.resize(1);
+
+    auto& vec = std::get<std::vector<double>>(pd[0]);
+    if (vec.size() != elements)
+        vec.assign(elements, 0.0);
+
+    stream->peek_sequential(
+        std::span<double> { vec.data(), elements },
+        elements,
+        m_cursor * num_channels);
+
+    m_cursor += m_frames_per_block;
+
+    if (m_cursor >= loop_end) {
+        if (m_looping) {
+            m_cursor = m_loop_start;
+        } else {
+            m_active = false;
+            m_cursor = m_loop_start;
+            if (m_on_end)
+                m_on_end();
+        }
+    }
+
+    container->update_processing_state(ProcessingState::PROCESSED);
+    m_is_processing.store(false, std::memory_order_relaxed);
+}
+
+void CursorAccessProcessor::reset()
+{
+    m_cursor = m_loop_start;
+    m_active = true;
+}
+
+void CursorAccessProcessor::stop()
+{
+    m_active = false;
+}
+
+void CursorAccessProcessor::set_frames_per_block(uint64_t frames_per_block)
+{
+    m_frames_per_block = frames_per_block;
+}
+
+void CursorAccessProcessor::set_loop_region(uint64_t start_frame, uint64_t end_frame)
+{
+    m_loop_start = start_frame;
+    m_loop_end = end_frame;
+}
+
+void CursorAccessProcessor::write_silence(const std::shared_ptr<SignalSourceContainer>& container) const
+{
+    auto stream = m_stream.lock();
+    const uint64_t num_channels = stream ? stream->get_num_channels() : 2;
+    const uint64_t elements = m_frames_per_block * num_channels;
+
+    auto& pd = container->get_processed_data();
+    pd.resize(1);
+
+    auto& vec = std::get<std::vector<double>>(pd[0]);
+    vec.assign(elements, 0.0);
+
+    container->update_processing_state(ProcessingState::PROCESSED);
+}
+
+} // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.cpp
+++ b/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.cpp
@@ -105,6 +105,18 @@ void CursorAccessProcessor::process(const std::shared_ptr<SignalSourceContainer>
 
     if (next >= loop_end) {
         if (m_looping) {
+            if (m_loop_count > 0) {
+                --m_loops_remaining;
+                if (m_loops_remaining == 0) {
+                    m_active = false;
+                    m_speed_remainder = 0.0;
+                    m_cursor.assign(m_cursor.size(), m_loop_start);
+                    if (m_on_end)
+                        m_on_end();
+                    m_is_processing.store(false, std::memory_order_relaxed);
+                    return;
+                }
+            }
             m_speed_remainder = 0.0;
             m_cursor.assign(m_cursor.size(), m_loop_start);
         } else {
@@ -124,6 +136,7 @@ void CursorAccessProcessor::process(const std::shared_ptr<SignalSourceContainer>
 void CursorAccessProcessor::reset()
 {
     m_cursor.assign(m_cursor.size(), m_loop_start);
+    m_loops_remaining = m_loop_count;
     m_active = true;
 }
 
@@ -136,6 +149,12 @@ void CursorAccessProcessor::set_speed(double speed)
 void CursorAccessProcessor::stop()
 {
     m_active = false;
+}
+
+void CursorAccessProcessor::set_loop_count(size_t n)
+{
+    m_loop_count = n;
+    m_loops_remaining = n;
 }
 
 void CursorAccessProcessor::set_frames_per_block(uint64_t frames_per_block)

--- a/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.cpp
+++ b/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.cpp
@@ -26,18 +26,11 @@ void CursorAccessProcessor::on_attach(const std::shared_ptr<SignalSourceContaine
     m_slot_index = stream->allocate_dynamic_slot();
 
     const uint64_t num_channels = m_structure.get_channel_count();
-    m_cursor.assign(num_channels, 0);
-    m_loop_start = 0;
-    m_loop_end = stream->get_num_frames();
-
-    container->mark_ready_for_processing(true);
+    m_cursor.assign(num_channels, m_loop_start);
 }
 
 void CursorAccessProcessor::on_detach(const std::shared_ptr<SignalSourceContainer>& container)
 {
-    m_active = false;
-    m_cursor.clear();
-
     auto stream = std::dynamic_pointer_cast<DynamicSoundStream>(container);
     if (!stream) {
         MF_ERROR(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
@@ -45,6 +38,8 @@ void CursorAccessProcessor::on_detach(const std::shared_ptr<SignalSourceContaine
         return;
     }
 
+    m_active = false;
+    m_cursor.clear();
     stream->release_dynamic_slot(m_slot_index);
 }
 
@@ -72,7 +67,6 @@ void CursorAccessProcessor::process(const std::shared_ptr<SignalSourceContainer>
             for (auto& ch : pd)
                 std::get<std::vector<double>>(ch).assign(m_frames_per_block, 0.0);
         }
-        container->update_processing_state(ProcessingState::PROCESSED);
         m_is_processing.store(false, std::memory_order_relaxed);
         return;
     }
@@ -120,7 +114,6 @@ void CursorAccessProcessor::process(const std::shared_ptr<SignalSourceContainer>
         m_cursor.assign(m_cursor.size(), next);
     }
 
-    container->update_processing_state(ProcessingState::PROCESSED);
     m_is_processing.store(false, std::memory_order_relaxed);
 }
 

--- a/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.cpp
+++ b/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.cpp
@@ -1,6 +1,7 @@
 #include "CursorAccessProcessor.hpp"
 
 #include "MayaFlux/Kakshya/Source/DynamicSoundStream.hpp"
+#include "MayaFlux/Kakshya/Utils/DataUtils.hpp"
 
 #include "MayaFlux/Journal/Archivist.hpp"
 
@@ -20,70 +21,97 @@ void CursorAccessProcessor::on_attach(const std::shared_ptr<SignalSourceContaine
         return;
     }
 
-    m_stream = stream;
-    m_cursor = 0;
+    m_structure = container->get_structure();
+
+    m_slot_index = stream->allocate_dynamic_slot();
+
+    const uint64_t num_channels = m_structure.get_channel_count();
+    m_cursor.assign(num_channels, 0);
     m_loop_start = 0;
     m_loop_end = stream->get_num_frames();
-
-    const uint64_t n = m_frames_per_block * stream->get_num_channels();
-    auto& pd = container->get_processed_data();
-    pd.resize(1);
-    pd[0] = std::vector<double>(n, 0.0);
 
     container->mark_ready_for_processing(true);
 }
 
-void CursorAccessProcessor::on_detach(const std::shared_ptr<SignalSourceContainer>&)
+void CursorAccessProcessor::on_detach(const std::shared_ptr<SignalSourceContainer>& container)
 {
-    m_stream.reset();
     m_active = false;
-    m_cursor = 0;
+    m_cursor.clear();
+
+    auto stream = std::dynamic_pointer_cast<DynamicSoundStream>(container);
+    if (!stream) {
+        MF_ERROR(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
+            "CursorAccessProcessor requires a DynamicSoundStream, slot index can potentially leak");
+        return;
+    }
+
+    stream->release_dynamic_slot(m_slot_index);
 }
 
 void CursorAccessProcessor::process(const std::shared_ptr<SignalSourceContainer>& container)
 {
     m_is_processing.store(true, std::memory_order_relaxed);
 
-    if (!m_active) {
-        write_silence(container);
-        m_is_processing.store(false, std::memory_order_relaxed);
-        return;
-    }
-
-    auto stream = m_stream.lock();
+    auto stream = std::dynamic_pointer_cast<DynamicSoundStream>(container);
     if (!stream) {
-        write_silence(container);
+        MF_RT_ERROR(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
+            "CursorAccessProcessor requires a DynamicSoundStream");
         m_is_processing.store(false, std::memory_order_relaxed);
         return;
     }
 
-    const uint64_t num_channels = stream->get_num_channels();
-    const uint64_t elements = m_frames_per_block * num_channels;
-    const uint64_t loop_end = std::min(m_loop_end, stream->get_num_frames());
+    auto& pd = stream->get_dynamic_data(m_slot_index);
 
-    auto& pd = container->get_processed_data();
-    pd.resize(1);
+    if (!m_active) {
+        const uint64_t num_channels = m_structure.get_channel_count();
+        if (m_structure.organization == OrganizationStrategy::INTERLEAVED) {
+            pd.resize(1);
+            std::get<std::vector<double>>(pd[0]).assign(m_frames_per_block * num_channels, 0.0);
+        } else {
+            pd.resize(num_channels);
+            for (auto& ch : pd)
+                std::get<std::vector<double>>(ch).assign(m_frames_per_block, 0.0);
+        }
+        container->update_processing_state(ProcessingState::PROCESSED);
+        m_is_processing.store(false, std::memory_order_relaxed);
+        return;
+    }
 
-    auto& vec = std::get<std::vector<double>>(pd[0]);
-    if (vec.size() != elements)
-        vec.assign(elements, 0.0);
+    const uint64_t frame = m_cursor.empty() ? 0 : m_cursor[0];
+    const Region region {
+        std::vector<uint64_t> { frame, 0 },
+        std::vector<uint64_t> { frame + m_frames_per_block - 1, m_structure.get_channel_count() - 1 }
+    };
 
-    stream->peek_sequential(
-        std::span<double> { vec.data(), elements },
-        elements,
-        m_cursor * num_channels);
+    auto region_data = container->get_region_data(region);
 
-    m_cursor += m_frames_per_block;
+    if (m_structure.organization == OrganizationStrategy::INTERLEAVED) {
+        pd.resize(1);
+        if (!region_data.empty())
+            safe_copy_data_variant(region_data[0], pd[0]);
+    } else {
+        const uint64_t ch_count = std::min(
+            static_cast<uint64_t>(region_data.size()),
+            m_structure.get_channel_count());
+        pd.resize(ch_count);
+        for (size_t c = 0; c < ch_count; ++c)
+            safe_copy_data_variant(region_data[c], pd[c]);
+    }
 
-    if (m_cursor >= loop_end) {
+    const uint64_t next = frame + m_frames_per_block;
+    const uint64_t loop_end = m_loop_end;
+
+    if (next >= loop_end) {
         if (m_looping) {
-            m_cursor = m_loop_start;
+            m_cursor.assign(m_cursor.size(), m_loop_start);
         } else {
             m_active = false;
-            m_cursor = m_loop_start;
+            m_cursor.assign(m_cursor.size(), m_loop_start);
             if (m_on_end)
                 m_on_end();
         }
+    } else {
+        m_cursor.assign(m_cursor.size(), next);
     }
 
     container->update_processing_state(ProcessingState::PROCESSED);
@@ -92,7 +120,7 @@ void CursorAccessProcessor::process(const std::shared_ptr<SignalSourceContainer>
 
 void CursorAccessProcessor::reset()
 {
-    m_cursor = m_loop_start;
+    m_cursor.assign(m_cursor.size(), m_loop_start);
     m_active = true;
 }
 
@@ -110,21 +138,6 @@ void CursorAccessProcessor::set_loop_region(uint64_t start_frame, uint64_t end_f
 {
     m_loop_start = start_frame;
     m_loop_end = end_frame;
-}
-
-void CursorAccessProcessor::write_silence(const std::shared_ptr<SignalSourceContainer>& container) const
-{
-    auto stream = m_stream.lock();
-    const uint64_t num_channels = stream ? stream->get_num_channels() : 2;
-    const uint64_t elements = m_frames_per_block * num_channels;
-
-    auto& pd = container->get_processed_data();
-    pd.resize(1);
-
-    auto& vec = std::get<std::vector<double>>(pd[0]);
-    vec.assign(elements, 0.0);
-
-    container->update_processing_state(ProcessingState::PROCESSED);
 }
 
 } // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.cpp
+++ b/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.cpp
@@ -72,9 +72,13 @@ void CursorAccessProcessor::process(const std::shared_ptr<SignalSourceContainer>
     }
 
     const uint64_t frame = m_cursor.empty() ? 0 : m_cursor[0];
+
+    const uint64_t total_frames = m_structure.get_samples_count_per_channel();
+    const uint64_t read_end = std::min(frame + m_frames_per_block - 1, total_frames - 1);
+
     const Region region {
         std::vector<uint64_t> { frame, 0 },
-        std::vector<uint64_t> { frame + m_frames_per_block - 1, m_structure.get_channel_count() - 1 }
+        std::vector<uint64_t> { read_end, m_structure.get_channel_count() - 1 }
     };
 
     auto region_data = container->get_region_data(region);

--- a/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.cpp
+++ b/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.cpp
@@ -98,14 +98,20 @@ void CursorAccessProcessor::process(const std::shared_ptr<SignalSourceContainer>
             safe_copy_data_variant(region_data[c], pd[c]);
     }
 
-    const uint64_t next = frame + m_frames_per_block;
+    const double raw_advance = static_cast<double>(m_frames_per_block) * m_speed + m_speed_remainder;
+    const auto int_advance = static_cast<uint64_t>(raw_advance);
+    m_speed_remainder = raw_advance - static_cast<double>(int_advance);
+
+    const uint64_t next = frame + int_advance;
     const uint64_t loop_end = m_loop_end;
 
     if (next >= loop_end) {
         if (m_looping) {
+            m_speed_remainder = 0.0;
             m_cursor.assign(m_cursor.size(), m_loop_start);
         } else {
             m_active = false;
+            m_speed_remainder = 0.0;
             m_cursor.assign(m_cursor.size(), m_loop_start);
             if (m_on_end)
                 m_on_end();
@@ -122,6 +128,12 @@ void CursorAccessProcessor::reset()
 {
     m_cursor.assign(m_cursor.size(), m_loop_start);
     m_active = true;
+}
+
+void CursorAccessProcessor::set_speed(double speed)
+{
+    if (speed > 0.0)
+        m_speed = speed;
 }
 
 void CursorAccessProcessor::stop()

--- a/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.hpp
+++ b/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.hpp
@@ -1,10 +1,9 @@
 #pragma once
 
 #include "MayaFlux/Kakshya/DataProcessor.hpp"
+#include "MayaFlux/Kakshya/NDimensionalContainer.hpp"
 
 namespace MayaFlux::Kakshya {
-
-class DynamicSoundStream;
 
 /**
  * @class CursorAccessProcessor
@@ -17,8 +16,9 @@ class DynamicSoundStream;
  * treated as immutable memory after load; multiple CursorAccessProcessor
  * instances may attach to the same DynamicSoundStream with no contention.
  *
- * Output is always a single interleaved std::vector<double> written into
- * processed_data[0]. Block size is set once at construction or via
+ * Output mirrors ContiguousAccessProcessor's contract: interleaved layout
+ * produces one DataVariant in processed_data; planar layout produces one
+ * DataVariant per channel. Block size is set once at construction or via
  * set_frames_per_block() and does not change during processing.
  *
  * When inactive, process() writes silence and returns immediately without
@@ -97,15 +97,19 @@ public:
     void set_on_end(std::function<void()> cb) { m_on_end = std::move(cb); }
 
     [[nodiscard]] bool is_active() const { return m_active; }
-    [[nodiscard]] uint64_t cursor() const { return m_cursor; }
+    [[nodiscard]] uint64_t cursor() const { return m_cursor[0]; }
     [[nodiscard]] uint64_t loop_start() const { return m_loop_start; }
     [[nodiscard]] uint64_t loop_end() const { return m_loop_end; }
+    [[nodiscard]] uint32_t get_slot_index() const { return m_slot_index; }
 
 private:
     uint64_t m_frames_per_block;
-    uint64_t m_cursor { 0 };
+    std::vector<uint64_t> m_cursor { 0 };
     uint64_t m_loop_start { 0 };
     uint64_t m_loop_end { 0 };
+    uint32_t m_slot_index { std::numeric_limits<uint32_t>::max() };
+
+    ContainerDataStructure m_structure;
 
     bool m_looping { false };
     bool m_active { false };
@@ -113,10 +117,6 @@ private:
     std::atomic<bool> m_is_processing { false };
 
     std::function<void()> m_on_end;
-
-    std::weak_ptr<DynamicSoundStream> m_stream;
-
-    void write_silence(const std::shared_ptr<SignalSourceContainer>& container) const;
 };
 
 } // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.hpp
+++ b/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include "MayaFlux/Kakshya/DataProcessor.hpp"
+
+namespace MayaFlux::Kakshya {
+
+class DynamicSoundStream;
+
+/**
+ * @class CursorAccessProcessor
+ * @brief DataProcessor that reads a bounded DynamicSoundStream via an owned
+ *        frame cursor, writing a fixed-size block into the container's
+ *        processed_data each process() call.
+ *
+ * Unlike ContiguousAccessProcessor, this processor owns its read position
+ * independently of the container's internal read state. The container is
+ * treated as immutable memory after load; multiple CursorAccessProcessor
+ * instances may attach to the same DynamicSoundStream with no contention.
+ *
+ * Output is always a single interleaved std::vector<double> written into
+ * processed_data[0]. Block size is set once at construction or via
+ * set_frames_per_block() and does not change during processing.
+ *
+ * When inactive, process() writes silence and returns immediately without
+ * advancing the cursor. Activation and cursor reset are explicit operations
+ * via reset(), allowing external trigger logic to remain decoupled.
+ */
+class MAYAFLUX_API CursorAccessProcessor : public DataProcessor {
+public:
+    /**
+     * @brief Construct with a fixed output block size.
+     * @param frames_per_block Number of frames extracted per process() call.
+     *                         One frame = one sample per channel. Should match
+     *                         the engine buffer size in frames.
+     */
+    explicit CursorAccessProcessor(uint64_t frames_per_block);
+
+    ~CursorAccessProcessor() override = default;
+
+    void on_attach(const std::shared_ptr<SignalSourceContainer>& container) override;
+    void on_detach(const std::shared_ptr<SignalSourceContainer>& container) override;
+
+    /**
+     * @brief Extract one block of frames into container processed_data[0].
+     *
+     * If inactive, fills processed_data[0] with silence and returns.
+     * Advances m_cursor by m_frames_per_block after each active read.
+     * On reaching the loop end, wraps to m_loop_start if looping, otherwise
+     * deactivates and fires m_on_end if set.
+     *
+     * @param container Must be the DynamicSoundStream passed to on_attach.
+     */
+    void process(const std::shared_ptr<SignalSourceContainer>& container) override;
+
+    [[nodiscard]] bool is_processing() const override { return m_is_processing.load(); }
+
+    /**
+     * @brief Reset cursor to loop start and activate the processor.
+     * Safe to call from any thread between process() calls.
+     */
+    void reset();
+
+    /**
+     * @brief Deactivate without resetting the cursor position.
+     */
+    void stop();
+
+    /**
+     * @brief Set the output block size in frames.
+     * @param frames_per_block Must be > 0.
+     */
+    void set_frames_per_block(uint64_t frames_per_block);
+
+    /**
+     * @brief Enable or disable looping within the loop region.
+     * @param enable True to loop, false for one-shot.
+     */
+    void set_looping(bool enable) { m_looping = enable; }
+
+    /**
+     * @brief Set the loop region in frames.
+     *
+     * Defaults to [0, total_frames) on attach. Both values are clamped to the
+     * container's frame count on the next process() call. All units are frames
+     * (one frame = num_channels samples); conversion to sample offsets for
+     * peek_sequential happens internally.
+     *
+     * @param start_frame Inclusive loop start, in frames.
+     * @param end_frame   Exclusive loop end, in frames.
+     */
+    void set_loop_region(uint64_t start_frame, uint64_t end_frame);
+
+    /**
+     * @brief Register a callback fired when one-shot playback reaches the end.
+     * @param cb Callback with no arguments. Called from the process() thread.
+     */
+    void set_on_end(std::function<void()> cb) { m_on_end = std::move(cb); }
+
+    [[nodiscard]] bool is_active() const { return m_active; }
+    [[nodiscard]] uint64_t cursor() const { return m_cursor; }
+    [[nodiscard]] uint64_t loop_start() const { return m_loop_start; }
+    [[nodiscard]] uint64_t loop_end() const { return m_loop_end; }
+
+private:
+    uint64_t m_frames_per_block;
+    uint64_t m_cursor { 0 };
+    uint64_t m_loop_start { 0 };
+    uint64_t m_loop_end { 0 };
+
+    bool m_looping { false };
+    bool m_active { false };
+
+    std::atomic<bool> m_is_processing { false };
+
+    std::function<void()> m_on_end;
+
+    std::weak_ptr<DynamicSoundStream> m_stream;
+
+    void write_silence(const std::shared_ptr<SignalSourceContainer>& container) const;
+};
+
+} // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.hpp
+++ b/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.hpp
@@ -97,6 +97,16 @@ public:
     void set_loop_region(uint64_t start_frame, uint64_t end_frame);
 
     /**
+     * @brief Set the number of loops to play before stopping.
+     * Loop count is decremented on each loop completion; when it reaches zero,
+     * the processor deactivates and fires m_on_end if set. Loop count is
+     * ignored if looping is disabled.
+     *
+     * @param n Number of loops to play (0 for infinite).
+     */
+    void set_loop_count(size_t n);
+
+    /**
      * @brief Register a callback fired when one-shot playback reaches the end.
      * @param cb Callback with no arguments. Called from the process() thread.
      */
@@ -128,6 +138,8 @@ private:
     uint64_t m_loop_end {};
     bool m_looping {};
     bool m_active {};
+    size_t m_loop_count {};
+    size_t m_loops_remaining {};
     double m_speed_remainder {};
     double m_speed { 1.0 };
 

--- a/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.hpp
+++ b/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.hpp
@@ -83,7 +83,7 @@ public:
      * Defaults to [0, total_frames) on attach. Both values are clamped to the
      * container's frame count on the next process() call. All units are frames
      * (one frame = num_channels samples); conversion to sample offsets for
-     * peek_sequential happens internally.
+     * get_region_data happens internally.
      *
      * @param start_frame Inclusive loop start, in frames.
      * @param end_frame   Exclusive loop end, in frames.
@@ -96,6 +96,19 @@ public:
      */
     void set_on_end(std::function<void()> cb) { m_on_end = std::move(cb); }
 
+    /**
+     * @brief Set the playback speed relative to nominal rate.
+     *
+     * Speed is applied as a fractional frame accumulator: each process() call
+     * advances the cursor by m_frames_per_block * m_speed frames, with the
+     * sub-frame remainder carried in m_speed_remainder for the next call.
+     * Speed 1.0 is the default (no accumulator overhead). Values <= 0.0 are
+     * ignored.
+     *
+     * @param speed Playback speed multiplier (1.0 = normal).
+     */
+    void set_speed(double speed);
+
     [[nodiscard]] bool is_active() const { return m_active; }
     [[nodiscard]] uint64_t cursor() const { return m_cursor[0]; }
     [[nodiscard]] uint64_t loop_start() const { return m_loop_start; }
@@ -104,17 +117,19 @@ public:
 
 private:
     uint64_t m_frames_per_block;
-    std::vector<uint64_t> m_cursor { 0 };
-    uint64_t m_loop_start { 0 };
-    uint64_t m_loop_end { 0 };
+    std::vector<uint64_t> m_cursor {};
+    uint64_t m_loop_start {};
+    uint64_t m_loop_end {};
+    bool m_looping {};
+    bool m_active {};
+    double m_speed_remainder {};
+    double m_speed { 1.0 };
+
     uint32_t m_slot_index { std::numeric_limits<uint32_t>::max() };
 
-    ContainerDataStructure m_structure;
-
-    bool m_looping { false };
-    bool m_active { false };
-
     std::atomic<bool> m_is_processing { false };
+
+    ContainerDataStructure m_structure;
 
     std::function<void()> m_on_end;
 };

--- a/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.hpp
+++ b/src/MayaFlux/Kakshya/Processors/CursorAccessProcessor.hpp
@@ -7,23 +7,29 @@ namespace MayaFlux::Kakshya {
 
 /**
  * @class CursorAccessProcessor
- * @brief DataProcessor that reads a bounded DynamicSoundStream via an owned
- *        frame cursor, writing a fixed-size block into the container's
- *        processed_data each process() call.
+ * @brief Independent cursor reader for DynamicSoundStream, writing exclusively
+ *        to a dynamic slot allocated at attach time.
  *
- * Unlike ContiguousAccessProcessor, this processor owns its read position
- * independently of the container's internal read state. The container is
- * treated as immutable memory after load; multiple CursorAccessProcessor
- * instances may attach to the same DynamicSoundStream with no contention.
+ * Intended for use cases where multiple independent cursors must read the same
+ * DynamicSoundStream simultaneously -- for example StreamSliceProcessor holding
+ * N slots over the same loaded buffer. Each instance allocates one dynamic slot
+ * via DynamicSoundStream::allocate_dynamic_slot() and writes only into that slot
+ * via get_dynamic_data(m_slot_index). The stream's processed_data, processing
+ * state, and ready/consumed machinery are never touched. Callers read output
+ * directly from get_dynamic_data(get_slot_index()).
  *
- * Output mirrors ContiguousAccessProcessor's contract: interleaved layout
- * produces one DataVariant in processed_data; planar layout produces one
- * DataVariant per channel. Block size is set once at construction or via
- * set_frames_per_block() and does not change during processing.
+ * on_attach does three things only: cache the container structure, allocate the
+ * dynamic slot, and initialise the cursor. It does not set the stream as ready
+ * for processing or register any state callbacks. on_detach releases the slot.
+ * All other container lifecycle is the caller's responsibility.
  *
- * When inactive, process() writes silence and returns immediately without
- * advancing the cursor. Activation and cursor reset are explicit operations
- * via reset(), allowing external trigger logic to remain decoupled.
+ * For default single-cursor sequential reads driven by the container's own
+ * processing state, use ContiguousAccessProcessor instead.
+ *
+ * The stream is treated as immutable memory after load. Block size is fixed at
+ * construction or via set_frames_per_block(). When inactive, process() writes
+ * silence without advancing the cursor. Activation and cursor reset are explicit
+ * via reset(), keeping trigger logic decoupled from the processor.
  */
 class MAYAFLUX_API CursorAccessProcessor : public DataProcessor {
 public:

--- a/src/MayaFlux/Kakshya/Source/DynamicSoundStream.cpp
+++ b/src/MayaFlux/Kakshya/Source/DynamicSoundStream.cpp
@@ -329,6 +329,39 @@ void DynamicSoundStream::enable_circular_buffer(uint64_t capacity)
     m_is_circular = true;
 }
 
+uint32_t DynamicSoundStream::allocate_dynamic_slot()
+{
+    for (uint32_t i = 0; i < m_dynamic_slots.size(); ++i) {
+        if (!m_dynamic_slots[i]) {
+            m_dynamic_slots[i] = true;
+            m_dynamic_data[i].clear();
+            return i;
+        }
+    }
+
+    m_dynamic_data.emplace_back();
+    m_dynamic_slots.push_back(true);
+    return static_cast<uint32_t>(m_dynamic_slots.size() - 1);
+}
+
+void DynamicSoundStream::release_dynamic_slot(uint32_t index)
+{
+    if (index < m_dynamic_slots.size()) {
+        m_dynamic_slots[index] = false;
+        m_dynamic_data[index].clear();
+    }
+}
+
+std::vector<DataVariant>& DynamicSoundStream::get_dynamic_data(uint32_t index)
+{
+    return m_dynamic_data.at(index);
+}
+
+const std::vector<DataVariant>& DynamicSoundStream::get_dynamic_data(uint32_t index) const
+{
+    return m_dynamic_data.at(index);
+}
+
 void DynamicSoundStream::disable_circular_buffer()
 {
     set_looping(false);
@@ -362,7 +395,7 @@ void DynamicSoundStream::set_all_data(const std::vector<DataVariant>& data)
 
 void DynamicSoundStream::set_all_data(const DataVariant& data)
 {
-    set_all_data(std::vector<DataVariant> {data});
+    set_all_data(std::vector<DataVariant> { data });
 }
 
 void DynamicSoundStream::expand_to(uint64_t target_frames)

--- a/src/MayaFlux/Kakshya/Source/DynamicSoundStream.hpp
+++ b/src/MayaFlux/Kakshya/Source/DynamicSoundStream.hpp
@@ -127,10 +127,37 @@ public:
 
     uint64_t get_circular_capacity() const { return m_circular_capacity; }
 
+    /**
+     * @brief Allocate an independent processed data slot.
+     *
+     * Returns a unique index into m_dynamic_data. Intended for processors
+     * that share this stream but require independent output buffers, such
+     * as multiple CursorAccessProcessor instances reading at different
+     * cursors. The slot is empty on allocation.
+     *
+     * @return Slot index, stable until release_dynamic_slot is called.
+     */
+    uint32_t allocate_dynamic_slot();
+
+    /**
+     * @brief Release a previously allocated dynamic slot, clearing its data.
+     * @param index Slot index returned by allocate_dynamic_slot.
+     */
+    void release_dynamic_slot(uint32_t index);
+
+    /**
+     * @brief Access a dynamic processed data slot by index.
+     * @param index Slot index returned by allocate_dynamic_slot.
+     */
+    [[nodiscard]] std::vector<DataVariant>& get_dynamic_data(uint32_t index);
+    [[nodiscard]] const std::vector<DataVariant>& get_dynamic_data(uint32_t index) const;
+
 private:
     bool m_auto_resize; ///< Enable automatic capacity expansion
     bool m_is_circular {}; ///< True when operating in circular buffer mode
     uint64_t m_circular_capacity {}; ///< Fixed capacity for circular mode
+    std::vector<std::vector<DataVariant>> m_dynamic_data;
+    std::vector<bool> m_dynamic_slots;
 
     void expand_to(uint64_t target_frames);
 

--- a/src/MayaFlux/Kakshya/Source/DynamicSoundStream.hpp
+++ b/src/MayaFlux/Kakshya/Source/DynamicSoundStream.hpp
@@ -2,6 +2,10 @@
 
 #include "SoundStreamContainer.hpp"
 
+namespace MayaFlux::IO {
+class SoundFileReader;
+}
+
 namespace MayaFlux::Kakshya {
 
 /**
@@ -138,6 +142,8 @@ private:
     uint64_t validate(std::vector<std::span<const double>>& data, uint64_t start_frame = 0);
 
     uint64_t validate_single_channel(std::span<const double> data, uint64_t start_frame = 0, uint32_t channel = 0);
+
+    friend class MayaFlux::IO::SoundFileReader; ///< Allow SoundFileReader to access private members for loading data
 };
 
 } // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Source/StreamSlice.hpp
+++ b/src/MayaFlux/Kakshya/Source/StreamSlice.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+namespace MayaFlux::Kakshya {
+
+class DynamicSoundStream;
+
+/**
+ * @struct StreamSlice
+ * @brief Plain data describing the state of one bounded stream read operation.
+ *
+ * Cursor and loop boundaries are in frames. Speed is a rate multiplier applied
+ * to cursor advancement per block; values other than 1.0 require fractional
+ * accumulation via cursor_remainder. Index identifies the slot within a
+ * multi-slice processor and determines mix priority. Scale is an independent
+ * per-slice amplitude multiplier applied at mix time.
+ */
+struct StreamSlice {
+    std::shared_ptr<DynamicSoundStream> stream;
+
+    uint64_t cursor { 0 };
+    double cursor_remainder { 0.0 };
+    double speed { 1.0 };
+
+    uint64_t loop_start { 0 };
+    uint64_t loop_end { 0 };
+
+    bool looping { false };
+    bool active { false };
+
+    uint8_t index { 0 };
+    double scale { 1.0 };
+};
+
+} // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Source/StreamSlice.hpp
+++ b/src/MayaFlux/Kakshya/Source/StreamSlice.hpp
@@ -34,6 +34,7 @@ struct StreamSlice {
     bool looping {};
     bool active {};
     uint8_t index {};
+    size_t loop_count {};
 
     /**
      * @brief Construct a slice spanning the full stream across all channels.
@@ -124,6 +125,12 @@ struct StreamSlice {
     StreamSlice& with_scale(double s)
     {
         scale = s;
+        return *this;
+    }
+
+    StreamSlice& with_loop_count(size_t n)
+    {
+        loop_count = n;
         return *this;
     }
 };

--- a/src/MayaFlux/Kakshya/Source/StreamSlice.hpp
+++ b/src/MayaFlux/Kakshya/Source/StreamSlice.hpp
@@ -1,34 +1,113 @@
 #pragma once
 
-namespace MayaFlux::Kakshya {
+#include "MayaFlux/Kakshya/Region/Region.hpp"
+#include "MayaFlux/Kakshya/Source/DynamicSoundStream.hpp"
 
-class DynamicSoundStream;
+namespace MayaFlux::Kakshya {
 
 /**
  * @struct StreamSlice
- * @brief Plain data describing the state of one bounded stream read operation.
+ * @brief A bounded region of a DynamicSoundStream with associated playback parameters.
  *
- * Cursor and loop boundaries are in frames. Speed is a rate multiplier applied
- * to cursor advancement per block; values other than 1.0 require fractional
- * accumulation via cursor_remainder. Index identifies the slot within a
- * multi-slice processor and determines mix priority. Scale is an independent
- * per-slice amplitude multiplier applied at mix time.
+ * Describes a slice of audio data within a DynamicSoundStream as a Region.
+ * region.start_coordinates[0] / end_coordinates[0] are the frame bounds;
+ * region.start_coordinates[1] / end_coordinates[1] are the channel bounds.
+ *
+ * The slice does not own a processor. The region is the contract; whatever
+ * drives this slice resolves the appropriate processor at activation time.
+ * Currently that is CursorAccessProcessor for sequential bounded reads, but
+ * the region descriptor is equally valid input to RegionOrganizationProcessor
+ * (non-linear navigation, selection patterns, transitions) or any future
+ * region-aware processor against a DynamicSoundStream.
+ *
+ * speed and scale are playback parameters applied by the driving processor.
+ * cursor_remainder accumulates sub-frame advancement for speed != 1.0.
+ * looping and index are playback state and identity carried with the slice.
  */
 struct StreamSlice {
     std::shared_ptr<DynamicSoundStream> stream;
+    Region region;
 
-    uint64_t cursor { 0 };
-    double cursor_remainder { 0.0 };
     double speed { 1.0 };
-
-    uint64_t loop_start { 0 };
-    uint64_t loop_end { 0 };
-
-    bool looping { false };
-    bool active { false };
-
-    uint8_t index { 0 };
+    double cursor_remainder {};
     double scale { 1.0 };
+    bool looping {};
+    bool active {};
+    uint8_t index {};
+
+    /**
+     * @brief Construct a slice spanning the full stream across all channels.
+     * @param stream Source stream.
+     * @param index  Slot identity.
+     */
+    static StreamSlice from_stream(
+        std::shared_ptr<DynamicSoundStream> stream,
+        uint8_t index = 0)
+    {
+        const uint64_t end_frame = stream->get_num_frames() > 0
+            ? stream->get_num_frames() - 1
+            : 0;
+        const uint64_t end_channel = stream->get_num_channels() > 0
+            ? stream->get_num_channels() - 1
+            : 0;
+        return StreamSlice {
+            .stream = std::move(stream),
+            .region = Region::audio_span(0, end_frame, 0, end_channel),
+            .index = index,
+        };
+    }
+
+    /**
+     * @brief Construct a slice spanning a frame sub-region across all channels.
+     * @param stream      Source stream.
+     * @param start_frame Inclusive start frame.
+     * @param end_frame   Inclusive end frame.
+     * @param index       Slot identity.
+     */
+    static StreamSlice from_frame_range(
+        std::shared_ptr<DynamicSoundStream> stream,
+        uint64_t start_frame,
+        uint64_t end_frame,
+        uint8_t index = 0)
+    {
+        const uint64_t end_channel = stream->get_num_channels() > 0
+            ? stream->get_num_channels() - 1
+            : 0;
+        return StreamSlice {
+            .stream = std::move(stream),
+            .region = Region::audio_span(start_frame, end_frame, 0, end_channel),
+            .index = index,
+        };
+    }
+
+    /**
+     * @brief Construct a slice spanning a frame and channel sub-region.
+     * @param stream        Source stream.
+     * @param start_frame   Inclusive start frame.
+     * @param end_frame     Inclusive end frame.
+     * @param start_channel Inclusive start channel.
+     * @param end_channel   Inclusive end channel.
+     * @param index         Slot identity.
+     */
+    static StreamSlice from_region(
+        std::shared_ptr<DynamicSoundStream> stream,
+        uint64_t start_frame,
+        uint64_t end_frame,
+        uint32_t start_channel,
+        uint32_t end_channel,
+        uint8_t index = 0)
+    {
+        return StreamSlice {
+            .stream = std::move(stream),
+            .region = Region::audio_span(start_frame, end_frame, start_channel, end_channel),
+            .index = index,
+        };
+    }
+
+    [[nodiscard]] uint64_t start_frame() const { return region.start_coordinates[0]; }
+    [[nodiscard]] uint64_t end_frame() const { return region.end_coordinates[0]; }
+    [[nodiscard]] uint32_t start_channel() const { return static_cast<uint32_t>(region.start_coordinates[1]); }
+    [[nodiscard]] uint32_t end_channel() const { return static_cast<uint32_t>(region.end_coordinates[1]); }
 };
 
 } // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Source/StreamSlice.hpp
+++ b/src/MayaFlux/Kakshya/Source/StreamSlice.hpp
@@ -108,6 +108,24 @@ struct StreamSlice {
     [[nodiscard]] uint64_t end_frame() const { return region.end_coordinates[0]; }
     [[nodiscard]] uint32_t start_channel() const { return static_cast<uint32_t>(region.start_coordinates[1]); }
     [[nodiscard]] uint32_t end_channel() const { return static_cast<uint32_t>(region.end_coordinates[1]); }
+
+    StreamSlice& with_speed(double s)
+    {
+        speed = s;
+        return *this;
+    }
+
+    StreamSlice& with_looping(bool l)
+    {
+        looping = l;
+        return *this;
+    }
+
+    StreamSlice& with_scale(double s)
+    {
+        scale = s;
+        return *this;
+    }
 };
 
 } // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Utils/ContainerUtils.cpp
+++ b/src/MayaFlux/Kakshya/Utils/ContainerUtils.cpp
@@ -169,7 +169,7 @@ void extract_processed_data(
         thread_local std::vector<double> tmp;
         auto data_span = extract_from_variant<double>(pd[0], tmp);
 
-        const auto samples_to_copy = std::min(
+        const auto samples_to_copy = std::min<size_t>(
             output.size(),
             data_span.size() / std::max<uint64_t>(num_channels, 1));
 

--- a/src/MayaFlux/Kakshya/Utils/ContainerUtils.cpp
+++ b/src/MayaFlux/Kakshya/Utils/ContainerUtils.cpp
@@ -10,7 +10,7 @@ namespace MayaFlux::Kakshya {
 std::unordered_map<std::string, std::any> extract_processing_state_info(const std::shared_ptr<SignalSourceContainer>& container)
 {
     if (!container) {
-        throw std::invalid_argument("Container is null");
+        error<std::invalid_argument>(Journal::Component::Kakshya, Journal::Context::Runtime, std::source_location::current(), "Container is null");
     }
 
     std::unordered_map<std::string, std::any> state_info;
@@ -31,7 +31,7 @@ std::unordered_map<std::string, std::any> extract_processing_state_info(const st
 std::unordered_map<std::string, std::any> extract_processor_info(const std::shared_ptr<SignalSourceContainer>& container)
 {
     if (!container) {
-        throw std::invalid_argument("Container is null");
+        error<std::invalid_argument>(Journal::Component::Kakshya, Journal::Context::Runtime, std::source_location::current(), "Container is null");
     }
 
     std::unordered_map<std::string, std::any> processor_info;
@@ -79,7 +79,7 @@ std::unordered_map<std::string, std::any> analyze_access_pattern(const Region& r
     std::unordered_map<std::string, std::any> analysis;
 
     if (!container) {
-        throw std::invalid_argument("Container is null");
+        error<std::invalid_argument>(Journal::Component::Kakshya, Journal::Context::Runtime, std::source_location::current(), "Container is null");
     }
 
     const auto dimensions = container->get_dimensions();
@@ -106,21 +106,21 @@ DataVariant extract_channel_data(const std::shared_ptr<SignalSourceContainer>& c
     uint32_t channel_index)
 {
     if (!container) {
-        throw std::invalid_argument("Container is null");
+        error<std::invalid_argument>(Journal::Component::Kakshya, Journal::Context::Runtime, std::source_location::current(), "Container is null");
     }
 
     const auto structure = container->get_structure();
     auto channel_count = structure.get_channel_count();
 
     if (channel_index >= channel_count) {
-        throw std::out_of_range("Channel index out of range");
+        error<std::out_of_range>(Journal::Component::Kakshya, Journal::Context::Runtime, std::source_location::current(), "Channel index out of range: {} (available channels: {})", channel_index, channel_count);
     }
 
     auto data = container->get_data();
 
     if (structure.organization == OrganizationStrategy::PLANAR) {
         if (channel_index >= data.size()) {
-            throw std::out_of_range("Channel index out of range for planar data");
+            error<std::out_of_range>(Journal::Component::Kakshya, Journal::Context::Runtime, std::source_location::current(), "Channel index out of range for planar data: {} (available channels: {})", channel_index, data.size());
         }
         return data[channel_index];
     }
@@ -129,11 +129,11 @@ DataVariant extract_channel_data(const std::shared_ptr<SignalSourceContainer>& c
     auto interleaved_span = extract_from_variant<double>(data[0], temp_storage);
 
     if (interleaved_span.empty()) {
-        throw std::runtime_error("Failed to extract interleaved data");
+        error<std::runtime_error>(Journal::Component::Kakshya, Journal::Context::Runtime, std::source_location::current(), "Failed to extract interleaved data");
     }
 
     if (interleaved_span.size() % channel_count != 0) {
-        throw std::runtime_error("Interleaved data size is not a multiple of channel count");
+        error<std::runtime_error>(Journal::Component::Kakshya, Journal::Context::Runtime, std::source_location::current(), "Interleaved data size ({}) is not a multiple of channel count ({})", interleaved_span.size(), channel_count);
     }
 
 #ifdef MAYAFLUX_PLATFORM_MACOS
@@ -151,6 +151,50 @@ DataVariant extract_channel_data(const std::shared_ptr<SignalSourceContainer>& c
 #endif // MAYAFLUX_PLATFORM_MACOS
 
     return DataVariant { std::move(channel_data) };
+}
+
+void extract_processed_data(
+    const std::vector<DataVariant>& pd,
+    OrganizationStrategy organization,
+    uint64_t num_channels,
+    uint32_t ch,
+    std::span<double> output)
+{
+    if (pd.empty() || output.empty()) {
+        std::ranges::fill(output, 0.0);
+        return;
+    }
+
+    if (organization == OrganizationStrategy::INTERLEAVED) {
+        thread_local std::vector<double> tmp;
+        auto data_span = extract_from_variant<double>(pd[0], tmp);
+
+        const auto samples_to_copy = std::min(
+            output.size(),
+            data_span.size() / std::max<uint64_t>(num_channels, 1));
+
+        for (auto s : std::views::iota(0UZ, samples_to_copy)) {
+            const auto idx = s * num_channels + ch;
+            output[s] = idx < data_span.size() ? data_span[idx] : 0.0;
+        }
+
+        if (samples_to_copy < output.size())
+            std::ranges::fill(output.subspan(samples_to_copy), 0.0);
+    } else {
+        if (ch >= pd.size()) {
+            std::ranges::fill(output, 0.0);
+            return;
+        }
+
+        thread_local std::vector<double> tmp;
+        auto ch_span = extract_from_variant<double>(pd[ch], tmp);
+
+        const auto samples_to_copy = std::min(output.size(), ch_span.size());
+        std::ranges::copy_n(ch_span.begin(), samples_to_copy, output.begin());
+
+        if (samples_to_copy < output.size())
+            std::ranges::fill(output.subspan(samples_to_copy), 0.0);
+    }
 }
 
 std::vector<double> extract_region_channel(
@@ -175,12 +219,12 @@ std::pair<std::shared_ptr<SignalSourceContainer>, std::vector<DataDimension>>
 validate_container_for_analysis(const std::shared_ptr<SignalSourceContainer>& container)
 {
     if (!container || !container->has_data()) {
-        throw std::invalid_argument("Container is null or has no data");
+        error<std::invalid_argument>(Journal::Component::Kakshya, Journal::Context::Runtime, std::source_location::current(), "Container is null or has no data");
     }
 
     auto dimensions = container->get_dimensions();
     if (dimensions.empty()) {
-        throw std::runtime_error("Container has no dimensions");
+        error<std::runtime_error>(Journal::Component::Kakshya, Journal::Context::Runtime, std::source_location::current(), "Container has no dimensions");
     }
 
     return std::make_pair(container, std::move(dimensions));
@@ -189,7 +233,7 @@ validate_container_for_analysis(const std::shared_ptr<SignalSourceContainer>& co
 std::vector<std::span<double>> extract_numeric_data(const std::shared_ptr<SignalSourceContainer>& container)
 {
     if (!container || !container->has_data()) {
-        throw std::invalid_argument("Container is null or has no data");
+        error<std::invalid_argument>(Journal::Component::Kakshya, Journal::Context::Runtime, std::source_location::current(), "Container is null or has no data");
     }
 
     auto container_data = container->get_data();
@@ -206,11 +250,11 @@ void validate_numeric_data_for_analysis(const std::vector<double>& data,
     size_t min_size)
 {
     if (data.empty()) {
-        throw std::invalid_argument("Cannot perform " + operation_name + " on empty data");
+        error<std::invalid_argument>(Journal::Component::Kakshya, Journal::Context::Runtime, std::source_location::current(), "Cannot perform {} on empty data", operation_name);
     }
 
     if (data.size() < min_size) {
-        throw std::invalid_argument(operation_name + " requires at least " + std::to_string(min_size) + " data points, got " + std::to_string(data.size()));
+        error<std::invalid_argument>(Journal::Component::Kakshya, Journal::Context::Runtime, std::source_location::current(), "{} requires at least {} data points, got {}", operation_name, min_size, data.size());
     }
 
     if (auto invalid_it = std::ranges::find_if_not(data, [](double val) {
@@ -219,7 +263,7 @@ void validate_numeric_data_for_analysis(const std::vector<double>& data,
         invalid_it != data.end()) {
 
         const auto index = std::distance(data.begin(), invalid_it);
-        throw std::invalid_argument(operation_name + " data contains NaN or infinite values at index " + std::to_string(index));
+        error<std::invalid_argument>(Journal::Component::Kakshya, Journal::Context::Runtime, std::source_location::current(), "{} data contains NaN or infinite values at index {}", operation_name, index);
     }
 }
 

--- a/src/MayaFlux/Kakshya/Utils/ContainerUtils.hpp
+++ b/src/MayaFlux/Kakshya/Utils/ContainerUtils.hpp
@@ -93,6 +93,29 @@ DataVariant extract_channel_data(const std::shared_ptr<SignalSourceContainer>& c
     uint32_t channel_index);
 
 /**
+ * @brief Extract one channel's samples from a processed dynamic data block.
+ *
+ * Handles both INTERLEAVED and PLANAR organization. For interleaved layout
+ * pd[0] holds all channels multiplexed; for planar layout pd[ch] holds the
+ * channel directly. In either case the result is written into @p output up
+ * to min(output.size(), available_samples) samples, with any remainder
+ * zero-filled.
+ *
+ * @param pd           Dynamic data block as returned by
+ *                     container::get_processed_data() or similar.
+ * @param organization Memory organization of the stream.
+ * @param num_channels Total channel count of the stream.
+ * @param ch           Zero-based channel index to extract.
+ * @param output       Destination buffer; size determines the copy limit.
+ */
+void extract_processed_data(
+    const std::vector<DataVariant>& pd,
+    OrganizationStrategy organization,
+    uint64_t num_channels,
+    uint32_t ch,
+    std::span<double> output);
+
+/**
  * @brief Extract samples for a single channel within a Region from a container.
  *
  * Slices the container's channel data by the sample range defined by

--- a/src/MayaFlux/Kriya/BufferPipeline.cpp
+++ b/src/MayaFlux/Kriya/BufferPipeline.cpp
@@ -203,6 +203,12 @@ bool BufferPipeline::has_pending_data() const
         [](DataState state) { return state == DataState::READY; });
 }
 
+BufferPipeline& BufferPipeline::on_complete(std::function<void()> cb)
+{
+    m_on_complete = std::move(cb);
+    return *this;
+}
+
 Kakshya::DataVariant BufferPipeline::extract_buffer_data(const std::shared_ptr<Buffers::AudioBuffer>& buffer, bool should_process)
 {
     auto audio_buffer = std::dynamic_pointer_cast<Buffers::AudioBuffer>(buffer);
@@ -916,6 +922,9 @@ Vruta::SoundRoutine BufferPipeline::execute_phased(uint64_t max_cycles, uint64_t
         m_current_cycle++;
         cycles_executed++;
     }
+
+    if (m_on_complete)
+        m_on_complete();
 }
 
 Vruta::SoundRoutine BufferPipeline::execute_streaming(uint64_t max_cycles, uint64_t samples_per_operation)
@@ -998,6 +1007,9 @@ Vruta::SoundRoutine BufferPipeline::execute_streaming(uint64_t max_cycles, uint6
         m_current_cycle++;
         cycles_executed++;
     }
+
+    if (m_on_complete)
+        m_on_complete();
 }
 
 Vruta::SoundRoutine BufferPipeline::execute_parallel(uint64_t max_cycles, uint64_t samples_per_operation)

--- a/src/MayaFlux/Kriya/BufferPipeline.hpp
+++ b/src/MayaFlux/Kriya/BufferPipeline.hpp
@@ -400,6 +400,17 @@ public:
      */
     uint32_t get_current_cycle() const { return m_current_cycle; }
 
+    /**
+     * @brief Register a callback fired once when pipeline execution ends.
+     *
+     * Fires when the cycle limit exhausts or stop_continuous() terminates the loop.
+     * Not fired if the pipeline is destroyed mid-execution.
+     *
+     * @param cb Callback with no arguments.
+     * @return Reference to this pipeline for chaining.
+     */
+    BufferPipeline& on_complete(std::function<void()> cb);
+
 private:
     enum class DataState : uint8_t {
         EMPTY, ///< No data available
@@ -427,6 +438,7 @@ private:
     std::vector<std::shared_ptr<Vruta::SoundRoutine>> m_branch_tasks;
     std::function<void(uint32_t)> m_cycle_start_callback;
     std::function<void(uint32_t)> m_cycle_end_callback;
+    std::function<void()> m_on_complete;
 
     uint64_t m_current_cycle { 0 };
     uint64_t m_max_cycles { 0 };

--- a/src/MayaFlux/Kriya/SamplingPipeline.cpp
+++ b/src/MayaFlux/Kriya/SamplingPipeline.cpp
@@ -83,6 +83,8 @@ void SamplingPipeline<N>::play(size_t index)
 {
     if (index >= N)
         return;
+
+    m_processor->load(index, m_processor->slice(index));
     m_processor->bind(index);
 }
 
@@ -92,8 +94,8 @@ void SamplingPipeline<N>::play(size_t index, Kakshya::StreamSlice slice)
     if (index >= N)
         return;
 
+    m_processor->load(index, std::move(slice));
     if (!m_built) {
-        m_processor->load(index, std::move(slice));
         build();
     }
 

--- a/src/MayaFlux/Kriya/SamplingPipeline.cpp
+++ b/src/MayaFlux/Kriya/SamplingPipeline.cpp
@@ -7,14 +7,14 @@
 
 namespace MayaFlux::Kriya {
 
-template <size_t N>
-SamplingPipeline<N>::SamplingPipeline(
+SamplingPipeline::SamplingPipeline(
     std::shared_ptr<Kakshya::DynamicSoundStream> stream,
     Buffers::BufferManager& mgr,
     Vruta::TaskScheduler& scheduler,
     uint32_t channel,
     uint32_t buf_size)
     : m_stream(std::move(stream))
+    , m_processor(std::make_shared<Buffers::StreamSliceProcessor>())
     , m_mgr(mgr)
     , m_capture(nullptr)
     , m_scheduler(scheduler)
@@ -23,12 +23,7 @@ SamplingPipeline<N>::SamplingPipeline(
 {
     m_buffer = std::make_shared<Buffers::AudioBuffer>(channel, buf_size);
 
-    m_processor = std::make_shared<Buffers::StreamSliceProcessor<N>>();
-
     m_buffer->set_default_processor(m_processor);
-
-    for (size_t i = 0; i < N; ++i)
-        m_processor->load(i, Kakshya::StreamSlice::from_stream(m_stream, static_cast<uint8_t>(i)));
 
     m_capture = CaptureBuilder(m_buffer);
     m_capture.on_capture_processing().for_cycles(1);
@@ -40,8 +35,7 @@ SamplingPipeline<N>::SamplingPipeline(
     });
 }
 
-template <size_t N>
-SamplingPipeline<N>::~SamplingPipeline()
+SamplingPipeline::~SamplingPipeline()
 {
     if (m_built) {
         m_pipeline->stop_continuous();
@@ -50,20 +44,17 @@ SamplingPipeline<N>::~SamplingPipeline()
     }
 }
 
-template <size_t N>
-BufferPipeline& SamplingPipeline<N>::pipeline()
+BufferPipeline& SamplingPipeline::pipeline()
 {
     return *m_pipeline;
 }
 
-template <size_t N>
-CaptureBuilder& SamplingPipeline<N>::capture()
+CaptureBuilder& SamplingPipeline::capture()
 {
     return m_capture;
 }
 
-template <size_t N>
-void SamplingPipeline<N>::build()
+void SamplingPipeline::build()
 {
     if (m_built)
         return;
@@ -78,22 +69,20 @@ void SamplingPipeline<N>::build()
     m_built = true;
 }
 
-template <size_t N>
-void SamplingPipeline<N>::play(size_t index)
+void SamplingPipeline::play(size_t index)
 {
-    if (index >= N)
+    if (index >= m_processor->slot_count()) {
+        MF_RT_ERROR(Journal::Component::Kriya, Journal::Context::Configuration,
+            "SamplingPipeline::play index {} exceeds slot count {}", index, m_processor->slot_count());
         return;
+    }
 
     m_processor->load(index, m_processor->slice(index));
     m_processor->bind(index);
 }
 
-template <size_t N>
-void SamplingPipeline<N>::play(size_t index, Kakshya::StreamSlice slice)
+void SamplingPipeline::play(size_t index, Kakshya::StreamSlice slice)
 {
-    if (index >= N)
-        return;
-
     m_processor->load(index, std::move(slice));
     if (!m_built) {
         build();
@@ -102,11 +91,13 @@ void SamplingPipeline<N>::play(size_t index, Kakshya::StreamSlice slice)
     m_processor->bind(index);
 }
 
-template <size_t N>
-void SamplingPipeline<N>::play_continuous(size_t index)
+void SamplingPipeline::play_continuous(size_t index)
 {
-    if (index >= N)
+    if (index >= m_processor->slot_count()) {
+        MF_RT_ERROR(Journal::Component::Kriya, Journal::Context::Configuration,
+            "SamplingPipeline::play_continuous index {} exceeds slot count {}", index, m_processor->slot_count());
         return;
+    }
 
     auto sl = m_processor->slice(index);
     sl.looping = true;
@@ -114,12 +105,8 @@ void SamplingPipeline<N>::play_continuous(size_t index)
     m_processor->bind(index);
 }
 
-template <size_t N>
-void SamplingPipeline<N>::play_continuous(size_t index, Kakshya::StreamSlice slice)
+void SamplingPipeline::play_continuous(size_t index, Kakshya::StreamSlice slice)
 {
-    if (index >= N)
-        return;
-
     slice.looping = true;
     m_processor->load(index, std::move(slice));
 
@@ -130,32 +117,24 @@ void SamplingPipeline<N>::play_continuous(size_t index, Kakshya::StreamSlice sli
     m_processor->bind(index);
 }
 
-template <size_t N>
-void SamplingPipeline<N>::stop(size_t index)
+void SamplingPipeline::stop(size_t index)
 {
-    if (index >= N)
+    if (index >= m_processor->slot_count()) {
+        MF_WARN(Journal::Component::Kriya, Journal::Context::Configuration,
+            "SamplingPipeline::stop index {} exceeds slot count {}", index, m_processor->slot_count());
         return;
+    }
     m_processor->unbind(index);
 }
 
-template <size_t N>
-Kakshya::StreamSlice& SamplingPipeline<N>::slice(size_t index)
+Kakshya::StreamSlice& SamplingPipeline::slice(size_t index)
 {
     return m_processor->slice(index);
 }
 
-template <size_t N>
-bool SamplingPipeline<N>::any_active() const
+bool SamplingPipeline::any_active() const
 {
-    for (size_t i = 0; i < N; ++i) {
-        if (m_processor->slice(i).active)
-            return true;
-    }
-    return false;
+    return m_processor->any_active();
 }
-
-template class SamplingPipeline<2>;
-template class SamplingPipeline<4>;
-template class SamplingPipeline<8>;
 
 } // namespace MayaFlux::Kriya

--- a/src/MayaFlux/Kriya/SamplingPipeline.cpp
+++ b/src/MayaFlux/Kriya/SamplingPipeline.cpp
@@ -4,6 +4,7 @@
 #include "MayaFlux/Buffers/BufferManager.hpp"
 
 #include "MayaFlux/Kakshya/Source/DynamicSoundStream.hpp"
+#include "MayaFlux/Vruta/ChronUtils.hpp"
 
 namespace MayaFlux::Kriya {
 
@@ -67,6 +68,49 @@ void SamplingPipeline::build()
     m_pipeline->execute_buffer_rate(0);
 
     m_built = true;
+}
+
+void SamplingPipeline::build_for(uint64_t milliseconds)
+{
+    if (m_built)
+        return;
+
+    m_mgr.supply_buffer_to(m_buffer,
+        Buffers::ProcessingToken::AUDIO_BACKEND, m_channel, 1.0, true);
+
+    m_pipeline >> static_cast<BufferOperation>(m_capture);
+
+    const double seconds = static_cast<double>(milliseconds) / 1000.0;
+    const uint64_t cycles = Vruta::seconds_to_blocks(
+        seconds, m_mgr.get_sample_rate(), m_mgr.get_buffer_size(Buffers::ProcessingToken::AUDIO_BACKEND));
+
+    m_pipeline->on_complete([this] {
+        std::ranges::fill(m_buffer->get_data(), 0.0);
+    });
+
+    m_pipeline->execute_buffer_rate(cycles);
+
+    m_built = true;
+}
+
+void SamplingPipeline::rebuild_for(uint64_t milliseconds)
+{
+    if (!m_built) {
+        MF_WARN(Journal::Component::Kriya, Journal::Context::Configuration,
+            "SamplingPipeline::rebuild_for called before build. Use build_for instead to avoid redundant setup.");
+        return;
+    }
+    m_pipeline->stop_continuous();
+
+    const double seconds = static_cast<double>(milliseconds) / 1000.0;
+    const uint64_t cycles = Vruta::seconds_to_blocks(
+        seconds, m_mgr.get_sample_rate(), m_mgr.get_buffer_size(Buffers::ProcessingToken::AUDIO_BACKEND));
+
+    m_pipeline->on_complete([this] {
+        std::ranges::fill(m_buffer->get_data(), 0.0);
+    });
+
+    m_pipeline->execute_buffer_rate(cycles);
 }
 
 void SamplingPipeline::play(size_t index)

--- a/src/MayaFlux/Kriya/SamplingPipeline.cpp
+++ b/src/MayaFlux/Kriya/SamplingPipeline.cpp
@@ -108,6 +108,7 @@ void SamplingPipeline<N>::play_continuous(size_t index)
 
     auto sl = m_processor->slice(index);
     sl.looping = true;
+    m_processor->load(index, sl);
     m_processor->bind(index);
 }
 
@@ -117,13 +118,13 @@ void SamplingPipeline<N>::play_continuous(size_t index, Kakshya::StreamSlice sli
     if (index >= N)
         return;
 
+    slice.looping = true;
+    m_processor->load(index, std::move(slice));
+
     if (!m_built) {
-        m_processor->load(index, std::move(slice));
         build();
     }
 
-    auto sl = m_processor->slice(index);
-    sl.looping = true;
     m_processor->bind(index);
 }
 

--- a/src/MayaFlux/Kriya/SamplingPipeline.cpp
+++ b/src/MayaFlux/Kriya/SamplingPipeline.cpp
@@ -1,0 +1,158 @@
+#include "SamplingPipeline.hpp"
+
+#include "MayaFlux/Buffers/AudioBuffer.hpp"
+#include "MayaFlux/Buffers/BufferManager.hpp"
+
+#include "MayaFlux/Kakshya/Source/DynamicSoundStream.hpp"
+
+namespace MayaFlux::Kriya {
+
+template <size_t N>
+SamplingPipeline<N>::SamplingPipeline(
+    std::shared_ptr<Kakshya::DynamicSoundStream> stream,
+    Buffers::BufferManager& mgr,
+    Vruta::TaskScheduler& scheduler,
+    uint32_t channel,
+    uint32_t buf_size)
+    : m_stream(std::move(stream))
+    , m_mgr(mgr)
+    , m_capture(nullptr)
+    , m_scheduler(scheduler)
+    , m_channel(channel)
+    , m_buf_size(buf_size)
+{
+    m_buffer = std::make_shared<Buffers::AudioBuffer>(channel, buf_size);
+
+    m_processor = std::make_shared<Buffers::StreamSliceProcessor<N>>();
+
+    m_buffer->set_default_processor(m_processor);
+
+    for (size_t i = 0; i < N; ++i)
+        m_processor->load(i, Kakshya::StreamSlice::from_stream(m_stream, static_cast<uint8_t>(i)));
+
+    m_capture = CaptureBuilder(m_buffer);
+    m_capture.on_capture_processing().for_cycles(1);
+
+    m_pipeline = BufferPipeline::create(m_scheduler);
+    m_processor->set_on_end([this](size_t) {
+        if (!any_active())
+            m_pipeline->stop_continuous();
+    });
+}
+
+template <size_t N>
+SamplingPipeline<N>::~SamplingPipeline()
+{
+    if (m_built) {
+        m_pipeline->stop_continuous();
+        m_mgr.remove_supplied_buffer(m_buffer,
+            Buffers::ProcessingToken::AUDIO_BACKEND, m_channel);
+    }
+}
+
+template <size_t N>
+BufferPipeline& SamplingPipeline<N>::pipeline()
+{
+    return *m_pipeline;
+}
+
+template <size_t N>
+CaptureBuilder& SamplingPipeline<N>::capture()
+{
+    return m_capture;
+}
+
+template <size_t N>
+void SamplingPipeline<N>::build()
+{
+    if (m_built)
+        return;
+
+    m_mgr.supply_buffer_to(m_buffer,
+        Buffers::ProcessingToken::AUDIO_BACKEND, m_channel, 1.0, true);
+
+    m_pipeline >> static_cast<BufferOperation>(m_capture);
+
+    m_pipeline->execute_buffer_rate(0);
+
+    m_built = true;
+}
+
+template <size_t N>
+void SamplingPipeline<N>::play(size_t index)
+{
+    if (index >= N)
+        return;
+    m_processor->bind(index);
+}
+
+template <size_t N>
+void SamplingPipeline<N>::play(size_t index, Kakshya::StreamSlice slice)
+{
+    if (index >= N)
+        return;
+
+    if (!m_built) {
+        m_processor->load(index, std::move(slice));
+        build();
+    }
+
+    m_processor->bind(index);
+}
+
+template <size_t N>
+void SamplingPipeline<N>::play_continuous(size_t index)
+{
+    if (index >= N)
+        return;
+
+    auto sl = m_processor->slice(index);
+    sl.looping = true;
+    m_processor->bind(index);
+}
+
+template <size_t N>
+void SamplingPipeline<N>::play_continuous(size_t index, Kakshya::StreamSlice slice)
+{
+    if (index >= N)
+        return;
+
+    if (!m_built) {
+        m_processor->load(index, std::move(slice));
+        build();
+    }
+
+    auto sl = m_processor->slice(index);
+    sl.looping = true;
+    m_processor->bind(index);
+}
+
+template <size_t N>
+void SamplingPipeline<N>::stop(size_t index)
+{
+    if (index >= N)
+        return;
+    m_processor->unbind(index);
+}
+
+template <size_t N>
+Kakshya::StreamSlice& SamplingPipeline<N>::slice(size_t index)
+{
+    return m_processor->slice(index);
+}
+
+template <size_t N>
+bool SamplingPipeline<N>::any_active() const
+{
+    for (size_t i = 0; i < N; ++i) {
+        if (m_processor->slice(i).active)
+            return true;
+    }
+    return false;
+}
+
+template class SamplingPipeline<2>;
+template class SamplingPipeline<4>;
+template class SamplingPipeline<8>;
+
+} // namespace MayaFlux::Kriya

--- a/src/MayaFlux/Kriya/SamplingPipeline.hpp
+++ b/src/MayaFlux/Kriya/SamplingPipeline.hpp
@@ -105,10 +105,12 @@ public:
      *
      * @param index Voice index [0, N).
      * @param slice StreamSlice to load.
+     * @return Reference to the loaded StreamSlice for further configuration.
      */
-    void load(size_t index, Kakshya::StreamSlice slice)
+    Kakshya::StreamSlice& load(size_t index, Kakshya::StreamSlice slice)
     {
         m_processor->load(index, std::move(slice));
+        return m_processor->slice(index);
     }
 
     /**

--- a/src/MayaFlux/Kriya/SamplingPipeline.hpp
+++ b/src/MayaFlux/Kriya/SamplingPipeline.hpp
@@ -1,0 +1,206 @@
+#pragma once
+
+#include "BufferPipeline.hpp"
+
+#include "MayaFlux/Buffers/Container/StreamSliceProcessor.hpp"
+#include "MayaFlux/Kakshya/Source/StreamSlice.hpp"
+
+namespace MayaFlux::Kakshya {
+class DynamicSoundStream;
+}
+
+namespace MayaFlux::Buffers {
+class AudioBuffer;
+class BufferManager;
+}
+
+namespace MayaFlux::Kriya {
+
+/**
+ * @class SamplingPipeline
+ * @brief Pipeline-coordinated polyphonic playback of a bounded audio stream.
+ *
+ * Owns a private AudioBuffer with a StreamSliceProcessor as its default
+ * processor. The buffer is supplied to an output channel via BufferManager.
+ * A BufferPipeline captures from the buffer at buffer rate with ON_CAPTURE
+ * processing, driving process_default() each cycle. The root buffer's
+ * ChannelProcessor mixes the result into output.
+ *
+ * Voices are activated and deactivated via play() and stop(), which
+ * delegate to StreamSliceProcessor::bind/unbind. The pipeline runs
+ * for the lifetime of the SamplingPipeline. Inactive voices contribute
+ * silence with no read overhead. One-shot voices self-deactivate via
+ * the processor's on_end callback.
+ *
+ * The pipeline and capture operation are exposed for further chaining:
+ * lifecycle callbacks, branching, data-ready hooks, and strategy
+ * selection are available through the standard BufferPipeline and
+ * CaptureBuilder fluent interfaces before calling build().
+ *
+ * @tparam N Maximum concurrent voices.
+ */
+template <size_t N = 4>
+class MAYAFLUX_API SamplingPipeline {
+public:
+    /**
+     * @brief Begin construction with a loaded stream and output channel.
+     * @param stream    Loaded DynamicSoundStream.
+     * @param mgr       BufferManager for channel supply.
+     * @param scheduler Scheduler for the internal BufferPipeline.
+     * @param channel   Output channel index.
+     * @param buf_size  Engine buffer size in frames.
+     *
+     * After construction, optionally call pipeline() and capture() to
+     * configure the fluent chain, then call build() to start processing.
+     * If build() is never called, the destructor is a no-op.
+     */
+    SamplingPipeline(
+        std::shared_ptr<Kakshya::DynamicSoundStream> stream,
+        Buffers::BufferManager& mgr,
+        Vruta::TaskScheduler& scheduler,
+        uint32_t channel,
+        uint32_t buf_size);
+
+    ~SamplingPipeline();
+
+    SamplingPipeline(const SamplingPipeline&) = delete;
+    SamplingPipeline& operator=(const SamplingPipeline&) = delete;
+
+    /**
+     * @brief Access the internal pipeline for fluent configuration.
+     *
+     * Allows lifecycle callbacks, branching, strategy selection, and
+     * additional operations before build().
+     *
+     * @code
+     * sampler.pipeline()
+     *     .with_strategy(ExecutionStrategy::STREAMING)
+     *     .with_lifecycle(on_start, on_end)
+     *     .branch_if(every_16, snapshot_branch);
+     * @endcode
+     */
+    [[nodiscard]] BufferPipeline& pipeline();
+
+    /**
+     * @brief Access the capture operation builder for fluent configuration.
+     *
+     * Allows data-ready callbacks, windowed/circular modes, tagging,
+     * and metadata before build().
+     *
+     * @code
+     * sampler.capture()
+     *     .on_data_ready([](auto& data, uint32_t cycle) { analyze(data); })
+     *     .with_tag("lead_sampler");
+     * @endcode
+     */
+    [[nodiscard]] CaptureBuilder& capture();
+
+    /**
+     * @brief Load a StreamSlice into a voice slot for later playback.
+     *
+     * Must be called after build(). Replaces any existing slice in the slot.
+     * Use slice() to mutate parameters of an already-loaded slot in place.
+     *
+     * @param index Voice index [0, N).
+     * @param slice StreamSlice to load.
+     */
+    void load(size_t index, Kakshya::StreamSlice slice)
+    {
+        m_processor->load(index, std::move(slice));
+    }
+
+    /**
+     * @brief Finalize configuration and start processing.
+     *
+     * Supplies the buffer to the output channel, chains the capture
+     * operation into the pipeline, and starts execution at buffer rate.
+     * Must be called before play(). Calling build() more than once
+     * has no effect.
+     */
+    void build();
+
+    /**
+     * @brief Activate a voice, resetting its cursor to loop_start.
+     * @param index Voice index [0, N).
+     */
+    void play(size_t index = 0);
+
+    /**
+     * @brief Load a slice into a voice slot and activate it immediately.
+     *
+     * Equivalent to load(index, slice) followed by play(index).
+     * Requires build() to have been called first.
+     *
+     * @param index Voice index [0, N).
+     * @param slice StreamSlice to load and activate.
+     */
+    void play(size_t index, Kakshya::StreamSlice slice);
+
+    /**
+     * @brief Activate a voice with looping enabled.
+     * @param index Voice index [0, N).
+     */
+    void play_continuous(size_t index = 0);
+
+    /**
+     * @brief Load a slice into a voice slot and activate it with looping enabled.
+     *
+     * Sets looping on the slice before loading. Equivalent to setting
+     * slice.looping = true, calling load(index, slice), then play_continuous(index).
+     * Requires build() to have been called first.
+     *
+     * @param index Voice index [0, N).
+     * @param slice StreamSlice to load and activate with looping.
+     */
+    void play_continuous(size_t index, Kakshya::StreamSlice slice);
+
+    /**
+     * @brief Deactivate a voice.
+     * @param index Voice index [0, N).
+     */
+    void stop(size_t index = 0);
+
+    /**
+     * @brief Direct access to a voice's StreamSlice for configuration.
+     *
+     * Configure stream, loop_start, loop_end, speed, scale before play().
+     *
+     * @code
+     * sampler.slice(0).speed = 0.5;
+     * sampler.slice(0).loop_start = 48000;
+     * sampler.slice(0).loop_end   = 96000;
+     * sampler.play(0);
+     * @endcode
+     *
+     * @param index Voice index [0, N).
+     */
+    [[nodiscard]] Kakshya::StreamSlice& slice(size_t index);
+
+    /**
+     * @brief Get the internal AudioBuffer for direct manipulation.
+     *
+     * The buffer is supplied to the output channel and processed by the
+     * pipeline. External processing or inspection is possible but should
+     * be done with care to avoid conflicts with the pipeline's operations.
+     *
+     * @return Shared pointer to the internal AudioBuffer.
+     */
+    std::shared_ptr<Buffers::AudioBuffer> get_buffer() const { return m_buffer; }
+
+private:
+    std::shared_ptr<Kakshya::DynamicSoundStream> m_stream;
+    std::shared_ptr<Buffers::AudioBuffer> m_buffer;
+    std::shared_ptr<Buffers::StreamSliceProcessor<N>> m_processor;
+    Buffers::BufferManager& m_mgr;
+    Vruta::TaskScheduler& m_scheduler;
+    uint32_t m_channel;
+    uint32_t m_buf_size;
+
+    std::shared_ptr<BufferPipeline> m_pipeline;
+    CaptureBuilder m_capture;
+    bool m_built { false };
+
+    [[nodiscard]] bool any_active() const;
+};
+
+} // namespace MayaFlux::Kriya

--- a/src/MayaFlux/Kriya/SamplingPipeline.hpp
+++ b/src/MayaFlux/Kriya/SamplingPipeline.hpp
@@ -5,6 +5,8 @@
 #include "MayaFlux/Buffers/Container/StreamSliceProcessor.hpp"
 #include "MayaFlux/Kakshya/Source/StreamSlice.hpp"
 
+#include "MayaFlux/Journal/Archivist.hpp"
+
 namespace MayaFlux::Kakshya {
 class DynamicSoundStream;
 }
@@ -161,6 +163,38 @@ public:
     void stop(size_t index = 0);
 
     /**
+     * @brief Construct a slice spanning the full stream.
+     * @param index Slot identity.
+     */
+    [[nodiscard]] Kakshya::StreamSlice slice_from_stream(uint8_t index = 0) const
+    {
+        if (!m_stream) {
+            MF_ERROR(Journal::Component::Kriya, Journal::Context::Configuration,
+                "SamplingPipeline::slice_from_stream called with null stream");
+            return {};
+        }
+        return Kakshya::StreamSlice::from_stream(m_stream, index);
+    }
+
+    /**
+     * @brief Construct a slice spanning a frame sub-region.
+     * @param start_frame Inclusive start frame.
+     * @param end_frame   Inclusive end frame.
+     * @param index       Slot identity.
+     */
+    [[nodiscard]] Kakshya::StreamSlice slice_from_range(
+        uint64_t start_frame, uint64_t end_frame, uint8_t index = 0) const
+    {
+
+        if (!m_stream) {
+            MF_ERROR(Journal::Component::Kriya, Journal::Context::Configuration,
+                "SamplingPipeline::slice_from_range called with null stream");
+            return {};
+        }
+        return Kakshya::StreamSlice::from_frame_range(m_stream, start_frame, end_frame, index);
+    }
+
+    /**
      * @brief Direct access to a voice's StreamSlice for configuration.
      *
      * Configure stream, loop_start, loop_end, speed, scale before play().
@@ -186,6 +220,16 @@ public:
      * @return Shared pointer to the internal AudioBuffer.
      */
     std::shared_ptr<Buffers::AudioBuffer> get_buffer() const { return m_buffer; }
+
+    /**
+     * @brief Get the underlying DynamicSoundStream.
+     *
+     * Exposes stream properties and allows construction of custom slices
+     * outside of the provided StreamSliceProcessor interface.
+     *
+     * @return Shared pointer to the DynamicSoundStream.
+     */
+    std::shared_ptr<Kakshya::DynamicSoundStream> get_stream() const { return m_stream; }
 
 private:
     std::shared_ptr<Kakshya::DynamicSoundStream> m_stream;

--- a/src/MayaFlux/Kriya/SamplingPipeline.hpp
+++ b/src/MayaFlux/Kriya/SamplingPipeline.hpp
@@ -121,6 +121,31 @@ public:
     void build();
 
     /**
+     * @brief Finalize configuration and start processing for a bounded duration.
+     *
+     * Converts milliseconds to pipeline cycles via sample rate and buffer size,
+     * then starts execution for exactly that many cycles. When the cycle count
+     * exhausts, the pipeline stops unconditionally regardless of voice state.
+     * Any active voice is cut immediately with no fade or drain.
+     *
+     * Must not be called if build() has already been called.
+     *
+     * @param milliseconds Duration in milliseconds.
+     */
+    void build_for(uint64_t milliseconds);
+
+    /**
+     * @brief Stop and restart pipeline execution for a bounded duration.
+     *
+     * Stops any running pipeline execution, resets the cycle counter, and
+     * restarts for the given duration. Hard-cuts all active voices at the
+     * point of restart. Document as a destructive operation.
+     *
+     * @param milliseconds Duration in milliseconds.
+     */
+    void rebuild_for(uint64_t milliseconds);
+
+    /**
      * @brief Activate a voice, resetting its cursor to loop_start.
      * @param index Voice index.
      */

--- a/src/MayaFlux/Kriya/SamplingPipeline.hpp
+++ b/src/MayaFlux/Kriya/SamplingPipeline.hpp
@@ -38,10 +38,7 @@ namespace MayaFlux::Kriya {
  * lifecycle callbacks, branching, data-ready hooks, and strategy
  * selection are available through the standard BufferPipeline and
  * CaptureBuilder fluent interfaces before calling build().
- *
- * @tparam N Maximum concurrent voices.
  */
-template <size_t N = 4>
 class MAYAFLUX_API SamplingPipeline {
 public:
     /**
@@ -103,7 +100,7 @@ public:
      * Must be called after build(). Replaces any existing slice in the slot.
      * Use slice() to mutate parameters of an already-loaded slot in place.
      *
-     * @param index Voice index [0, N).
+     * @param index Voice index.
      * @param slice StreamSlice to load.
      * @return Reference to the loaded StreamSlice for further configuration.
      */
@@ -125,7 +122,7 @@ public:
 
     /**
      * @brief Activate a voice, resetting its cursor to loop_start.
-     * @param index Voice index [0, N).
+     * @param index Voice index.
      */
     void play(size_t index = 0);
 
@@ -135,14 +132,14 @@ public:
      * Equivalent to load(index, slice) followed by play(index).
      * Requires build() to have been called first.
      *
-     * @param index Voice index [0, N).
+     * @param index Voice index.
      * @param slice StreamSlice to load and activate.
      */
     void play(size_t index, Kakshya::StreamSlice slice);
 
     /**
      * @brief Activate a voice with looping enabled.
-     * @param index Voice index [0, N).
+     * @param index Voice index.
      */
     void play_continuous(size_t index = 0);
 
@@ -153,14 +150,14 @@ public:
      * slice.looping = true, calling load(index, slice), then play_continuous(index).
      * Requires build() to have been called first.
      *
-     * @param index Voice index [0, N).
+     * @param index Voice index.
      * @param slice StreamSlice to load and activate with looping.
      */
     void play_continuous(size_t index, Kakshya::StreamSlice slice);
 
     /**
      * @brief Deactivate a voice.
-     * @param index Voice index [0, N).
+     * @param index Voice index.
      */
     void stop(size_t index = 0);
 
@@ -208,7 +205,7 @@ public:
      * sampler.play(0);
      * @endcode
      *
-     * @param index Voice index [0, N).
+     * @param index Voice index.
      */
     [[nodiscard]] Kakshya::StreamSlice& slice(size_t index);
 
@@ -236,7 +233,7 @@ public:
 private:
     std::shared_ptr<Kakshya::DynamicSoundStream> m_stream;
     std::shared_ptr<Buffers::AudioBuffer> m_buffer;
-    std::shared_ptr<Buffers::StreamSliceProcessor<N>> m_processor;
+    std::shared_ptr<Buffers::StreamSliceProcessor> m_processor;
     Buffers::BufferManager& m_mgr;
     Vruta::TaskScheduler& m_scheduler;
     uint32_t m_channel;

--- a/src/MayaFlux/MayaFlux.hpp
+++ b/src/MayaFlux/MayaFlux.hpp
@@ -30,6 +30,8 @@
 
 #include "MayaFlux/API/Proxy/Temporal.hpp"
 
+#include "MayaFlux/API/Rigs.hpp"
+
 #ifdef MAYASIMPLE
 #include "Nodes/Conduit/Constant.hpp"
 #include "Nodes/Conduit/NodeChain.hpp"

--- a/src/MayaFlux/Vruta/Routine.cpp
+++ b/src/MayaFlux/Vruta/Routine.cpp
@@ -145,10 +145,6 @@ bool SoundRoutine::try_resume_with_context(uint64_t current_value, DelayContext 
     case DelayContext::BUFFER_BASED:
         if (promise_ref.active_delay_context == DelayContext::BUFFER_BASED) {
             should_resume = (current_value >= promise_ref.next_buffer_cycle);
-
-            if (should_resume) {
-                promise_ref.next_buffer_cycle = current_value + promise_ref.delay_amount;
-            }
         } else {
             should_resume = false;
         }


### PR DESCRIPTION
Introduces `SamplingPipeline`, a pipeline-coordinated polyphonic playback system for bounded audio streams, along with the full supporting infrastructure in Kakshya, Buffers, and Kriya.

---

## **What changed**

**Kakshya**
- `StreamSlice` : region descriptor for a bounded read against a `DynamicSoundStream`. Carries `speed`, `scale`, `looping`, `loop_count`, and fluent setters (`with_speed`, `with_looping`, `with_scale`, `with_loop_count`).
- `CursorAccessProcessor` : independent cursor reader per dynamic slot. Handles loop wrapping, one-shot deactivation, speed accumulation with sub-frame remainder, and bounded loop count. `reset()` restores `loops_remaining` to `loop_count` for correct retrigger.
- `DynamicSoundStream` : gains dynamic processed data slots (`allocate_dynamic_slot`, `release_dynamic_slot`, `get_dynamic_data`) for concurrent multi-cursor reads without contention.

**Buffers**
- `StreamSliceProcessor` : `BufferProcessor` driving a growable pool of independent `StreamSlice`/`CursorAccessProcessor` pairs. Slots grow on demand via `load(index, slice)`; no upfront capacity declaration. Sparse index access logs a warning suggesting the next available slot. `any_active()` and `slot_count()` for inspection.

**Kriya**
- `SamplingPipeline` : owns an `AudioBuffer` with a `StreamSliceProcessor`, supplies it to a `BufferManager` output channel, and drives processing via an internal `BufferPipeline` at buffer rate. Voice control via `play`/`stop`/`play_continuous`. One-shot voices self-deactivate; pipeline stops when all voices go inactive.
- `BufferPipeline` : gains `on_complete(cb)` fired once when the cycle limit exhausts or `stop_continuous()` terminates the loop.

**API**
- `create_sampler` : loads a file, builds a pipeline, returns it ready for immediate use. Gains optional `max_dur_ms` for bounded execution.
- `create_sampler_from_stream` : constructs a pipeline from an existing `DynamicSoundStream`, allowing multiple pipelines to share one loaded file without redundant IO.
- `create_samplers` : loads a file once and returns one pipeline per channel. `max_channels = 0` uses all channels in the file.

---

## **Design notes**

`StreamSliceProcessor` was introduced with a template parameter `<N>` for the slot pool. This was removed two commits in: the stack allocation argument is void given `Slot` already contains heap-indirected `shared_ptr`s, and the explicit instantiation list was maintenance friction with no payoff. Slots now grow on demand.

`SamplingPipeline` is not a per-voice pipeline. It is a single pipeline over a single buffer with N independent cursors multiplexed into it. The per-voice concept lives at the `StreamSlice`/`CursorAccessProcessor` level, not at the pipeline level. This is intentional: one audio buffer per output channel, one pipeline per buffer.

Domain resolution follows the MayaFlux convention: the same `DynamicSoundStream` data substrate underlies all playback. Channel identity is a scheduling annotation on the buffer, not a property of the stream.

---

## **Usage**

**Basic single-file playback**
```cpp
auto sampler = MayaFlux::create_sampler("res/kick.wav", 48000 * 2);

// one-shot
sampler->play(0, sampler->slice_from_stream());

// looping
sampler->play_continuous(0, sampler->slice_from_stream());

// region + speed
sampler->load(0, sampler->slice_from_range(0, 48000))
    .with_speed(1.5)
    .with_looping(true);
sampler->play(0);
```

**Polyphonic voices**
```cpp
auto sampler = MayaFlux::create_sampler("res/pad.wav", 48000 * 4);

sampler->load(0, sampler->slice_from_range(0, 48000 * 2)).with_speed(1.0);
sampler->load(1, sampler->slice_from_range(48000, 48000 * 3)).with_speed(0.75);
sampler->load(2, sampler->slice_from_range(0, 48000 * 4)).with_looping(true);

sampler->play(0);
sampler->play(1);
sampler->play_continuous(2);
```

**Bounded loop count**
```cpp
sampler->load(0, sampler->slice_from_stream()
    .with_looping(true)
    .with_loop_count(4));
sampler->play(0); // loops 4 times then self-stops
```

**Bounded duration**
```cpp
// pipeline hard-stops after 3 seconds regardless of voice state
auto sampler = MayaFlux::create_sampler("res/drone.wav", 48000 * 10, true, 0, 3000);

// or rebuild for a new window
sampler->rebuild_for(5000);
```

**Multichannel from one file**
```cpp
// explicit: share the stream manually
auto ch0 = MayaFlux::create_sampler("res/stereo.wav", 48000 * 5);
auto ch1 = MayaFlux::create_sampler_from_stream(ch0->get_stream(), 1);

// convenience: all channels at once
auto ch = MayaFlux::create_samplers("res/stereo.wav", 48000 * 5);
ch[0]->play(0, ch[0]->slice_from_stream());
ch[1]->play(0, ch[1]->slice_from_stream());
```

**Pre-build pipeline configuration**
```cpp
auto sampler = MayaFlux::create_sampler("res/audio.wav", 48000 * 5); // already built

// or: construct manually for pre-build access
auto stream = get_io_manager()->load_audio_bounded("res/audio.wav", 48000 * 5);
auto raw = std::make_shared<MayaFlux::Kriya::SamplingPipeline>(
    stream, *get_buffer_manager(), *get_scheduler(), 0, Config::get_buffer_size());

raw->pipeline()
    .with_lifecycle(
        [](uint32_t cycle) { /* on cycle start */ },
        [](uint32_t cycle) { /* on cycle end */ })
    .on_complete([] { /* pipeline expired */ });

raw->capture()
    .on_data_ready([](const auto& data, uint32_t cycle) { analyze(data); });

raw->build_for(4000); // 4 seconds
raw->load(0, raw->slice_from_stream()).with_looping(true);
raw->play(0);
```

---

## **Commits**

- `feat(Kakshya)`: StreamSlice, CursorAccessProcessor dynamic slots, speed, loop count
- `feat(Buffers)`: StreamSliceProcessor polyphonic mixing, demand-grown slot pool
- `feat(kriya)`: SamplingPipeline with polyphonic slice playback
- `fix(kakshya,kriya)`: CursorAccessProcessor tail read overrun, looping propagation
- `refactor(kriya)`: remove template parameter from StreamSliceProcessor and SamplingPipeline
- `feat(kakshya)`: add loop_count to StreamSlice and CursorAccessProcessor
- `feat(kriya)`: BufferPipeline::on_complete, bounded duration build, sampler rig duration
- `feat(kriya)`: create_sampler_from_stream, create_samplers multichannel
