### PR TITLE
Portal::Forma: composable surface interaction as signal

### DIFF
--- a/data/shaders/forma_textured.frag
+++ b/data/shaders/forma_textured.frag
@@ -1,0 +1,14 @@
+#version 450
+
+layout(location = 0) in vec3 in_color;
+layout(location = 1) in vec2 in_uv;
+
+layout(set = 0, binding = 1) uniform sampler2D texSampler;
+
+layout(location = 0) out vec4 out_color;
+
+void main()
+{
+    vec4 tex = texture(texSampler, in_uv);
+    out_color = vec4(in_color * tex.rgb, tex.a);
+}

--- a/src/MayaFlux/Buffers/Forma/FormaBindingsProcessor.cpp
+++ b/src/MayaFlux/Buffers/Forma/FormaBindingsProcessor.cpp
@@ -25,24 +25,13 @@ FormaBindingsProcessor::FormaBindingsProcessor(ShaderConfig config)
 void FormaBindingsProcessor::bind_push_constant(
     const std::string& name,
     std::function<float()> reader,
-    std::shared_ptr<ShaderProcessor> target,
     uint32_t offset,
     size_t size)
 {
-    if (!reader || !target) {
-        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
-            "FormaBindingsProcessor::bind_push_constant: null reader or target for '{}'", name);
-        return;
-    }
-
     auto& b = m_bindings[name];
     b.kind = TargetKind::PUSH_CONSTANT;
     b.reader = std::move(reader);
-    b.pc = PushConstantTarget {
-        .processor = std::move(target),
-        .offset = offset,
-        .size = size,
-    };
+    b.pc = PushConstantTarget { .offset = offset, .size = size };
     b.desc.reset();
 }
 
@@ -105,24 +94,17 @@ bool FormaBindingsProcessor::unbind(const std::string& name)
 void FormaBindingsProcessor::execute_shader(const std::shared_ptr<VKBuffer>& buffer)
 {
     for (const auto& [name, b] : m_bindings) {
-        if (!b.reader) {
-            MF_RT_WARN(Journal::Component::Buffers, Journal::Context::BufferProcessing,
-                "FormaBindingsProcessor: binding '{}' has no reader", name);
+        if (!b.reader)
             continue;
-        }
-
         const float value = b.reader();
-
         switch (b.kind) {
         case TargetKind::PUSH_CONSTANT:
-            if (b.pc) {
-                flush_push_constant(value, *b.pc);
-            }
+            if (b.pc)
+                flush_push_constant(value, *b.pc, buffer);
             break;
         case TargetKind::DESCRIPTOR:
-            if (b.desc) {
+            if (b.desc)
                 flush_descriptor(value, *b.desc, buffer);
-            }
             break;
         }
     }
@@ -132,28 +114,23 @@ void FormaBindingsProcessor::execute_shader(const std::shared_ptr<VKBuffer>& buf
 // Private
 // =============================================================================
 
-void FormaBindingsProcessor::flush_push_constant(float value, const PushConstantTarget& pc)
+void FormaBindingsProcessor::flush_push_constant(
+    float value,
+    const PushConstantTarget& pc,
+    const std::shared_ptr<VKBuffer>& buffer)
 {
-    if (!pc.processor) {
-        return;
-    }
-
-    auto& staging = pc.processor->get_push_constant_data();
+    auto& staging = buffer->get_pipeline_context().push_constant_staging;
     const size_t end = static_cast<size_t>(pc.offset) + pc.size;
 
-    if (staging.size() < end) {
+    if (staging.size() < end)
         staging.resize(end);
-    }
 
-    if (pc.size == sizeof(float)) {
+    if (pc.size == sizeof(float))
         std::memcpy(staging.data() + pc.offset, &value, sizeof(float));
-    } else if (pc.size == sizeof(double)) {
+    else if (pc.size == sizeof(double)) {
         auto promoted = static_cast<double>(value);
         std::memcpy(staging.data() + pc.offset, &promoted, sizeof(double));
     }
-
-    MF_RT_DEBUG(Journal::Component::Buffers, Journal::Context::BufferProcessing,
-        "FormaBindingsProcessor: PC write offset={} value={}", pc.offset, value);
 }
 
 void FormaBindingsProcessor::flush_descriptor(

--- a/src/MayaFlux/Buffers/Forma/FormaBindingsProcessor.cpp
+++ b/src/MayaFlux/Buffers/Forma/FormaBindingsProcessor.cpp
@@ -53,14 +53,20 @@ void FormaBindingsProcessor::bind_descriptor(
     b.kind = TargetKind::DESCRIPTOR;
     b.reader = std::move(reader);
     b.pc.reset();
+
+    auto gpu_buf = make_descriptor_buffer(role);
+
     b.desc = DescriptorTarget {
         .descriptor_name = descriptor_name,
         .set_index = set,
         .binding_index = binding_index,
         .role = role,
-        .gpu_buffer = make_descriptor_buffer(role),
+        .gpu_buffer = gpu_buf,
         .buffer_size = sizeof(float),
     };
+
+    bind_buffer(descriptor_name, gpu_buf);
+    m_needs_descriptor_rebuild = true;
 }
 
 // =============================================================================
@@ -94,8 +100,12 @@ bool FormaBindingsProcessor::unbind(const std::string& name)
 void FormaBindingsProcessor::execute_shader(const std::shared_ptr<VKBuffer>& buffer)
 {
     for (const auto& [name, b] : m_bindings) {
-        if (!b.reader)
+        if (!b.reader) {
+            MF_RT_WARN(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+                "FormaBindingsProcessor: binding '{}' has no reader", name);
             continue;
+        }
+
         const float value = b.reader();
         switch (b.kind) {
         case TargetKind::PUSH_CONSTANT:
@@ -125,12 +135,15 @@ void FormaBindingsProcessor::flush_push_constant(
     if (staging.size() < end)
         staging.resize(end);
 
-    if (pc.size == sizeof(float))
+    if (pc.size == sizeof(float)) {
         std::memcpy(staging.data() + pc.offset, &value, sizeof(float));
-    else if (pc.size == sizeof(double)) {
+    } else if (pc.size == sizeof(double)) {
         auto promoted = static_cast<double>(value);
         std::memcpy(staging.data() + pc.offset, &promoted, sizeof(double));
     }
+
+    MF_RT_DEBUG(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+        "FormaBindingsProcessor: PC write offset={} value={}", pc.offset, value);
 }
 
 void FormaBindingsProcessor::flush_descriptor(
@@ -138,42 +151,28 @@ void FormaBindingsProcessor::flush_descriptor(
     const DescriptorTarget& desc,
     const std::shared_ptr<VKBuffer>& attached)
 {
-    if (!desc.gpu_buffer) {
-        return;
-    }
-
     upload_to_gpu(&value, sizeof(float), desc.gpu_buffer, nullptr);
 
     auto& bindings_list = attached->get_pipeline_context().descriptor_buffer_bindings;
 
-    bool found = false;
     for (auto& entry : bindings_list) {
         if (entry.set == desc.set_index && entry.binding == desc.binding_index) {
             entry.buffer_info.buffer = desc.gpu_buffer->get_buffer();
             entry.buffer_info.offset = 0;
             entry.buffer_info.range = sizeof(float);
-            found = true;
-            break;
+            return;
         }
     }
 
-    if (!found) {
-        bindings_list.push_back({
-            .set = desc.set_index,
-            .binding = desc.binding_index,
-            .type = (desc.role == Portal::Graphics::DescriptorRole::UNIFORM)
-                ? vk::DescriptorType::eUniformBuffer
-                : vk::DescriptorType::eStorageBuffer,
-            .buffer_info = vk::DescriptorBufferInfo {
-                desc.gpu_buffer->get_buffer(),
-                0,
-                sizeof(float) },
-        });
-    }
-
-    MF_RT_DEBUG(Journal::Component::Buffers, Journal::Context::BufferProcessing,
-        "FormaBindingsProcessor: descriptor write '{}' set={} binding={} value={}",
-        desc.descriptor_name, desc.set_index, desc.binding_index, value);
+    bindings_list.push_back({
+        .set = desc.set_index,
+        .binding = desc.binding_index,
+        .type = (desc.role == Portal::Graphics::DescriptorRole::UNIFORM)
+            ? vk::DescriptorType::eUniformBuffer
+            : vk::DescriptorType::eStorageBuffer,
+        .buffer_info = vk::DescriptorBufferInfo {
+            desc.gpu_buffer->get_buffer(), 0, sizeof(float) },
+    });
 }
 
 std::shared_ptr<VKBuffer> FormaBindingsProcessor::make_descriptor_buffer(

--- a/src/MayaFlux/Buffers/Forma/FormaBindingsProcessor.cpp
+++ b/src/MayaFlux/Buffers/Forma/FormaBindingsProcessor.cpp
@@ -19,6 +19,62 @@ FormaBindingsProcessor::FormaBindingsProcessor(ShaderConfig config)
 }
 
 // =============================================================================
+// Raw reader overloads
+// =============================================================================
+
+void FormaBindingsProcessor::bind_push_constant(
+    const std::string& name,
+    std::function<float()> reader,
+    std::shared_ptr<ShaderProcessor> target,
+    uint32_t offset,
+    size_t size)
+{
+    if (!reader || !target) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "FormaBindingsProcessor::bind_push_constant: null reader or target for '{}'", name);
+        return;
+    }
+
+    auto& b = m_bindings[name];
+    b.kind = TargetKind::PUSH_CONSTANT;
+    b.reader = std::move(reader);
+    b.pc = PushConstantTarget {
+        .processor = std::move(target),
+        .offset = offset,
+        .size = size,
+    };
+    b.desc.reset();
+}
+
+void FormaBindingsProcessor::bind_descriptor(
+    const std::string& name,
+    std::function<float()> reader,
+    const std::string& descriptor_name,
+    uint32_t binding_index,
+    uint32_t set,
+    Portal::Graphics::DescriptorRole role)
+{
+    if (!reader) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "FormaBindingsProcessor::bind_descriptor: null reader for '{}'", name);
+        return;
+    }
+
+    auto& b = m_bindings[name];
+    b.kind = TargetKind::DESCRIPTOR;
+    b.reader = std::move(reader);
+    b.pc.reset();
+    b.desc = DescriptorTarget {
+        .descriptor_name = descriptor_name,
+        .set_index = set,
+        .binding_index = binding_index,
+        .role = role,
+        .gpu_buffer = make_descriptor_buffer(role),
+        .buffer_size = sizeof(float),
+    };
+}
+
+// =============================================================================
 // Introspection
 // =============================================================================
 

--- a/src/MayaFlux/Buffers/Forma/FormaBindingsProcessor.cpp
+++ b/src/MayaFlux/Buffers/Forma/FormaBindingsProcessor.cpp
@@ -1,0 +1,173 @@
+#include "FormaBindingsProcessor.hpp"
+
+#include "MayaFlux/Buffers/Staging/StagingUtils.hpp"
+#include "MayaFlux/Buffers/VKBuffer.hpp"
+#include "MayaFlux/Journal/Archivist.hpp"
+#include "MayaFlux/Registry/BackendRegistry.hpp"
+#include "MayaFlux/Registry/Service/BufferService.hpp"
+
+namespace MayaFlux::Buffers {
+
+FormaBindingsProcessor::FormaBindingsProcessor(const std::string& shader_path)
+    : ShaderProcessor(shader_path)
+{
+}
+
+FormaBindingsProcessor::FormaBindingsProcessor(ShaderConfig config)
+    : ShaderProcessor(std::move(config))
+{
+}
+
+// =============================================================================
+// Introspection
+// =============================================================================
+
+bool FormaBindingsProcessor::has_binding(const std::string& name) const
+{
+    return m_bindings.contains(name);
+}
+
+std::vector<std::string> FormaBindingsProcessor::get_binding_names() const
+{
+    std::vector<std::string> names;
+    names.reserve(m_bindings.size());
+    for (const auto& [k, _] : m_bindings) {
+        names.push_back(k);
+    }
+    return names;
+}
+
+bool FormaBindingsProcessor::unbind(const std::string& name)
+{
+    return m_bindings.erase(name) > 0;
+}
+
+// =============================================================================
+// ShaderProcessor hook
+// =============================================================================
+
+void FormaBindingsProcessor::execute_shader(const std::shared_ptr<VKBuffer>& buffer)
+{
+    for (const auto& [name, b] : m_bindings) {
+        if (!b.reader) {
+            MF_RT_WARN(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+                "FormaBindingsProcessor: binding '{}' has no reader", name);
+            continue;
+        }
+
+        const float value = b.reader();
+
+        switch (b.kind) {
+        case TargetKind::PUSH_CONSTANT:
+            if (b.pc) {
+                flush_push_constant(value, *b.pc);
+            }
+            break;
+        case TargetKind::DESCRIPTOR:
+            if (b.desc) {
+                flush_descriptor(value, *b.desc, buffer);
+            }
+            break;
+        }
+    }
+}
+
+// =============================================================================
+// Private
+// =============================================================================
+
+void FormaBindingsProcessor::flush_push_constant(float value, const PushConstantTarget& pc)
+{
+    if (!pc.processor) {
+        return;
+    }
+
+    auto& staging = pc.processor->get_push_constant_data();
+    const size_t end = static_cast<size_t>(pc.offset) + pc.size;
+
+    if (staging.size() < end) {
+        staging.resize(end);
+    }
+
+    if (pc.size == sizeof(float)) {
+        std::memcpy(staging.data() + pc.offset, &value, sizeof(float));
+    } else if (pc.size == sizeof(double)) {
+        auto promoted = static_cast<double>(value);
+        std::memcpy(staging.data() + pc.offset, &promoted, sizeof(double));
+    }
+
+    MF_RT_DEBUG(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+        "FormaBindingsProcessor: PC write offset={} value={}", pc.offset, value);
+}
+
+void FormaBindingsProcessor::flush_descriptor(
+    float value,
+    const DescriptorTarget& desc,
+    const std::shared_ptr<VKBuffer>& attached)
+{
+    if (!desc.gpu_buffer) {
+        return;
+    }
+
+    upload_to_gpu(&value, sizeof(float), desc.gpu_buffer, nullptr);
+
+    auto& bindings_list = attached->get_pipeline_context().descriptor_buffer_bindings;
+
+    bool found = false;
+    for (auto& entry : bindings_list) {
+        if (entry.set == desc.set_index && entry.binding == desc.binding_index) {
+            entry.buffer_info.buffer = desc.gpu_buffer->get_buffer();
+            entry.buffer_info.offset = 0;
+            entry.buffer_info.range = sizeof(float);
+            found = true;
+            break;
+        }
+    }
+
+    if (!found) {
+        bindings_list.push_back({
+            .set = desc.set_index,
+            .binding = desc.binding_index,
+            .type = (desc.role == Portal::Graphics::DescriptorRole::UNIFORM)
+                ? vk::DescriptorType::eUniformBuffer
+                : vk::DescriptorType::eStorageBuffer,
+            .buffer_info = vk::DescriptorBufferInfo {
+                desc.gpu_buffer->get_buffer(),
+                0,
+                sizeof(float) },
+        });
+    }
+
+    MF_RT_DEBUG(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+        "FormaBindingsProcessor: descriptor write '{}' set={} binding={} value={}",
+        desc.descriptor_name, desc.set_index, desc.binding_index, value);
+}
+
+std::shared_ptr<VKBuffer> FormaBindingsProcessor::make_descriptor_buffer(
+    Portal::Graphics::DescriptorRole role)
+{
+    const VKBuffer::Usage usage = (role == Portal::Graphics::DescriptorRole::UNIFORM)
+        ? VKBuffer::Usage::UNIFORM
+        : VKBuffer::Usage::COMPUTE;
+
+    auto buf = std::make_shared<VKBuffer>(
+        sizeof(float),
+        usage,
+        Kakshya::DataModality::UNKNOWN);
+
+    auto svc = Registry::BackendRegistry::instance()
+                   .get_service<Registry::Service::BufferService>();
+
+    if (!svc) {
+        error<std::runtime_error>(
+            Journal::Component::Buffers,
+            Journal::Context::BufferProcessing,
+            std::source_location::current(),
+            "FormaBindingsProcessor: no BufferService available");
+    }
+
+    svc->initialize_buffer(buf);
+    return buf;
+}
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/Forma/FormaBindingsProcessor.hpp
+++ b/src/MayaFlux/Buffers/Forma/FormaBindingsProcessor.hpp
@@ -132,6 +132,12 @@ public:
         uint32_t offset,
         size_t size = sizeof(float))
     {
+        if (!state) {
+            MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+                "FormaBindingsProcessor::bind_push_constant: null state for '{}'", name);
+            return;
+        }
+
         auto& b = m_bindings[name];
         b.kind = TargetKind::PUSH_CONSTANT;
         b.reader = [s = std::move(state), p = std::move(project)]() {
@@ -178,6 +184,8 @@ public:
             return;
         }
 
+        auto gpu_buf = make_descriptor_buffer(role);
+
         auto& b = m_bindings[name];
         b.kind = TargetKind::DESCRIPTOR;
         b.reader = [s = std::move(state), p = std::move(project)]() {
@@ -189,9 +197,16 @@ public:
             .set_index = set,
             .binding_index = binding_index,
             .role = role,
-            .gpu_buffer = make_descriptor_buffer(role),
+            .gpu_buffer = gpu_buf,
             .buffer_size = sizeof(float),
         };
+
+        bind_buffer(descriptor_name, gpu_buf);
+        m_needs_descriptor_rebuild = true;
+
+        MF_DEBUG(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "FormaBindingsProcessor::bind_descriptor: '{}' -> descriptor '{}' set={} binding={}",
+            name, descriptor_name, set, binding_index);
     }
 
     // =========================================================================

--- a/src/MayaFlux/Buffers/Forma/FormaBindingsProcessor.hpp
+++ b/src/MayaFlux/Buffers/Forma/FormaBindingsProcessor.hpp
@@ -1,0 +1,224 @@
+#pragma once
+
+#include "MayaFlux/Buffers/Shaders/ShaderProcessor.hpp"
+
+#include "MayaFlux/Portal/Forma/Primitives/Mapped.hpp"
+
+#include "MayaFlux/Journal/Archivist.hpp"
+
+namespace MayaFlux::Buffers {
+
+/**
+ * @class FormaBindingsProcessor
+ * @brief ShaderProcessor that reads Forma element state and routes it to push
+ *        constants or descriptor bindings on external pipelines each graphics tick.
+ *
+ * Attaches to a FormaBuffer as a secondary processor — never as the primary.
+ * Owns no pipeline or shader of its own; initialize_pipeline() and
+ * initialize_descriptors() are no-ops, matching NodeBindingsProcessor and
+ * DescriptorBindingsProcessor.
+ *
+ * The processor is the automation layer. Each binding registers:
+ *   - A type-erased reader: std::function<float()> that closes over a
+ *     shared_ptr<MappedState<T>> and a projection function T -> float.
+ *     The reader is called every graphics tick regardless of version — the
+ *     graphics tick IS the sampling boundary.
+ *   - A target: either a push constant slot on an external ShaderProcessor,
+ *     or a descriptor buffer registered on the attached buffer's
+ *     pipeline_context.
+ *
+ * Templated bind overloads accept any MappedState<T> and a projection
+ * function, constructing the type-erased reader internally. The processor
+ * itself holds no template parameters.
+ *
+ * Usage:
+ * @code
+ * // Fader state drives a push constant on a compute processor
+ * forma_bindings->bind_push_constant(
+ *     "cutoff",
+ *     fader.state,
+ *     [](float v) { return v; },
+ *     compute_proc,
+ *     offsetof(MyPC, cutoff));
+ *
+ * // 2D picker x-axis drives a descriptor uniform
+ * forma_bindings->bind_descriptor(
+ *     "pan",
+ *     picker.state,
+ *     [](glm::vec2 v) { return v.x; },
+ *     "pan_ubo",
+ *     0,
+ *     Portal::Graphics::DescriptorRole::UNIFORM);
+ *
+ * forma_buffer->add_processor(forma_bindings);
+ * @endcode
+ */
+class MAYAFLUX_API FormaBindingsProcessor : public ShaderProcessor {
+public:
+    explicit FormaBindingsProcessor(const std::string& shader_path);
+    explicit FormaBindingsProcessor(ShaderConfig config);
+    ~FormaBindingsProcessor() override = default;
+
+    FormaBindingsProcessor(const FormaBindingsProcessor&) = delete;
+    FormaBindingsProcessor& operator=(const FormaBindingsProcessor&) = delete;
+    FormaBindingsProcessor(FormaBindingsProcessor&&) = delete;
+    FormaBindingsProcessor& operator=(FormaBindingsProcessor&&) = delete;
+
+    // =========================================================================
+    // Push constant bindings
+    // =========================================================================
+
+    /**
+     * @brief Bind a MappedState<T> to a push constant slot on an external
+     *        ShaderProcessor.
+     *
+     * @param name      Logical binding name for introspection and unbind.
+     * @param state     MappedState whose value is read each graphics tick.
+     * @param project   Projection from T to float. Called every tick.
+     * @param target    ShaderProcessor whose push_constant_data receives
+     *                  the value at @p offset. Any subclass is valid.
+     * @param offset    Byte offset in the target's push constant struct.
+     * @param size      Byte width of the written value. Defaults to sizeof(float).
+     * @tparam T        MappedState value type.
+     */
+    template <typename T>
+    void bind_push_constant(
+        const std::string& name,
+        std::shared_ptr<Portal::Forma::MappedState<T>> state,
+        std::function<float(T)> project,
+        std::shared_ptr<ShaderProcessor> target,
+        uint32_t offset,
+        size_t size = sizeof(float))
+    {
+        if (!state || !target) {
+            MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+                "FormaBindingsProcessor::bind_push_constant: null state or target for '{}'", name);
+            return;
+        }
+
+        auto& b = m_bindings[name];
+        b.kind = TargetKind::PUSH_CONSTANT;
+        b.reader = [s = std::move(state), p = std::move(project)]() {
+            return p(s->value);
+        };
+        b.pc = PushConstantTarget {
+            .processor = std::move(target),
+            .offset = offset,
+            .size = size,
+        };
+        b.desc.reset();
+    }
+
+    // =========================================================================
+    // Descriptor bindings
+    // =========================================================================
+
+    /**
+     * @brief Bind a MappedState<T> to a descriptor binding on the attached buffer.
+     *
+     * Creates an owned host-visible GPU buffer sized to sizeof(float).
+     * Each tick the projected value is uploaded into this buffer and
+     * registered in the attached buffer's descriptor_buffer_bindings,
+     * following the same path as DescriptorBindingsProcessor.
+     *
+     * @param name            Logical binding name.
+     * @param state           MappedState whose value is read each graphics tick.
+     * @param project         Projection from T to float. Called every tick.
+     * @param descriptor_name Descriptor name in the shader config.
+     * @param binding_index   Vulkan binding index within the descriptor set.
+     * @param set             Descriptor set index.
+     * @param role            UNIFORM for UBO, STORAGE for SSBO.
+     * @tparam T              MappedState value type.
+     */
+    template <typename T>
+    void bind_descriptor(
+        const std::string& name,
+        std::shared_ptr<Portal::Forma::MappedState<T>> state,
+        std::function<float(T)> project,
+        const std::string& descriptor_name,
+        uint32_t binding_index,
+        uint32_t set,
+        Portal::Graphics::DescriptorRole role = Portal::Graphics::DescriptorRole::UNIFORM)
+    {
+        if (!state) {
+            MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+                "FormaBindingsProcessor::bind_descriptor: null state for '{}'", name);
+            return;
+        }
+
+        auto& b = m_bindings[name];
+        b.kind = TargetKind::DESCRIPTOR;
+        b.reader = [s = std::move(state), p = std::move(project)]() {
+            return p(s->value);
+        };
+        b.pc.reset();
+        b.desc = DescriptorTarget {
+            .descriptor_name = descriptor_name,
+            .set_index = set,
+            .binding_index = binding_index,
+            .role = role,
+            .gpu_buffer = make_descriptor_buffer(role),
+            .buffer_size = sizeof(float),
+        };
+    }
+
+    // =========================================================================
+    // Introspection
+    // =========================================================================
+
+    /** @brief Returns true if a binding with @p name exists. */
+    [[nodiscard]] bool has_binding(const std::string& name) const;
+
+    /** @brief Returns all registered binding names. */
+    [[nodiscard]] std::vector<std::string> get_binding_names() const;
+
+    /**
+     * @brief Remove a binding by name.
+     * @return True if found and removed.
+     */
+    bool unbind(const std::string& name);
+
+protected:
+    void execute_shader(const std::shared_ptr<VKBuffer>& buffer) override;
+    void initialize_pipeline(const std::shared_ptr<VKBuffer>&) override { }
+    void initialize_descriptors(const std::shared_ptr<VKBuffer>&) override { }
+
+private:
+    enum class TargetKind : uint8_t {
+        PUSH_CONSTANT,
+        DESCRIPTOR,
+    };
+
+    struct PushConstantTarget {
+        std::shared_ptr<ShaderProcessor> processor;
+        uint32_t offset;
+        size_t size;
+    };
+
+    struct DescriptorTarget {
+        std::string descriptor_name;
+        uint32_t set_index;
+        uint32_t binding_index;
+        Portal::Graphics::DescriptorRole role;
+        std::shared_ptr<VKBuffer> gpu_buffer;
+        size_t buffer_size;
+    };
+
+    struct Binding {
+        TargetKind kind;
+        std::function<float()> reader;
+        std::optional<PushConstantTarget> pc;
+        std::optional<DescriptorTarget> desc;
+    };
+
+    std::unordered_map<std::string, Binding> m_bindings;
+
+    void flush_push_constant(float value, const PushConstantTarget& pc);
+    void flush_descriptor(float value, const DescriptorTarget& desc,
+        const std::shared_ptr<VKBuffer>& attached);
+
+    [[nodiscard]] static std::shared_ptr<VKBuffer> make_descriptor_buffer(
+        Portal::Graphics::DescriptorRole role);
+};
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/Forma/FormaBindingsProcessor.hpp
+++ b/src/MayaFlux/Buffers/Forma/FormaBindingsProcessor.hpp
@@ -76,14 +76,12 @@ public:
      *
      * @param name     Logical binding name.
      * @param reader   Callable returning the current float value each tick.
-     * @param target   ShaderProcessor whose push_constant_data receives the value.
      * @param offset   Byte offset in the push constant struct.
      * @param size     Byte width. Defaults to sizeof(float).
      */
     void bind_push_constant(
         const std::string& name,
         std::function<float()> reader,
-        std::shared_ptr<ShaderProcessor> target,
         uint32_t offset,
         size_t size = sizeof(float));
 
@@ -121,7 +119,6 @@ public:
      * @param name      Logical binding name for introspection and unbind.
      * @param state     MappedState whose value is read each graphics tick.
      * @param project   Projection from T to float. Called every tick.
-     * @param target    ShaderProcessor whose push_constant_data receives
      *                  the value at @p offset. Any subclass is valid.
      * @param offset    Byte offset in the target's push constant struct.
      * @param size      Byte width of the written value. Defaults to sizeof(float).
@@ -132,26 +129,15 @@ public:
         const std::string& name,
         std::shared_ptr<Portal::Forma::MappedState<T>> state,
         std::function<float(T)> project,
-        std::shared_ptr<ShaderProcessor> target,
         uint32_t offset,
         size_t size = sizeof(float))
     {
-        if (!state || !target) {
-            MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
-                "FormaBindingsProcessor::bind_push_constant: null state or target for '{}'", name);
-            return;
-        }
-
         auto& b = m_bindings[name];
         b.kind = TargetKind::PUSH_CONSTANT;
         b.reader = [s = std::move(state), p = std::move(project)]() {
             return p(s->value);
         };
-        b.pc = PushConstantTarget {
-            .processor = std::move(target),
-            .offset = offset,
-            .size = size,
-        };
+        b.pc = PushConstantTarget { .offset = offset, .size = size };
         b.desc.reset();
     }
 
@@ -236,7 +222,6 @@ private:
     };
 
     struct PushConstantTarget {
-        std::shared_ptr<ShaderProcessor> processor;
         uint32_t offset;
         size_t size;
     };
@@ -259,7 +244,8 @@ private:
 
     std::unordered_map<std::string, Binding> m_bindings;
 
-    void flush_push_constant(float value, const PushConstantTarget& pc);
+    void flush_push_constant(float value, const PushConstantTarget& pc, const std::shared_ptr<VKBuffer>& buffer);
+
     void flush_descriptor(float value, const DescriptorTarget& desc,
         const std::shared_ptr<VKBuffer>& attached);
 

--- a/src/MayaFlux/Buffers/Forma/FormaBindingsProcessor.hpp
+++ b/src/MayaFlux/Buffers/Forma/FormaBindingsProcessor.hpp
@@ -65,8 +65,54 @@ public:
     FormaBindingsProcessor& operator=(FormaBindingsProcessor&&) = delete;
 
     // =========================================================================
-    // Push constant bindings
+    // Push constant bindings — raw reader overload
     // =========================================================================
+
+    /**
+     * @brief Bind a type-erased reader to a push constant slot.
+     *
+     * Used by Bridge, which holds readers as std::function<float()> after
+     * type-erasing MappedState<T> at register_element time.
+     *
+     * @param name     Logical binding name.
+     * @param reader   Callable returning the current float value each tick.
+     * @param target   ShaderProcessor whose push_constant_data receives the value.
+     * @param offset   Byte offset in the push constant struct.
+     * @param size     Byte width. Defaults to sizeof(float).
+     */
+    void bind_push_constant(
+        const std::string& name,
+        std::function<float()> reader,
+        std::shared_ptr<ShaderProcessor> target,
+        uint32_t offset,
+        size_t size = sizeof(float));
+
+    // =========================================================================
+    // Descriptor bindings — raw reader overload
+    // =========================================================================
+
+    /**
+     * @brief Bind a type-erased reader to a descriptor binding.
+     *
+     * Used by Bridge for the same reason as the push constant raw overload.
+     *
+     * @param name            Logical binding name.
+     * @param reader          Callable returning the current float value each tick.
+     * @param descriptor_name Descriptor name in the shader config.
+     * @param binding_index   Vulkan binding index within the descriptor set.
+     * @param set             Descriptor set index.
+     * @param role            UNIFORM for UBO, STORAGE for SSBO.
+     */
+    void bind_descriptor(
+        const std::string& name,
+        std::function<float()> reader,
+        const std::string& descriptor_name,
+        uint32_t binding_index,
+        uint32_t set,
+        Portal::Graphics::DescriptorRole role = Portal::Graphics::DescriptorRole::UNIFORM);
+
+    // =========================================================================
+    // Push constant bindings — MappedState<T> overload
 
     /**
      * @brief Bind a MappedState<T> to a push constant slot on an external

--- a/src/MayaFlux/Buffers/Forma/FormaBuffer.cpp
+++ b/src/MayaFlux/Buffers/Forma/FormaBuffer.cpp
@@ -1,0 +1,121 @@
+#include "FormaBuffer.hpp"
+
+#include "MayaFlux/Buffers/BufferProcessingChain.hpp"
+#include "MayaFlux/Buffers/Shaders/RenderProcessor.hpp"
+#include "MayaFlux/Buffers/Staging/BufferUploadProcessor.hpp"
+#include "MayaFlux/Core/Backends/Windowing/Window.hpp"
+#include "MayaFlux/Journal/Archivist.hpp"
+
+namespace MayaFlux::Buffers {
+
+FormaBuffer::FormaBuffer(
+    size_t capacity_bytes,
+    Portal::Graphics::PrimitiveTopology topology)
+    : VKBuffer(capacity_bytes, Buffers::VKBuffer::Usage::VERTEX,
+          Kakshya::DataModality::VERTEX_POSITIONS_3D)
+    , m_topology(topology)
+{
+}
+
+void FormaBuffer::setup_processors(ProcessingToken token)
+{
+    auto upload = std::make_shared<Buffers::BufferUploadProcessor>();
+    set_default_processor(upload);
+
+    auto chain = std::make_shared<Buffers::BufferProcessingChain>();
+    chain->set_preferred_token(token);
+    set_processing_chain(chain);
+}
+
+void FormaBuffer::setup_rendering(const RenderConfig& config)
+{
+    RenderConfig resolved_config = config;
+    resolved_config.topology = m_topology;
+
+    switch (resolved_config.topology) {
+    case Portal::Graphics::PrimitiveTopology::POINT_LIST:
+        if (config.vertex_shader.empty())
+            resolved_config.vertex_shader = "point.vert.spv";
+        if (config.fragment_shader.empty())
+            resolved_config.fragment_shader = "point.frag.spv";
+        break;
+
+    case Portal::Graphics::PrimitiveTopology::LINE_LIST:
+    case Portal::Graphics::PrimitiveTopology::LINE_STRIP:
+
+        if (config.fragment_shader.empty())
+            resolved_config.fragment_shader = "line.frag.spv";
+
+#ifndef MAYAFLUX_PLATFORM_MACOS
+        if (config.vertex_shader.empty())
+            resolved_config.vertex_shader = "line.vert.spv";
+        if (config.geometry_shader.empty())
+            resolved_config.geometry_shader = "line.geom.spv";
+#else
+        if (config.vertex_shader.empty())
+            resolved_config.vertex_shader = "line_fallback.vert.spv";
+
+        resolved_config.topology = Portal::Graphics::PrimitiveTopology::TRIANGLE_LIST;
+#endif
+
+        break;
+
+    case Portal::Graphics::PrimitiveTopology::TRIANGLE_LIST:
+    case Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP:
+        if (config.vertex_shader.empty())
+            resolved_config.vertex_shader = "triangle.vert.spv";
+        if (config.fragment_shader.empty())
+            resolved_config.fragment_shader = "triangle.frag.spv";
+        break;
+
+    default:
+        if (config.vertex_shader.empty())
+            resolved_config.vertex_shader = "point.vert.spv";
+        if (config.fragment_shader.empty())
+            resolved_config.fragment_shader = "point.frag.spv";
+    }
+
+    if (!m_render_processor) {
+        m_render_processor = std::make_shared<RenderProcessor>(ShaderConfig { resolved_config.vertex_shader });
+    } else {
+        m_render_processor->set_shader(resolved_config.vertex_shader);
+    }
+
+    m_render_processor->set_fragment_shader(resolved_config.fragment_shader);
+    if (!resolved_config.geometry_shader.empty()) {
+        m_render_processor->set_geometry_shader(resolved_config.geometry_shader);
+    }
+    m_render_processor->set_target_window(config.target_window, std::dynamic_pointer_cast<VKBuffer>(shared_from_this()));
+    m_render_processor->set_primitive_topology(resolved_config.topology);
+    m_render_processor->set_polygon_mode(config.polygon_mode);
+    m_render_processor->set_cull_mode(config.cull_mode);
+
+    get_processing_chain()->add_final_processor(m_render_processor, shared_from_this());
+
+    set_default_render_config(resolved_config);
+}
+
+void FormaBuffer::write_bytes(const std::vector<uint8_t>& bytes)
+{
+    if (bytes.empty())
+        return;
+
+    if (bytes.size() > get_size()) {
+        MF_RT_WARN(Journal::Component::Portal, Journal::Context::BufferProcessing,
+            "FormaBuffer::write_bytes: {} bytes exceeds capacity {}, skipping",
+            bytes.size(), get_size());
+        return;
+    }
+
+    auto& res = get_buffer_resources();
+    if (!res.mapped_ptr) {
+        MF_RT_WARN(Journal::Component::Portal, Journal::Context::BufferProcessing,
+            "FormaBuffer::write_bytes: buffer not host-visible or not yet registered");
+        return;
+    }
+
+    std::memcpy(res.mapped_ptr, bytes.data(), bytes.size());
+    mark_dirty_range(0, bytes.size());
+}
+
+} // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Buffers/Forma/FormaBuffer.cpp
+++ b/src/MayaFlux/Buffers/Forma/FormaBuffer.cpp
@@ -36,6 +36,8 @@ void FormaBuffer::setup_rendering(const RenderConfig& config)
     RenderConfig resolved_config = config;
     resolved_config.topology = m_topology;
 
+    const bool textured = !config.default_texture_binding.empty();
+
     switch (resolved_config.topology) {
     case Portal::Graphics::PrimitiveTopology::POINT_LIST:
         if (config.vertex_shader.empty())
@@ -67,8 +69,11 @@ void FormaBuffer::setup_rendering(const RenderConfig& config)
     case Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP:
         if (config.vertex_shader.empty())
             resolved_config.vertex_shader = "triangle.vert.spv";
-        if (config.fragment_shader.empty())
-            resolved_config.fragment_shader = "triangle.frag.spv";
+        if (config.fragment_shader.empty()) {
+            resolved_config.fragment_shader = textured
+                ? "forma_textured.frag.spv"
+                : "triangle.frag.spv";
+        }
         break;
 
     default:
@@ -76,19 +81,28 @@ void FormaBuffer::setup_rendering(const RenderConfig& config)
             resolved_config.vertex_shader = "point.vert.spv";
         if (config.fragment_shader.empty())
             resolved_config.fragment_shader = "point.frag.spv";
+        break;
+    }
+
+    ShaderConfig sc { resolved_config.vertex_shader };
+    if (textured) {
+        sc.bindings[resolved_config.default_texture_binding] = ShaderBinding(
+            0, 1, vk::DescriptorType::eCombinedImageSampler);
     }
 
     if (!m_render_processor) {
-        m_render_processor = std::make_shared<RenderProcessor>(ShaderConfig { resolved_config.vertex_shader });
+        m_render_processor = std::make_shared<RenderProcessor>(sc);
     } else {
         m_render_processor->set_shader(resolved_config.vertex_shader);
     }
 
     m_render_processor->set_fragment_shader(resolved_config.fragment_shader);
-    if (!resolved_config.geometry_shader.empty()) {
+    if (!resolved_config.geometry_shader.empty())
         m_render_processor->set_geometry_shader(resolved_config.geometry_shader);
-    }
-    m_render_processor->set_target_window(config.target_window, std::dynamic_pointer_cast<VKBuffer>(shared_from_this()));
+
+    m_render_processor->set_target_window(
+        config.target_window,
+        std::dynamic_pointer_cast<VKBuffer>(shared_from_this()));
     m_render_processor->set_primitive_topology(resolved_config.topology);
     m_render_processor->set_polygon_mode(config.polygon_mode);
     m_render_processor->set_cull_mode(config.cull_mode);

--- a/src/MayaFlux/Buffers/Forma/FormaBuffer.cpp
+++ b/src/MayaFlux/Buffers/Forma/FormaBuffer.cpp
@@ -1,9 +1,12 @@
 #include "FormaBuffer.hpp"
 
 #include "MayaFlux/Buffers/BufferProcessingChain.hpp"
+#include "MayaFlux/Buffers/Forma/FormaProcessor.hpp"
 #include "MayaFlux/Buffers/Shaders/RenderProcessor.hpp"
-#include "MayaFlux/Buffers/Staging/BufferUploadProcessor.hpp"
+#include "MayaFlux/Buffers/Staging/StagingUtils.hpp"
+
 #include "MayaFlux/Core/Backends/Windowing/Window.hpp"
+
 #include "MayaFlux/Journal/Archivist.hpp"
 
 namespace MayaFlux::Buffers {
@@ -19,8 +22,9 @@ FormaBuffer::FormaBuffer(
 
 void FormaBuffer::setup_processors(ProcessingToken token)
 {
-    auto upload = std::make_shared<Buffers::BufferUploadProcessor>();
-    set_default_processor(upload);
+    auto proc = std::make_shared<Buffers::FormaProcessor>(m_topology);
+    set_default_processor(proc);
+    m_processor = proc;
 
     auto chain = std::make_shared<Buffers::BufferProcessingChain>();
     chain->set_preferred_token(token);
@@ -42,7 +46,6 @@ void FormaBuffer::setup_rendering(const RenderConfig& config)
 
     case Portal::Graphics::PrimitiveTopology::LINE_LIST:
     case Portal::Graphics::PrimitiveTopology::LINE_STRIP:
-
         if (config.fragment_shader.empty())
             resolved_config.fragment_shader = "line.frag.spv";
 
@@ -89,6 +92,7 @@ void FormaBuffer::setup_rendering(const RenderConfig& config)
     m_render_processor->set_primitive_topology(resolved_config.topology);
     m_render_processor->set_polygon_mode(config.polygon_mode);
     m_render_processor->set_cull_mode(config.cull_mode);
+    m_render_processor->enable_alpha_blending();
 
     get_processing_chain()->add_final_processor(m_render_processor, shared_from_this());
 
@@ -97,25 +101,12 @@ void FormaBuffer::setup_rendering(const RenderConfig& config)
 
 void FormaBuffer::write_bytes(const std::vector<uint8_t>& bytes)
 {
-    if (bytes.empty())
-        return;
-
-    if (bytes.size() > get_size()) {
-        MF_RT_WARN(Journal::Component::Portal, Journal::Context::BufferProcessing,
-            "FormaBuffer::write_bytes: {} bytes exceeds capacity {}, skipping",
-            bytes.size(), get_size());
+    if (!m_processor) {
+        MF_RT_WARN(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "FormaBuffer::write_bytes called before setup_processors");
         return;
     }
-
-    auto& res = get_buffer_resources();
-    if (!res.mapped_ptr) {
-        MF_RT_WARN(Journal::Component::Portal, Journal::Context::BufferProcessing,
-            "FormaBuffer::write_bytes: buffer not host-visible or not yet registered");
-        return;
-    }
-
-    std::memcpy(res.mapped_ptr, bytes.data(), bytes.size());
-    mark_dirty_range(0, bytes.size());
+    m_processor->set_bytes(bytes);
 }
 
 } // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Buffers/Forma/FormaBuffer.cpp
+++ b/src/MayaFlux/Buffers/Forma/FormaBuffer.cpp
@@ -99,7 +99,7 @@ void FormaBuffer::setup_rendering(const RenderConfig& config)
     set_default_render_config(resolved_config);
 }
 
-void FormaBuffer::write_bytes(const std::vector<uint8_t>& bytes)
+void FormaBuffer::submit(const std::vector<uint8_t>& bytes)
 {
     if (!m_processor) {
         MF_RT_WARN(Journal::Component::Buffers, Journal::Context::BufferProcessing,
@@ -107,6 +107,16 @@ void FormaBuffer::write_bytes(const std::vector<uint8_t>& bytes)
         return;
     }
     m_processor->set_bytes(bytes);
+}
+
+void FormaBuffer::set_texture(std::shared_ptr<Core::VKImage> image, std::string binding)
+{
+    if (!m_processor) {
+        MF_RT_WARN(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "FormaBuffer::set_texture called before setup_processors");
+        return;
+    }
+    m_processor->set_texture(std::move(image), std::move(binding));
 }
 
 } // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Buffers/Forma/FormaBuffer.hpp
+++ b/src/MayaFlux/Buffers/Forma/FormaBuffer.hpp
@@ -78,7 +78,20 @@ public:
      * @param bytes Raw interleaved vertex bytes. Must not exceed the
      *              capacity set at construction.
      */
-    void write_bytes(const std::vector<uint8_t>& bytes);
+    void submit(const std::vector<uint8_t>& bytes);
+
+    /**
+     * @brief Supply a texture to be bound on the next graphics tick.
+     *
+     * The image is owned externally — a TextBuffer's VKImage from
+     * InkPress, a loaded asset, a render target, anything. FormaProcessor
+     * forwards it to the RenderProcessor on the next processing_function
+     * call. Calling again replaces the previous binding.
+     *
+     * @param image   GPU image to bind. nullptr clears the binding.
+     * @param binding Descriptor name in the shader (e.g. "texSampler").
+     */
+    void set_texture(std::shared_ptr<Core::VKImage> image, std::string binding);
 
     [[nodiscard]] std::shared_ptr<Buffers::RenderProcessor> get_render_processor() const override
     {

--- a/src/MayaFlux/Buffers/Forma/FormaBuffer.hpp
+++ b/src/MayaFlux/Buffers/Forma/FormaBuffer.hpp
@@ -1,0 +1,94 @@
+#pragma once
+
+#include "MayaFlux/Buffers/VKBuffer.hpp"
+#include "MayaFlux/Portal/Graphics/GraphicsUtils.hpp"
+
+namespace MayaFlux::Core {
+class Window;
+}
+
+namespace MayaFlux::Buffers {
+class RenderProcessor;
+
+/**
+ * @class FormaBuffer
+ * @brief VKBuffer for 2D screen-space Forma geometry.
+ *
+ * Encodes the invariants that hold for all Forma geometry:
+ *   - No depth test, no depth write, no view transform.
+ *   - Alpha blending enabled on the RenderProcessor.
+ *   - Topology fixed at construction (determines default shaders).
+ *
+ * Provides write_bytes() as the clean write interface for Mapped::sync(),
+ * replacing the raw set_data path on plain VKBuffer.
+ *
+ * Usage:
+ * @code
+ * auto buf = std::make_shared<FormaBuffer>(
+ *     initial_capacity_bytes,
+ *     Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP);
+ * buf->setup_processors(ProcessingToken::GRAPHICS_BACKEND);
+ * buf->setup_rendering({ .target_window = window });
+ * @endcode
+ */
+class MAYAFLUX_API FormaBuffer : public Buffers::VKBuffer {
+public:
+    /**
+     * @brief Construct a FormaBuffer.
+     * @param capacity_bytes  Initial buffer capacity. Size the buffer for the
+     *                        maximum expected vertex count from the geometry
+     *                        function. write_bytes() will warn if exceeded.
+     * @param topology        Primitive topology. Determines default shaders
+     *                        selected in setup_rendering().
+     */
+    FormaBuffer(
+        size_t capacity_bytes,
+        Portal::Graphics::PrimitiveTopology topology);
+
+    ~FormaBuffer() override = default;
+
+    FormaBuffer(const FormaBuffer&) = delete;
+    FormaBuffer& operator=(const FormaBuffer&) = delete;
+    FormaBuffer(FormaBuffer&&) = delete;
+    FormaBuffer& operator=(FormaBuffer&&) = delete;
+
+    /**
+     * @brief Register with the graphics subsystem.
+     *        Creates a BufferUploadProcessor as default processor.
+     */
+    void setup_processors(ProcessingToken token) override;
+
+    /**
+     * @brief Attach a RenderProcessor targeting the given window.
+     *
+     * Selects default shaders based on topology set at construction.
+     * Always enables alpha blending and disables depth testing.
+     * Caller may override shaders via config fields.
+     */
+    void setup_rendering(const RenderConfig& config);
+
+    /**
+     * @brief Write vertex bytes into the buffer.
+     *
+     * Called by Mapped::sync() each time the geometry function produces
+     * new vertex data. Copies bytes into the mapped host-visible region
+     * and marks the dirty range for flush on the next graphics tick.
+     *
+     * @param bytes Raw interleaved vertex bytes. Must not exceed the
+     *              capacity set at construction.
+     */
+    void write_bytes(const std::vector<uint8_t>& bytes);
+
+    [[nodiscard]] std::shared_ptr<Buffers::RenderProcessor> get_render_processor() const override
+    {
+        return m_render_processor;
+    }
+
+    [[nodiscard]] Portal::Graphics::PrimitiveTopology topology() const { return m_topology; }
+
+private:
+    Portal::Graphics::PrimitiveTopology m_topology;
+    std::shared_ptr<Buffers::RenderProcessor> m_render_processor;
+};
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/Forma/FormaBuffer.hpp
+++ b/src/MayaFlux/Buffers/Forma/FormaBuffer.hpp
@@ -8,6 +8,7 @@ class Window;
 }
 
 namespace MayaFlux::Buffers {
+class FormaProcessor;
 class RenderProcessor;
 
 /**
@@ -89,6 +90,7 @@ public:
 private:
     Portal::Graphics::PrimitiveTopology m_topology;
     std::shared_ptr<Buffers::RenderProcessor> m_render_processor;
+    std::shared_ptr<Buffers::FormaProcessor> m_processor;
 };
 
 } // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/Forma/FormaProcessor.cpp
+++ b/src/MayaFlux/Buffers/Forma/FormaProcessor.cpp
@@ -1,5 +1,6 @@
 #include "FormaProcessor.hpp"
 
+#include "MayaFlux/Buffers/Shaders/RenderProcessor.hpp"
 #include "MayaFlux/Buffers/Staging/StagingUtils.hpp"
 #include "MayaFlux/Journal/Archivist.hpp"
 #include "MayaFlux/Nodes/Graphics/VertexSpec.hpp"
@@ -29,13 +30,13 @@ FormaProcessor::FormaProcessor(Portal::Graphics::PrimitiveTopology topology)
 
 void FormaProcessor::set_bytes(std::vector<uint8_t> bytes)
 {
-    m_pending = std::move(bytes);
-    m_dirty.test_and_set(std::memory_order_release);
+    m_pending_geometry = std::move(bytes);
+    m_geometry_dirty.test_and_set(std::memory_order_release);
 }
 
 bool FormaProcessor::has_pending() const noexcept
 {
-    return m_dirty.test(std::memory_order_acquire);
+    return m_geometry_dirty.test(std::memory_order_acquire);
 }
 
 void FormaProcessor::on_attach(const std::shared_ptr<Buffer>& buffer)
@@ -70,17 +71,38 @@ void FormaProcessor::on_attach(const std::shared_ptr<Buffer>& buffer)
 void FormaProcessor::on_detach(const std::shared_ptr<Buffer>& /*buffer*/)
 {
     m_staging.reset();
-    m_pending.clear();
+    m_pending_geometry.clear();
     m_active.clear();
+}
+
+void FormaProcessor::set_texture(std::shared_ptr<Core::VKImage> image, std::string binding)
+{
+    m_pending_texture = PendingTexture { .image = std::move(image), .binding = std::move(binding) };
+    m_texture_dirty.test_and_set(std::memory_order_release);
 }
 
 void FormaProcessor::processing_function(const std::shared_ptr<Buffer>& buffer)
 {
-    if (!m_dirty.test(std::memory_order_acquire))
+    if (m_texture_dirty.test(std::memory_order_acquire)) {
+        m_texture_dirty.clear(std::memory_order_release);
+
+        auto vk = std::dynamic_pointer_cast<VKBuffer>(buffer);
+        if (vk) {
+            if (auto rp = vk->get_render_processor()) {
+                if (m_pending_texture) {
+                    rp->bind_texture(m_pending_texture->binding,
+                        m_pending_texture->image);
+                }
+            }
+        }
+        m_pending_texture.reset();
+    }
+
+    if (!m_geometry_dirty.test(std::memory_order_acquire))
         return;
 
-    m_dirty.clear(std::memory_order_release);
-    std::swap(m_active, m_pending);
+    m_geometry_dirty.clear(std::memory_order_release);
+    std::swap(m_active, m_pending_geometry);
 
     if (m_active.empty())
         return;

--- a/src/MayaFlux/Buffers/Forma/FormaProcessor.cpp
+++ b/src/MayaFlux/Buffers/Forma/FormaProcessor.cpp
@@ -1,0 +1,121 @@
+#include "FormaProcessor.hpp"
+
+#include "MayaFlux/Buffers/Staging/StagingUtils.hpp"
+#include "MayaFlux/Journal/Archivist.hpp"
+#include "MayaFlux/Nodes/Graphics/VertexSpec.hpp"
+
+namespace MayaFlux::Buffers {
+
+FormaProcessor::FormaProcessor(Portal::Graphics::PrimitiveTopology topology)
+    : m_topology(topology)
+{
+    m_processing_token = ProcessingToken::GRAPHICS_BACKEND;
+
+    switch (topology) {
+    case Portal::Graphics::PrimitiveTopology::POINT_LIST:
+        m_stride = sizeof(Nodes::PointVertex);
+        break;
+    case Portal::Graphics::PrimitiveTopology::LINE_LIST:
+    case Portal::Graphics::PrimitiveTopology::LINE_STRIP:
+        m_stride = sizeof(Nodes::LineVertex);
+        break;
+    case Portal::Graphics::PrimitiveTopology::TRIANGLE_LIST:
+    case Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP:
+    default:
+        m_stride = sizeof(Nodes::MeshVertex);
+        break;
+    }
+}
+
+void FormaProcessor::set_bytes(std::vector<uint8_t> bytes)
+{
+    m_pending = std::move(bytes);
+    m_dirty.test_and_set(std::memory_order_release);
+}
+
+bool FormaProcessor::has_pending() const noexcept
+{
+    return m_dirty.test(std::memory_order_acquire);
+}
+
+void FormaProcessor::on_attach(const std::shared_ptr<Buffer>& buffer)
+{
+    auto vk = std::dynamic_pointer_cast<VKBuffer>(buffer);
+    if (!vk) {
+        error<std::invalid_argument>(
+            Journal::Component::Buffers,
+            Journal::Context::BufferProcessing,
+            std::source_location::current(),
+            "FormaProcessor requires a VKBuffer");
+    }
+
+    m_staging = create_staging_buffer(vk->get_size_bytes());
+
+    switch (m_topology) {
+    case Portal::Graphics::PrimitiveTopology::POINT_LIST:
+        vk->set_vertex_layout(Kakshya::VertexLayout::for_points());
+        break;
+    case Portal::Graphics::PrimitiveTopology::LINE_LIST:
+    case Portal::Graphics::PrimitiveTopology::LINE_STRIP:
+        vk->set_vertex_layout(Kakshya::VertexLayout::for_lines());
+        break;
+    case Portal::Graphics::PrimitiveTopology::TRIANGLE_LIST:
+    case Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP:
+    default:
+        vk->set_vertex_layout(Kakshya::VertexLayout::for_meshes());
+        break;
+    }
+}
+
+void FormaProcessor::on_detach(const std::shared_ptr<Buffer>& /*buffer*/)
+{
+    m_staging.reset();
+    m_pending.clear();
+    m_active.clear();
+}
+
+void FormaProcessor::processing_function(const std::shared_ptr<Buffer>& buffer)
+{
+    if (!m_dirty.test(std::memory_order_acquire))
+        return;
+
+    m_dirty.clear(std::memory_order_release);
+    std::swap(m_active, m_pending);
+
+    if (m_active.empty())
+        return;
+
+    auto vk = std::dynamic_pointer_cast<VKBuffer>(buffer);
+    if (!vk)
+        return;
+
+    const size_t required = m_active.size();
+    const size_t available = vk->get_size_bytes();
+
+    if (required > available) {
+        vk->resize(static_cast<size_t>(required * 1.5F), false);
+        m_staging = create_staging_buffer(vk->get_size_bytes());
+    }
+
+    upload_to_gpu(
+        m_active.data(),
+        std::min(required, vk->get_size_bytes()),
+        vk,
+        m_staging);
+
+    auto layout = vk->get_vertex_layout();
+    if (layout) {
+        auto updated = *layout;
+        updated.vertex_count = vertex_count(m_active.size());
+        vk->set_vertex_layout(updated);
+    }
+}
+
+uint32_t FormaProcessor::vertex_count(size_t byte_count) const noexcept
+{
+    if (m_stride == 0)
+        return 0;
+    return static_cast<uint32_t>(byte_count / m_stride);
+}
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/Forma/FormaProcessor.cpp
+++ b/src/MayaFlux/Buffers/Forma/FormaProcessor.cpp
@@ -121,7 +121,7 @@ void FormaProcessor::processing_function(const std::shared_ptr<Buffer>& buffer)
 
     upload_to_gpu(
         m_active.data(),
-        std::min(required, vk->get_size_bytes()),
+        std::min<size_t>(required, vk->get_size_bytes()),
         vk,
         m_staging);
 

--- a/src/MayaFlux/Buffers/Forma/FormaProcessor.hpp
+++ b/src/MayaFlux/Buffers/Forma/FormaProcessor.hpp
@@ -39,18 +39,38 @@ public:
 
     [[nodiscard]] bool has_pending() const noexcept;
 
+    /**
+     * @brief Supply a texture to bind on the next graphics tick.
+     *
+     * Stores the image and binding name behind an atomic dirty flag.
+     * On the next processing_function call the image is bound to the
+     * RenderProcessor via bind_texture(). Calling again replaces the
+     * pending binding before it has been consumed.
+     *
+     * @param image   GPU image. nullptr clears the binding.
+     * @param binding Descriptor name matching the fragment shader.
+     */
+    void set_texture(std::shared_ptr<Core::VKImage> image, std::string binding);
+
 protected:
     void on_attach(const std::shared_ptr<Buffer>& buffer) override;
     void on_detach(const std::shared_ptr<Buffer>& buffer) override;
     void processing_function(const std::shared_ptr<Buffer>& buffer) override;
 
 private:
+    struct PendingTexture {
+        std::shared_ptr<Core::VKImage> image;
+        std::string binding;
+    };
+
     Portal::Graphics::PrimitiveTopology m_topology;
     uint32_t m_stride { 0 };
 
-    std::vector<uint8_t> m_pending;
+    std::vector<uint8_t> m_pending_geometry;
     std::vector<uint8_t> m_active;
-    std::atomic_flag m_dirty;
+    std::atomic_flag m_geometry_dirty;
+    std::optional<PendingTexture> m_pending_texture;
+    std::atomic_flag m_texture_dirty;
 
     std::shared_ptr<VKBuffer> m_staging;
 

--- a/src/MayaFlux/Buffers/Forma/FormaProcessor.hpp
+++ b/src/MayaFlux/Buffers/Forma/FormaProcessor.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "MayaFlux/Buffers/VKBuffer.hpp"
+#include "MayaFlux/Portal/Graphics/GraphicsUtils.hpp"
+
+namespace MayaFlux::Buffers {
+
+/**
+ * @class FormaProcessor
+ * @brief Default processor for FormaBuffer.
+ *
+ * Owns the CPU-to-GPU upload cycle for Forma geometry. Accepts raw
+ * interleaved vertex bytes via set_bytes(), stores them behind an
+ * atomic dirty flag, and uploads to the device-local buffer each
+ * graphics tick via a persistent staging buffer. Updates vertex_count
+ * in the buffer's VertexLayout after every upload so RenderProcessor
+ * draws the correct number of vertices.
+ *
+ * Mirrors GeometryWriteProcessor in structure. The topology is fixed
+ * at construction to derive the correct per-vertex stride for the
+ * vertex_count calculation.
+ */
+class MAYAFLUX_API FormaProcessor : public VKBufferProcessor {
+public:
+    explicit FormaProcessor(Portal::Graphics::PrimitiveTopology topology);
+    ~FormaProcessor() override = default;
+
+    /**
+     * @brief Supply new vertex bytes for the next graphics tick.
+     *
+     * Thread-safe via atomic_flag. Called from Mapped::sync() on the
+     * scheduler tick. The bytes are swapped into the active slot on the
+     * next processing_function call.
+     *
+     * @param bytes Raw interleaved vertex bytes matching the topology's
+     *              vertex type (PointVertex, LineVertex, or MeshVertex).
+     */
+    void set_bytes(std::vector<uint8_t> bytes);
+
+    [[nodiscard]] bool has_pending() const noexcept;
+
+protected:
+    void on_attach(const std::shared_ptr<Buffer>& buffer) override;
+    void on_detach(const std::shared_ptr<Buffer>& buffer) override;
+    void processing_function(const std::shared_ptr<Buffer>& buffer) override;
+
+private:
+    Portal::Graphics::PrimitiveTopology m_topology;
+    uint32_t m_stride { 0 };
+
+    std::vector<uint8_t> m_pending;
+    std::vector<uint8_t> m_active;
+    std::atomic_flag m_dirty;
+
+    std::shared_ptr<VKBuffer> m_staging;
+
+    [[nodiscard]] uint32_t vertex_count(size_t byte_count) const noexcept;
+};
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Core/Engine.cpp
+++ b/src/MayaFlux/Core/Engine.cpp
@@ -9,6 +9,8 @@
 #include "MayaFlux/Vruta/EventManager.hpp"
 #include "MayaFlux/Vruta/Scheduler.hpp"
 
+#include "MayaFlux/Portal/Forma/Forma.hpp"
+
 #include "MayaFlux/Journal/Archivist.hpp"
 
 #ifdef MAYAFLUX_PLATFORM_MACOS
@@ -155,6 +157,7 @@ void Engine::Start()
         Init();
     }
     m_subsystem_manager->start_all_subsystems();
+    Portal::Forma::initialize(m_buffer_manager, m_scheduler, m_event_manager);
 }
 
 void Engine::Pause()
@@ -316,6 +319,8 @@ void Engine::End()
 {
     if (!m_is_initialized)
         return;
+
+    Portal::Forma::shutdown();
 
     if (m_node_graph_manager) {
         m_node_graph_manager->terminate_active_processing();

--- a/src/MayaFlux/Kinesis/Spatial/Bounds.hpp
+++ b/src/MayaFlux/Kinesis/Spatial/Bounds.hpp
@@ -1,0 +1,235 @@
+#pragma once
+
+#include <glm/geometric.hpp>
+#include <glm/vec2.hpp>
+
+namespace MayaFlux::Kinesis {
+
+// =============================================================================
+// AABB2D
+// =============================================================================
+
+/**
+ * @struct AABB2D
+ * @brief Axis-aligned bounding rectangle in a 2D coordinate space.
+ *
+ * Used as a fast-reject hint in Portal::Forma::Element. All coordinates
+ * are in NDC by convention when used in Forma: x and y in [-1, +1],
+ * center origin, +Y up, matching ViewTransform.hpp and Windowing.hpp.
+ *
+ * Named constructors convert from other coordinate spaces into NDC.
+ */
+struct AABB2D {
+    glm::vec2 min;
+    glm::vec2 max;
+
+    [[nodiscard]] bool contains(glm::vec2 p) const noexcept
+    {
+        return p.x >= min.x && p.x <= max.x
+            && p.y >= min.y && p.y <= max.y;
+    }
+
+    [[nodiscard]] bool overlaps(const AABB2D& other) const noexcept
+    {
+        return min.x <= other.max.x && max.x >= other.min.x
+            && min.y <= other.max.y && max.y >= other.min.y;
+    }
+
+    [[nodiscard]] float width() const noexcept { return max.x - min.x; }
+    [[nodiscard]] float height() const noexcept { return max.y - min.y; }
+
+    [[nodiscard]] glm::vec2 center() const noexcept { return (min + max) * 0.5F; }
+
+    [[nodiscard]] AABB2D translated(glm::vec2 offset) const noexcept
+    {
+        return { .min = min + offset, .max = max + offset };
+    }
+
+    [[nodiscard]] AABB2D expanded(float margin) const noexcept
+    {
+        return { .min = min - glm::vec2(margin), .max = max + glm::vec2(margin) };
+    }
+
+    [[nodiscard]] static AABB2D from_ndc(glm::vec2 center, glm::vec2 half) noexcept
+    {
+        return { .min = center - half, .max = center + half };
+    }
+
+    /**
+     * @brief Construct from pixel-space top-left rect, converted to NDC.
+     * @param x     Left edge in pixels.
+     * @param y     Top edge in pixels (top-left origin, +Y down).
+     * @param w     Width in pixels.
+     * @param h     Height in pixels.
+     * @param win_w Window width in pixels.
+     * @param win_h Window height in pixels.
+     */
+    [[nodiscard]] static AABB2D from_pixel(
+        float x, float y, float w, float h,
+        uint32_t win_w, uint32_t win_h) noexcept
+    {
+        auto nx = [&](float px) {
+            return (px / static_cast<float>(win_w)) * 2.0F - 1.0F;
+        };
+        auto ny = [&](float py) {
+            return 1.0F - (py / static_cast<float>(win_h)) * 2.0F;
+        };
+        return { .min = glm::vec2(nx(x), ny(y + h)), .max = glm::vec2(nx(x + w), ny(y)) };
+    }
+
+    /**
+     * @brief Construct from a TextureBuffer NDC position and scale.
+     * @param ndc_position Center as returned by TextureBuffer::get_position().
+     * @param ndc_scale    Extent as returned by TextureBuffer::get_scale().
+     */
+    [[nodiscard]] static AABB2D from_buffer_transform(
+        glm::vec2 ndc_position, glm::vec2 ndc_scale) noexcept
+    {
+        glm::vec2 half = ndc_scale * 0.5F;
+        return { .min = ndc_position - half, .max = ndc_position + half };
+    }
+};
+
+// =============================================================================
+// Containment callables
+// All functions return std::function<bool(glm::vec2)> suitable for
+// direct assignment to Portal::Forma::Element::contains.
+// =============================================================================
+
+/**
+ * @brief Containment test for a circle.
+ * @param center NDC center.
+ * @param radius Radius in NDC units.
+ */
+[[nodiscard]] inline std::function<bool(glm::vec2)>
+circular_bounds(glm::vec2 center, float radius) noexcept
+{
+    float r2 = radius * radius;
+    return [center, r2](glm::vec2 p) {
+        glm::vec2 d = p - center;
+        return d.x * d.x + d.y * d.y <= r2;
+    };
+}
+
+/**
+ * @brief Containment test for a convex or concave polygon.
+ *
+ * Uses the winding number algorithm, which handles both convex and
+ * non-convex polygons correctly. Vertices are in NDC, ordered either
+ * clockwise or counter-clockwise.
+ *
+ * @param vertices Polygon vertices. Copied into the closure.
+ */
+[[nodiscard]] inline std::function<bool(glm::vec2)>
+polygon_bounds(std::span<const glm::vec2> vertices)
+{
+    std::vector<glm::vec2> verts(vertices.begin(), vertices.end());
+    return [verts = std::move(verts)](glm::vec2 p) {
+        int winding = 0;
+        size_t n = verts.size();
+        for (size_t i = 0; i < n; ++i) {
+            glm::vec2 a = verts[i];
+            glm::vec2 b = verts[(i + 1) % n];
+            if (a.y <= p.y) {
+                if (b.y > p.y) {
+                    float cross = (b.x - a.x) * (p.y - a.y)
+                        - (b.y - a.y) * (p.x - a.x);
+                    if (cross > 0.0F)
+                        ++winding;
+                }
+            } else {
+                if (b.y <= p.y) {
+                    float cross = (b.x - a.x) * (p.y - a.y)
+                        - (b.y - a.y) * (p.x - a.x);
+                    if (cross < 0.0F)
+                        --winding;
+                }
+            }
+        }
+        return winding != 0;
+    };
+}
+
+/**
+ * @brief Containment test for a polyline with a uniform half-thickness.
+ *
+ * Covers open and closed curves equally. A point is inside if its
+ * perpendicular distance to any segment is within @p half_thickness.
+ * Suitable for stroke-based interactive regions and cable hit testing.
+ *
+ * @param points        Ordered polyline vertices in NDC.
+ * @param half_thickness Distance threshold in NDC units.
+ */
+[[nodiscard]] inline std::function<bool(glm::vec2)>
+stroke_bounds(std::span<const glm::vec2> points, float half_thickness)
+{
+    std::vector<glm::vec2> pts(points.begin(), points.end());
+    float t2 = half_thickness * half_thickness;
+    return [pts = std::move(pts), t2](glm::vec2 p) {
+        for (size_t i = 0; i + 1 < pts.size(); ++i) {
+            glm::vec2 a = pts[i];
+            glm::vec2 b = pts[i + 1];
+            glm::vec2 ab = b - a;
+            float len2 = glm::dot(ab, ab);
+            float d2 = 0.0F;
+            if (len2 < 1e-12F) {
+                glm::vec2 ap = p - a;
+                d2 = glm::dot(ap, ap);
+            } else {
+                float t = glm::clamp(glm::dot(p - a, ab) / len2, 0.0F, 1.0F);
+                glm::vec2 proj = a + t * ab;
+                glm::vec2 diff = p - proj;
+                d2 = glm::dot(diff, diff);
+            }
+            if (d2 <= t2)
+                return true;
+        }
+        return false;
+    };
+}
+
+// =============================================================================
+// Combinators
+// =============================================================================
+
+/**
+ * @brief Union of two containment tests. Point is inside if either returns true.
+ */
+[[nodiscard]] inline std::function<bool(glm::vec2)>
+union_bounds(
+    std::function<bool(glm::vec2)> a,
+    std::function<bool(glm::vec2)> b)
+{
+    return [a = std::move(a), b = std::move(b)](glm::vec2 p) {
+        return a(p) || b(p);
+    };
+}
+
+/**
+ * @brief Intersection of two containment tests. Point is inside only if both return true.
+ */
+[[nodiscard]] inline std::function<bool(glm::vec2)>
+intersect_bounds(
+    std::function<bool(glm::vec2)> a,
+    std::function<bool(glm::vec2)> b)
+{
+    return [a = std::move(a), b = std::move(b)](glm::vec2 p) {
+        return a(p) && b(p);
+    };
+}
+
+/**
+ * @brief Difference of two containment tests. Point is inside if @p a is true and @p b is false.
+ *        Useful for donuts, cutouts, and exclusion zones.
+ */
+[[nodiscard]] inline std::function<bool(glm::vec2)>
+subtract_bounds(
+    std::function<bool(glm::vec2)> a,
+    std::function<bool(glm::vec2)> b)
+{
+    return [a = std::move(a), b = std::move(b)](glm::vec2 p) {
+        return a(p) && !b(p);
+    };
+}
+
+} // namespace MayaFlux::Kinesis

--- a/src/MayaFlux/MayaFlux.hpp
+++ b/src/MayaFlux/MayaFlux.hpp
@@ -74,6 +74,7 @@
 #include "Buffers/Container/SoundContainerBuffer.hpp"
 #include "Buffers/Container/SoundStreamWriter.hpp"
 #include "Buffers/Container/VideoContainerBuffer.hpp"
+#include "Buffers/Forma/FormaBuffer.hpp"
 #include "Buffers/Geometry/GeometryBuffer.hpp"
 #include "Buffers/Geometry/GeometryWriteProcessor.hpp"
 #include "Buffers/Geometry/MeshBuffer.hpp"
@@ -97,6 +98,7 @@
 #include "Buffers/Textures/NodeTextureBuffer.hpp"
 #include "Buffers/Textures/TextureBuffer.hpp"
 #include "Buffers/Textures/TextureWriteProcessor.hpp"
+#include "MayaFlux/Buffers/Forma/FormaBindingsProcessor.hpp"
 
 #include "Kriya/Awaiters/DelayAwaiters.hpp"
 #include "Kriya/Awaiters/EventAwaiter.hpp"
@@ -139,6 +141,9 @@
 
 #include "Portal/Text/InkPress.hpp"
 #include "Portal/Text/Text.hpp"
+
+#include "Portal/Forma/Forma.hpp"
+#include "Portal/Forma/Primitives/Geometry.hpp"
 
 #include "IO/IOManager.hpp"
 #include "IO/ImageReader.hpp"

--- a/src/MayaFlux/Portal/Forma/Bridge.cpp
+++ b/src/MayaFlux/Portal/Forma/Bridge.cpp
@@ -95,30 +95,25 @@ void Bridge::spawn_inbound(uint32_t id, std::function<float()> source)
 
 void Bridge::write(
     uint32_t id,
-    std::shared_ptr<Buffers::ShaderProcessor> target,
+    const std::shared_ptr<Buffers::VKBuffer>& target_buffer,
+    const std::string& shader_path,
     uint32_t offset,
     size_t size)
 {
     auto it = m_records.find(id);
-    if (it == m_records.end()) {
-        MF_ERROR(Journal::Component::Portal, Journal::Context::Init,
-            "Bridge::write: unknown element id {}", id);
+    if (it == m_records.end())
         return;
-    }
 
     auto& rec = it->second;
     if (!rec.bindings) {
-        rec.bindings = std::make_shared<Buffers::FormaBindingsProcessor>(
-            target->get_shader_path());
-        m_buffer_manager.add_processor(
-            rec.bindings, rec.buffer,
+        rec.bindings = std::make_shared<Buffers::FormaBindingsProcessor>(shader_path);
+        m_buffer_manager.add_processor(rec.bindings, target_buffer,
             Buffers::ProcessingToken::GRAPHICS_BACKEND);
     }
 
     rec.bindings->bind_push_constant(
         std::to_string(id) + "_pc_" + std::to_string(offset),
         rec.reader,
-        std::move(target),
         offset, size);
 }
 

--- a/src/MayaFlux/Portal/Forma/Bridge.cpp
+++ b/src/MayaFlux/Portal/Forma/Bridge.cpp
@@ -119,6 +119,8 @@ void Bridge::write(
 
 void Bridge::write(
     uint32_t id,
+    const std::shared_ptr<Buffers::VKBuffer>& target_buffer,
+    const std::string& shader_path,
     const std::string& descriptor_name,
     uint32_t binding_index,
     uint32_t set,
@@ -133,10 +135,9 @@ void Bridge::write(
 
     auto& rec = it->second;
     if (!rec.bindings) {
-        MF_ERROR(Journal::Component::Portal, Journal::Context::Init,
-            "Bridge::write(descriptor): attach a ShaderProcessor binding first "
-            "so the FormaBindingsProcessor has a shader path");
-        return;
+        rec.bindings = std::make_shared<Buffers::FormaBindingsProcessor>(shader_path);
+        m_buffer_manager.add_processor(rec.bindings, target_buffer,
+            Buffers::ProcessingToken::GRAPHICS_BACKEND);
     }
 
     rec.bindings->bind_descriptor(

--- a/src/MayaFlux/Portal/Forma/Bridge.cpp
+++ b/src/MayaFlux/Portal/Forma/Bridge.cpp
@@ -262,27 +262,6 @@ void Bridge::unbind(uint32_t id)
 // Private
 // =============================================================================
 
-uint32_t Bridge::get_id(const void* state_ptr) const
-{
-    if (!state_ptr) {
-        error<std::invalid_argument>(
-            Journal::Component::Portal, Journal::Context::Init,
-            std::source_location::current(),
-            "Bridge: null MappedState pointer");
-    }
-
-    const auto* id_ptr = static_cast<const uint32_t*>(state_ptr);
-
-    if (*id_ptr == 0) {
-        error<std::out_of_range>(
-            Journal::Component::Portal, Journal::Context::Init,
-            std::source_location::current(),
-            "Bridge: MappedState not registered — call register_element()");
-    }
-
-    return *id_ptr;
-}
-
 std::string Bridge::make_task_name(uint32_t id, const char* suffix) const
 {
     return "forma_bridge_" + std::to_string(id) + "_" + suffix

--- a/src/MayaFlux/Portal/Forma/Bridge.cpp
+++ b/src/MayaFlux/Portal/Forma/Bridge.cpp
@@ -1,0 +1,308 @@
+#include "Bridge.hpp"
+
+#include "MayaFlux/Buffers/BufferManager.hpp"
+#include "MayaFlux/Buffers/Forma/FormaBindingsProcessor.hpp"
+#include "MayaFlux/Buffers/Geometry/GeometryWriteProcessor.hpp"
+#include "MayaFlux/Buffers/Staging/AudioWriteProcessor.hpp"
+
+#include "MayaFlux/Kriya/Awaiters/DelayAwaiters.hpp"
+#include "MayaFlux/Kriya/Awaiters/GetPromise.hpp"
+#include "MayaFlux/Vruta/Scheduler.hpp"
+
+#include "MayaFlux/Nodes/Conduit/Constant.hpp"
+
+#include "MayaFlux/Journal/Archivist.hpp"
+
+namespace MayaFlux::Portal::Forma {
+
+Bridge::Bridge(
+    Vruta::TaskScheduler& scheduler,
+    Buffers::BufferManager& buffer_manager)
+    : m_scheduler(scheduler)
+    , m_buffer_manager(buffer_manager)
+{
+}
+
+Bridge::~Bridge()
+{
+    for (auto& [id, rec] : m_records) {
+        cancel_inbound(rec);
+        cancel_outbound(rec);
+    }
+}
+
+// =============================================================================
+// Inbound
+// =============================================================================
+
+void Bridge::bind(
+    uint32_t id,
+    std::shared_ptr<Nodes::Node> node,
+    std::function<float(double)> project)
+{
+    auto reader = project
+        ? std::function<float()>([n = std::move(node), p = std::move(project)] {
+              return p(n->get_last_output());
+          })
+        : std::function<float()>([n = std::move(node)] {
+              return static_cast<float>(n->get_last_output());
+          });
+
+    spawn_inbound(id, std::move(reader));
+}
+
+void Bridge::bind(uint32_t id, std::function<float()> source)
+{
+    spawn_inbound(id, std::move(source));
+}
+
+void Bridge::spawn_inbound(uint32_t id, std::function<float()> source)
+{
+    auto it = m_records.find(id);
+    if (it == m_records.end()) {
+        MF_ERROR(Journal::Component::Portal, Journal::Context::Init,
+            "Bridge::bind: unknown element id {}", id);
+        return;
+    }
+
+    cancel_inbound(it->second);
+
+    auto name = make_task_name(id, "inbound");
+    it->second.inbound_task = name;
+
+    auto& rec = it->second;
+    auto writer = rec.writer;
+
+    auto routine = [](Vruta::TaskScheduler&,
+                       std::function<float()> src,
+                       std::function<void(float)> write) -> Vruta::GraphicsRoutine {
+        auto& p = co_await Kriya::GetGraphicsPromise {};
+        while (!p.should_terminate) {
+            write(src());
+            co_await Kriya::FrameDelay { .frames_to_wait = 1 };
+        }
+    };
+
+    m_scheduler.add_task(
+        std::make_shared<Vruta::GraphicsRoutine>(
+            routine(m_scheduler, std::move(source), std::move(writer))),
+        name, false);
+}
+
+// =============================================================================
+// Outbound
+// =============================================================================
+
+void Bridge::write(
+    uint32_t id,
+    std::shared_ptr<Buffers::ShaderProcessor> target,
+    uint32_t offset,
+    size_t size)
+{
+    auto it = m_records.find(id);
+    if (it == m_records.end()) {
+        MF_ERROR(Journal::Component::Portal, Journal::Context::Init,
+            "Bridge::write: unknown element id {}", id);
+        return;
+    }
+
+    auto& rec = it->second;
+    if (!rec.bindings) {
+        rec.bindings = std::make_shared<Buffers::FormaBindingsProcessor>(
+            target->get_shader_path());
+        m_buffer_manager.add_processor(
+            rec.bindings, rec.buffer,
+            Buffers::ProcessingToken::GRAPHICS_BACKEND);
+    }
+
+    rec.bindings->bind_push_constant(
+        std::to_string(id) + "_pc_" + std::to_string(offset),
+        rec.reader,
+        std::move(target),
+        offset, size);
+}
+
+void Bridge::write(
+    uint32_t id,
+    const std::string& descriptor_name,
+    uint32_t binding_index,
+    uint32_t set,
+    Portal::Graphics::DescriptorRole role)
+{
+    auto it = m_records.find(id);
+    if (it == m_records.end()) {
+        MF_ERROR(Journal::Component::Portal, Journal::Context::Init,
+            "Bridge::write: unknown element id {}", id);
+        return;
+    }
+
+    auto& rec = it->second;
+    if (!rec.bindings) {
+        MF_ERROR(Journal::Component::Portal, Journal::Context::Init,
+            "Bridge::write(descriptor): attach a ShaderProcessor binding first "
+            "so the FormaBindingsProcessor has a shader path");
+        return;
+    }
+
+    rec.bindings->bind_descriptor(
+        descriptor_name + "_" + std::to_string(id),
+        rec.reader,
+        descriptor_name,
+        binding_index, set, role);
+}
+
+void Bridge::write(uint32_t id, std::shared_ptr<Buffers::AudioWriteProcessor> target)
+{
+    auto it = m_records.find(id);
+    if (it == m_records.end()) {
+        MF_ERROR(Journal::Component::Portal, Journal::Context::Init,
+            "Bridge::write: unknown element id {}", id);
+        return;
+    }
+
+    auto name = make_task_name(id, "audio");
+    it->second.outbound_tasks.push_back(name);
+
+    auto reader = it->second.reader;
+
+    auto routine = [](Vruta::TaskScheduler&,
+                       std::function<float()> r,
+                       std::shared_ptr<Buffers::AudioWriteProcessor> proc)
+        -> Vruta::GraphicsRoutine {
+        auto& p = co_await Kriya::GetGraphicsPromise {};
+        while (!p.should_terminate) {
+            proc->set_data(std::vector<double> { static_cast<double>(r()) });
+            co_await Kriya::FrameDelay { .frames_to_wait = 1 };
+        }
+    };
+
+    m_scheduler.add_task(
+        std::make_shared<Vruta::GraphicsRoutine>(
+            routine(m_scheduler, std::move(reader), std::move(target))),
+        name, false);
+}
+
+void Bridge::write(uint32_t id, std::shared_ptr<Buffers::GeometryWriteProcessor> target)
+{
+    auto it = m_records.find(id);
+    if (it == m_records.end()) {
+        MF_ERROR(Journal::Component::Portal, Journal::Context::Init,
+            "Bridge::write: unknown element id {}", id);
+        return;
+    }
+
+    auto name = make_task_name(id, "geometry");
+    it->second.outbound_tasks.push_back(name);
+
+    auto reader = it->second.reader;
+
+    auto routine = [](Vruta::TaskScheduler&,
+                       std::function<float()> r,
+                       std::shared_ptr<Buffers::GeometryWriteProcessor> proc)
+        -> Vruta::GraphicsRoutine {
+        auto& p = co_await Kriya::GetGraphicsPromise {};
+        while (!p.should_terminate) {
+            proc->set_data(Kakshya::DataVariant { std::vector<float> { r() } });
+            co_await Kriya::FrameDelay { .frames_to_wait = 1 };
+        }
+    };
+
+    m_scheduler.add_task(
+        std::make_shared<Vruta::GraphicsRoutine>(
+            routine(m_scheduler, std::move(reader), std::move(target))),
+        name, false);
+}
+
+void Bridge::write(uint32_t id, std::shared_ptr<Nodes::Constant> node)
+{
+    auto it = m_records.find(id);
+    if (it == m_records.end()) {
+        MF_ERROR(Journal::Component::Portal, Journal::Context::Init,
+            "Bridge::write: unknown element id {}", id);
+        return;
+    }
+
+    auto name = make_task_name(id, "constant");
+    it->second.outbound_tasks.push_back(name);
+
+    auto reader = it->second.reader;
+
+    auto routine = [](Vruta::TaskScheduler&,
+                       std::function<float()> r,
+                       std::shared_ptr<Nodes::Constant> n)
+        -> Vruta::GraphicsRoutine {
+        auto& p = co_await Kriya::GetGraphicsPromise {};
+        while (!p.should_terminate) {
+            n->set_constant(static_cast<double>(r()));
+            co_await Kriya::FrameDelay { .frames_to_wait = 1 };
+        }
+    };
+
+    m_scheduler.add_task(
+        std::make_shared<Vruta::GraphicsRoutine>(
+            routine(m_scheduler, std::move(reader), std::move(node))),
+        name, false);
+}
+
+// =============================================================================
+// Lifecycle
+// =============================================================================
+
+void Bridge::unbind(uint32_t id)
+{
+    auto it = m_records.find(id);
+    if (it == m_records.end())
+        return;
+
+    cancel_inbound(it->second);
+    cancel_outbound(it->second);
+}
+
+// =============================================================================
+// Private
+// =============================================================================
+
+uint32_t Bridge::get_id(const void* state_ptr) const
+{
+    if (!state_ptr) {
+        error<std::invalid_argument>(
+            Journal::Component::Portal, Journal::Context::Init,
+            std::source_location::current(),
+            "Bridge: null MappedState pointer");
+    }
+
+    const auto* id_ptr = static_cast<const uint32_t*>(state_ptr);
+
+    if (*id_ptr == 0) {
+        error<std::out_of_range>(
+            Journal::Component::Portal, Journal::Context::Init,
+            std::source_location::current(),
+            "Bridge: MappedState not registered — call register_element()");
+    }
+
+    return *id_ptr;
+}
+
+std::string Bridge::make_task_name(uint32_t id, const char* suffix) const
+{
+    return "forma_bridge_" + std::to_string(id) + "_" + suffix
+        + "_" + std::to_string(m_next_id++);
+}
+
+void Bridge::cancel_inbound(ElementRecord& rec)
+{
+    if (!rec.inbound_task.empty()) {
+        m_scheduler.cancel_task(rec.inbound_task);
+        rec.inbound_task.clear();
+    }
+}
+
+void Bridge::cancel_outbound(ElementRecord& rec)
+{
+    for (const auto& name : rec.outbound_tasks) {
+        m_scheduler.cancel_task(name);
+    }
+    rec.outbound_tasks.clear();
+}
+
+} // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Bridge.cpp
+++ b/src/MayaFlux/Portal/Forma/Bridge.cpp
@@ -284,4 +284,24 @@ void Bridge::cancel_outbound(ElementRecord& rec)
     rec.outbound_tasks.clear();
 }
 
+void Bridge::spawn_sync(uint32_t id, std::function<void()> sync_fn)
+{
+    auto name = make_task_name(id, "sync");
+    m_records[id].outbound_tasks.push_back(name);
+
+    auto routine = [](Vruta::TaskScheduler&,
+                       std::function<void()> fn) -> Vruta::GraphicsRoutine {
+        auto& p = co_await Kriya::GetGraphicsPromise {};
+        while (!p.should_terminate) {
+            fn();
+            co_await Kriya::FrameDelay { .frames_to_wait = 1 };
+        }
+    };
+
+    m_scheduler.add_task(
+        std::make_shared<Vruta::GraphicsRoutine>(
+            routine(m_scheduler, std::move(sync_fn))),
+        name, false);
+}
+
 } // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Bridge.hpp
+++ b/src/MayaFlux/Portal/Forma/Bridge.hpp
@@ -1,0 +1,309 @@
+#pragma once
+
+#include "Primitives/Mapped.hpp"
+
+namespace MayaFlux::Core {
+class Window;
+}
+
+namespace MayaFlux::Vruta {
+class TaskScheduler;
+}
+
+namespace MayaFlux::Buffers {
+class BufferManager;
+class ShaderProcessor;
+class AudioWriteProcessor;
+class GeometryWriteProcessor;
+class FormaBindingsProcessor;
+}
+
+namespace MayaFlux::Nodes {
+class Node;
+class Constant;
+}
+
+namespace MayaFlux::Portal::Forma {
+
+/**
+ * @class Bridge
+ * @brief Two-way binding orchestrator for Forma elements.
+ *
+ * One Bridge instance serves the full application. It owns all inbound
+ * GraphicsRoutine tasks and all outbound FormaBindingsProcessor instances.
+ * Layer and Context are created via the Forma free functions and passed in
+ * — Bridge does not own or create them.
+ *
+ * Inbound (what drives an element's MappedState each frame):
+ *   - bind(id, Node)     — reads Node::get_last_output() via GraphicsRoutine
+ *   - bind(id, lambda)   — calls std::function<float()> via GraphicsRoutine
+ *
+ * Outbound (where the element's value goes each frame):
+ *   - write(id, ShaderProcessor, offset) — push constant staging
+ *   - write(id, descriptor_name, ...)    — descriptor binding
+ *   - write(id, AudioWriteProcessor)     — audio buffer
+ *   - write(id, GeometryWriteProcessor)  — vertex buffer
+ *   - write(id, Constant)                — node graph value carrier
+ *
+ * All overloads also accept shared_ptr<MappedState<T>> in place of the
+ * element id. These resolve to the id via get_id() and forward — no
+ * duplicated logic.
+ *
+ * Usage:
+ * @code
+ * auto [layer, ctx] = Forma::create_layer(window, "hud", event_manager);
+ * auto el = Forma::create_element<float>(*layer, window, bm, geom, 0.5f);
+ *
+ * Bridge bridge(scheduler, buffer_manager);
+ * bridge.bind(el.state, envelope);
+ * bridge.write(el.state, compute_proc, offsetof(PC, cutoff));
+ *
+ * ctx->on_press(el.element.id, IO::MouseButtons::LEFT,
+ *     [](uint32_t, glm::vec2){});
+ * @endcode
+ */
+class MAYAFLUX_API Bridge {
+public:
+    Bridge(
+        Vruta::TaskScheduler& scheduler,
+        Buffers::BufferManager& buffer_manager);
+
+    ~Bridge();
+
+    Bridge(const Bridge&) = delete;
+    Bridge& operator=(const Bridge&) = delete;
+    Bridge(Bridge&&) = delete;
+    Bridge& operator=(Bridge&&) = delete;
+
+    // =========================================================================
+    // Inbound — id overloads (primary implementation)
+    // =========================================================================
+
+    /**
+     * @brief Drive element value from a Node's output each frame.
+     *
+     * Spawns a GraphicsRoutine that reads node->get_last_output() every tick,
+     * applies @p project, and writes into the element's MappedState.
+     * Node must be processed externally (EXTERNAL mode read).
+     * Replaces any existing inbound binding on this element.
+     *
+     * @param id      Element id (from Layer::add / Mapped::element.id).
+     * @param node    Node to read from.
+     * @param project Optional double -> float projection. Identity if empty.
+     */
+    void bind(uint32_t id,
+        std::shared_ptr<Nodes::Node> node,
+        std::function<float(double)> project = {});
+
+    /**
+     * @brief Drive element value from an arbitrary per-frame callable.
+     *
+     * Spawns a GraphicsRoutine that calls @p source every tick and writes
+     * the result into the element's MappedState.
+     * Replaces any existing inbound binding on this element.
+     *
+     * @param id     Element id.
+     * @param source Callable returning current float value.
+     */
+    void bind(uint32_t id, std::function<float()> source);
+
+    // =========================================================================
+    // Inbound — MappedState overloads
+    // =========================================================================
+
+    template <typename T>
+    void bind(std::shared_ptr<MappedState<T>> state,
+        std::shared_ptr<Nodes::Node> node,
+        std::function<float(double)> project = {})
+    {
+        bind(get_id(state.get()), std::move(node), std::move(project));
+    }
+
+    template <typename T>
+    void bind(std::shared_ptr<MappedState<T>> state, std::function<float()> source)
+    {
+        bind(get_id(state.get()), std::move(source));
+    }
+
+    // =========================================================================
+    // Outbound — id overloads (primary implementation)
+    // =========================================================================
+
+    /**
+     * @brief Route element value to a push constant slot on a ShaderProcessor.
+     * @param id     Element id.
+     * @param target ShaderProcessor whose push_constant_data receives the value.
+     * @param offset Byte offset in the push constant struct.
+     * @param size   Byte width. Defaults to sizeof(float).
+     */
+    void write(uint32_t id,
+        std::shared_ptr<Buffers::ShaderProcessor> target,
+        uint32_t offset,
+        size_t size = sizeof(float));
+
+    /**
+     * @brief Route element value to a descriptor binding.
+     * @param id              Element id.
+     * @param descriptor_name Descriptor name in the shader config.
+     * @param binding_index   Vulkan binding index.
+     * @param set             Descriptor set index.
+     * @param role            UNIFORM or STORAGE.
+     */
+    void write(uint32_t id,
+        const std::string& descriptor_name,
+        uint32_t binding_index,
+        uint32_t set,
+        Portal::Graphics::DescriptorRole role = Portal::Graphics::DescriptorRole::UNIFORM);
+
+    /**
+     * @brief Route element value to an AudioWriteProcessor each frame.
+     * @param id     Element id.
+     * @param target AudioWriteProcessor to call set_data() on.
+     */
+    void write(uint32_t id, std::shared_ptr<Buffers::AudioWriteProcessor> target);
+
+    /**
+     * @brief Route element value to a GeometryWriteProcessor each frame.
+     * @param id     Element id.
+     * @param target GeometryWriteProcessor to call set_data() on.
+     */
+    void write(uint32_t id, std::shared_ptr<Buffers::GeometryWriteProcessor> target);
+
+    /**
+     * @brief Route element value into a Constant node via set_constant().
+     * @param id   Element id.
+     * @param node Constant node updated each frame.
+     */
+    void write(uint32_t id, std::shared_ptr<Nodes::Constant> node);
+
+    // =========================================================================
+    // Outbound — MappedState overloads
+    // =========================================================================
+
+    template <typename T>
+    void write(std::shared_ptr<MappedState<T>> state,
+        std::shared_ptr<Buffers::ShaderProcessor> target,
+        uint32_t offset, size_t size = sizeof(float))
+    {
+        write(get_id(state.get()), std::move(target), offset, size);
+    }
+
+    template <typename T>
+    void write(std::shared_ptr<MappedState<T>> state,
+        const std::string& descriptor_name,
+        uint32_t binding_index, uint32_t set,
+        Portal::Graphics::DescriptorRole role = Portal::Graphics::DescriptorRole::UNIFORM)
+    {
+        write(get_id(state.get()), descriptor_name, binding_index, set, role);
+    }
+
+    template <typename T>
+    void write(std::shared_ptr<MappedState<T>> state,
+        std::shared_ptr<Buffers::AudioWriteProcessor> target)
+    {
+        write(get_id(state.get()), std::move(target));
+    }
+
+    template <typename T>
+    void write(std::shared_ptr<MappedState<T>> state,
+        std::shared_ptr<Buffers::GeometryWriteProcessor> target)
+    {
+        write(get_id(state.get()), std::move(target));
+    }
+
+    template <typename T>
+    void write(std::shared_ptr<MappedState<T>> state,
+        std::shared_ptr<Nodes::Constant> node)
+    {
+        write(get_id(state.get()), std::move(node));
+    }
+
+    // =========================================================================
+    // Registration — called by Forma::create_element to make state findable
+    // =========================================================================
+
+    /**
+     * @brief Register a MappedState<T> so that MappedState overloads and
+     *        outbound bindings can resolve to the correct element id and reader.
+     *
+     * Called by Forma::create_element. The reader closes over the MappedState
+     * and is stored type-erased as std::function<float()>.
+     *
+     * @tparam T        MappedState value type.
+     * @param state     MappedState to register.
+     * @param id        Element id from Layer::add.
+     * @param buffer    FormaBuffer the element renders into.
+     * @param project   Optional T -> float projection. Identity cast if empty.
+     */
+    template <typename T>
+    void register_element(
+        std::shared_ptr<MappedState<T>> state,
+        uint32_t id,
+        std::shared_ptr<Buffers::FormaBuffer> buffer,
+        std::function<float(T)> project = {})
+    {
+        std::function<float()> reader = project
+            ? std::function<float()>([s = state, p = std::move(project)] {
+                  return p(s->value);
+              })
+            : std::function<float()>([s = state] {
+                  return static_cast<float>(s->value);
+              });
+
+        std::function<void(float)> writer = [s = state](float v) {
+            s->write(static_cast<T>(v));
+        };
+
+        state->id = id;
+        m_records[id] = ElementRecord {
+            .buffer = std::move(buffer),
+            .bindings = nullptr,
+            .reader = std::move(reader),
+            .writer = std::move(writer),
+            .inbound_task = {},
+            .outbound_tasks = {},
+        };
+    }
+
+    // =========================================================================
+    // Binding lifecycle
+    // =========================================================================
+
+    /**
+     * @brief Cancel all inbound and outbound bindings for an element.
+     *        The element remains in its layer.
+     */
+    void unbind(uint32_t id);
+
+    template <typename T>
+    void unbind(std::shared_ptr<MappedState<T>> state)
+    {
+        unbind(get_id(state.get()));
+    }
+
+private:
+    struct ElementRecord {
+        std::shared_ptr<Buffers::FormaBuffer> buffer;
+        std::shared_ptr<Buffers::FormaBindingsProcessor> bindings;
+        std::function<float()> reader; ///< reads current value from MappedState (outbound)
+        std::function<void(float)> writer; ///< writes new value into MappedState (inbound)
+        std::string inbound_task;
+        std::vector<std::string> outbound_tasks;
+    };
+
+    Vruta::TaskScheduler& m_scheduler;
+    Buffers::BufferManager& m_buffer_manager;
+
+    mutable uint32_t m_next_id { 0 };
+
+    std::unordered_map<uint32_t, ElementRecord> m_records;
+
+    [[nodiscard]] uint32_t get_id(const void* state_ptr) const;
+
+    std::string make_task_name(uint32_t id, const char* suffix) const;
+    void cancel_inbound(ElementRecord& rec);
+    void cancel_outbound(ElementRecord& rec);
+    void spawn_inbound(uint32_t id, std::function<float()> source);
+};
+
+} // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Bridge.hpp
+++ b/src/MayaFlux/Portal/Forma/Bridge.hpp
@@ -144,14 +144,24 @@ public:
         size_t size = sizeof(float));
 
     /**
-     * @brief Route element value to a descriptor binding.
+     * @brief Route element value to a descriptor binding on @p target_buffer.
+     *
+     * Creates a FormaBindingsProcessor if one does not yet exist for this element
+     * and attaches it to @p target_buffer. If a processor already exists from a
+     * prior write() call, @p target_buffer must be the same buffer — a second
+     * attachment is not made.
+     *
      * @param id              Element id.
+     * @param target_buffer   Buffer whose pipeline context receives the descriptor update.
+     * @param shader_path     Shader path used to construct FormaBindingsProcessor if needed.
      * @param descriptor_name Descriptor name in the shader config.
      * @param binding_index   Vulkan binding index.
      * @param set             Descriptor set index.
      * @param role            UNIFORM or STORAGE.
      */
     void write(uint32_t id,
+        const std::shared_ptr<Buffers::VKBuffer>& target_buffer,
+        const std::string& shader_path,
         const std::string& descriptor_name,
         uint32_t binding_index,
         uint32_t set,
@@ -194,11 +204,15 @@ public:
 
     template <typename T>
     void write(std::shared_ptr<MappedState<T>> state,
+        std::shared_ptr<Buffers::VKBuffer> target_buffer,
+        const std::string& shader_path,
         const std::string& descriptor_name,
-        uint32_t binding_index, uint32_t set,
+        uint32_t binding_index,
+        uint32_t set,
         Portal::Graphics::DescriptorRole role = Portal::Graphics::DescriptorRole::UNIFORM)
     {
-        write(state->id, descriptor_name, binding_index, set, role);
+        write(state->id, std::move(target_buffer), shader_path,
+            descriptor_name, binding_index, set, role);
     }
 
     template <typename T>

--- a/src/MayaFlux/Portal/Forma/Bridge.hpp
+++ b/src/MayaFlux/Portal/Forma/Bridge.hpp
@@ -132,12 +132,14 @@ public:
     /**
      * @brief Route element value to a push constant slot on a ShaderProcessor.
      * @param id     Element id.
-     * @param target ShaderProcessor whose push_constant_data receives the value.
+     * @param target VKBuffer whose push_constant staging receives the value.
      * @param offset Byte offset in the push constant struct.
      * @param size   Byte width. Defaults to sizeof(float).
      */
-    void write(uint32_t id,
-        std::shared_ptr<Buffers::ShaderProcessor> target,
+    void write(
+        uint32_t id,
+        const std::shared_ptr<Buffers::VKBuffer>& target_buffer,
+        const std::string& shader_path,
         uint32_t offset,
         size_t size = sizeof(float));
 
@@ -182,10 +184,12 @@ public:
 
     template <typename T>
     void write(std::shared_ptr<MappedState<T>> state,
-        std::shared_ptr<Buffers::ShaderProcessor> target,
-        uint32_t offset, size_t size = sizeof(float))
+        std::shared_ptr<Buffers::VKBuffer> target_buffer,
+        const std::string& shader_path,
+        uint32_t offset,
+        size_t size = sizeof(float))
     {
-        write(state->id, std::move(target), offset, size);
+        write(state->id, std::move(target_buffer), shader_path, offset, size);
     }
 
     template <typename T>

--- a/src/MayaFlux/Portal/Forma/Bridge.hpp
+++ b/src/MayaFlux/Portal/Forma/Bridge.hpp
@@ -283,10 +283,10 @@ public:
      *                Identity cast used if empty.
      */
     template <typename T>
-    void register_element(Mapped<T>& mapped, std::function<float(T)> project = {})
+    void register_element(Mapped<T> mapped, std::function<float(T)> project = {})
     {
         register_element(mapped.state, mapped.element.id, mapped.element.buffer, std::move(project));
-        spawn_sync(mapped.element.id, [&mapped] { mapped.sync(); });
+        spawn_sync(mapped.element.id, [m = std::move(mapped)]() mutable { m.sync(); });
     }
 
     // =========================================================================

--- a/src/MayaFlux/Portal/Forma/Bridge.hpp
+++ b/src/MayaFlux/Portal/Forma/Bridge.hpp
@@ -46,7 +46,7 @@ namespace MayaFlux::Portal::Forma {
  *   - write(id, Constant)                — node graph value carrier
  *
  * All overloads also accept shared_ptr<MappedState<T>> in place of the
- * element id. These resolve to the id via get_id() and forward — no
+ * element id. These resolve to the state->id.
  * duplicated logic.
  *
  * Usage:
@@ -116,13 +116,13 @@ public:
         std::shared_ptr<Nodes::Node> node,
         std::function<float(double)> project = {})
     {
-        bind(get_id(state.get()), std::move(node), std::move(project));
+        bind(state->id, std::move(node), std::move(project));
     }
 
     template <typename T>
     void bind(std::shared_ptr<MappedState<T>> state, std::function<float()> source)
     {
-        bind(get_id(state.get()), std::move(source));
+        bind(state->id, std::move(source));
     }
 
     // =========================================================================
@@ -185,7 +185,7 @@ public:
         std::shared_ptr<Buffers::ShaderProcessor> target,
         uint32_t offset, size_t size = sizeof(float))
     {
-        write(get_id(state.get()), std::move(target), offset, size);
+        write(state->id, std::move(target), offset, size);
     }
 
     template <typename T>
@@ -194,28 +194,28 @@ public:
         uint32_t binding_index, uint32_t set,
         Portal::Graphics::DescriptorRole role = Portal::Graphics::DescriptorRole::UNIFORM)
     {
-        write(get_id(state.get()), descriptor_name, binding_index, set, role);
+        write(state->id, descriptor_name, binding_index, set, role);
     }
 
     template <typename T>
     void write(std::shared_ptr<MappedState<T>> state,
         std::shared_ptr<Buffers::AudioWriteProcessor> target)
     {
-        write(get_id(state.get()), std::move(target));
+        write(state->id, std::move(target));
     }
 
     template <typename T>
     void write(std::shared_ptr<MappedState<T>> state,
         std::shared_ptr<Buffers::GeometryWriteProcessor> target)
     {
-        write(get_id(state.get()), std::move(target));
+        write(state->id, std::move(target));
     }
 
     template <typename T>
     void write(std::shared_ptr<MappedState<T>> state,
         std::shared_ptr<Nodes::Constant> node)
     {
-        write(get_id(state.get()), std::move(node));
+        write(state->id, std::move(node));
     }
 
     // =========================================================================
@@ -278,7 +278,7 @@ public:
     template <typename T>
     void unbind(std::shared_ptr<MappedState<T>> state)
     {
-        unbind(get_id(state.get()));
+        unbind(state->id);
     }
 
 private:
@@ -297,8 +297,6 @@ private:
     mutable uint32_t m_next_id { 0 };
 
     std::unordered_map<uint32_t, ElementRecord> m_records;
-
-    [[nodiscard]] uint32_t get_id(const void* state_ptr) const;
 
     std::string make_task_name(uint32_t id, const char* suffix) const;
     void cancel_inbound(ElementRecord& rec);

--- a/src/MayaFlux/Portal/Forma/Bridge.hpp
+++ b/src/MayaFlux/Portal/Forma/Bridge.hpp
@@ -291,9 +291,7 @@ public:
      * that calls mapped.sync(). The routine is stored in outbound_tasks
      * and cancelled by unbind().
      *
-     * @p mapped must outlive the Bridge registration. The sync routine
-     * captures @p mapped by reference -- the caller is responsible for
-     * ensuring the Mapped<T> is not destroyed while the Bridge holds it.
+     * @p mapped must outlive the Bridge registration.
      *
      * @tparam T      MappedState value type.
      * @param mapped  Fully constructed Mapped<T>, typically from create_element.

--- a/src/MayaFlux/Portal/Forma/Bridge.hpp
+++ b/src/MayaFlux/Portal/Forma/Bridge.hpp
@@ -265,6 +265,30 @@ public:
         };
     }
 
+    /**
+     * @brief Register a fully constructed Mapped<T> and own its sync loop.
+     *
+     * Delegates record and reader/writer setup to the existing
+     * register_element overload, then spawns a per-frame GraphicsRoutine
+     * that calls mapped.sync(). The routine is stored in outbound_tasks
+     * and cancelled by unbind().
+     *
+     * @p mapped must outlive the Bridge registration. The sync routine
+     * captures @p mapped by reference -- the caller is responsible for
+     * ensuring the Mapped<T> is not destroyed while the Bridge holds it.
+     *
+     * @tparam T      MappedState value type.
+     * @param mapped  Fully constructed Mapped<T>, typically from create_element.
+     * @param project Optional T -> float projection for outbound readers.
+     *                Identity cast used if empty.
+     */
+    template <typename T>
+    void register_element(Mapped<T>& mapped, std::function<float(T)> project = {})
+    {
+        register_element(mapped.state, mapped.element.id, mapped.element.buffer, std::move(project));
+        spawn_sync(mapped.element.id, [&mapped] { mapped.sync(); });
+    }
+
     // =========================================================================
     // Binding lifecycle
     // =========================================================================
@@ -302,6 +326,19 @@ private:
     void cancel_inbound(ElementRecord& rec);
     void cancel_outbound(ElementRecord& rec);
     void spawn_inbound(uint32_t id, std::function<float()> source);
+
+    /**
+     * @brief Spawn a per-frame GraphicsRoutine that calls @p sync_fn each tick.
+     *
+     * Stores the task name in the outbound_tasks of the record for @p id so
+     * that unbind() cancels it correctly. The coroutine body is type-free --
+     * all type-specific work is captured inside @p sync_fn by the caller.
+     *
+     * @param id       Element id whose outbound_tasks receives the task name.
+     * @param sync_fn  Callable invoked once per frame. Typically a lambda
+     *                 capturing Mapped<T> by reference and calling sync().
+     */
+    void spawn_sync(uint32_t id, std::function<void()> sync_fn);
 };
 
 } // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Context.cpp
+++ b/src/MayaFlux/Portal/Forma/Context.cpp
@@ -1,0 +1,209 @@
+#include "Context.hpp"
+
+#include "MayaFlux/Core/Backends/Windowing/Window.hpp"
+#include "MayaFlux/Kriya/InputEvents.hpp"
+#include "MayaFlux/Vruta/EventManager.hpp"
+#include "MayaFlux/Vruta/EventSource.hpp"
+
+namespace MayaFlux::Portal::Forma {
+
+Context::Context(std::shared_ptr<Layer> layer,
+    std::shared_ptr<Core::Window> window,
+    Vruta::EventManager& event_manager,
+    std::string name)
+    : m_layer(std::move(layer))
+    , m_window(std::move(window))
+    , m_event_manager(event_manager)
+    , m_name(std::move(name))
+{
+    register_handlers();
+}
+
+Context::~Context()
+{
+    cancel_handlers();
+}
+
+// =============================================================================
+// Per-element callback registration
+// =============================================================================
+
+void Context::on_press(uint32_t id, IO::MouseButtons btn, PressFn fn)
+{
+    m_callbacks[id].press[static_cast<int>(btn)] = std::move(fn);
+}
+
+void Context::on_release(uint32_t id, IO::MouseButtons btn, PressFn fn)
+{
+    m_callbacks[id].release[static_cast<int>(btn)] = std::move(fn);
+}
+
+void Context::on_move(uint32_t id, MoveFn fn)
+{
+    m_callbacks[id].move = std::move(fn);
+}
+
+void Context::on_enter(uint32_t id, EnterFn fn)
+{
+    m_callbacks[id].enter = std::move(fn);
+}
+
+void Context::on_leave(uint32_t id, LeaveFn fn)
+{
+    m_callbacks[id].leave = std::move(fn);
+}
+
+void Context::on_scroll(uint32_t id, ScrollFn fn)
+{
+    m_callbacks[id].scroll = std::move(fn);
+}
+
+void Context::unbind(uint32_t id)
+{
+    m_callbacks.erase(id);
+}
+
+const Vruta::EventSource& Context::event_source() const
+{
+    return m_window->get_event_source();
+}
+
+// =============================================================================
+// Handler registration / cancellation
+// =============================================================================
+
+void Context::register_handlers()
+{
+    m_event_manager.add_event(
+        std::make_shared<Vruta::Event>(
+            Kriya::mouse_moved(m_window,
+                [this](double px, double py) { handle_move(px, py); })),
+        m_name + "_move");
+
+    m_event_manager.add_event(
+        std::make_shared<Vruta::Event>(
+            Kriya::mouse_pressed(m_window, IO::MouseButtons::Left,
+                [this](double px, double py) { handle_press(px, py, IO::MouseButtons::Left); })),
+        m_name + "_press_left");
+
+    m_event_manager.add_event(
+        std::make_shared<Vruta::Event>(
+            Kriya::mouse_released(m_window, IO::MouseButtons::Left,
+                [this](double px, double py) { handle_release(px, py, IO::MouseButtons::Left); })),
+        m_name + "_release_left");
+
+    m_event_manager.add_event(
+        std::make_shared<Vruta::Event>(
+            Kriya::mouse_pressed(m_window, IO::MouseButtons::Right,
+                [this](double px, double py) { handle_press(px, py, IO::MouseButtons::Right); })),
+        m_name + "_press_right");
+
+    m_event_manager.add_event(
+        std::make_shared<Vruta::Event>(
+            Kriya::mouse_released(m_window, IO::MouseButtons::Right,
+                [this](double px, double py) { handle_release(px, py, IO::MouseButtons::Right); })),
+        m_name + "_release_right");
+
+    m_event_manager.add_event(
+        std::make_shared<Vruta::Event>(
+            Kriya::mouse_scrolled(m_window,
+                [this](double dx, double dy) { handle_scroll(dx, dy); })),
+        m_name + "_scroll");
+}
+
+void Context::cancel_handlers()
+{
+    for (const char* suffix : {
+             "_move",
+             "_press_left", "_release_left",
+             "_press_right", "_release_right",
+             "_scroll" }) {
+        m_event_manager.cancel_event(m_name + suffix);
+    }
+}
+
+// =============================================================================
+// Event dispatch
+// =============================================================================
+
+glm::vec2 Context::to_ndc(double px, double py) const noexcept
+{
+    const auto& s = m_window->get_state();
+    return {
+        (static_cast<float>(px) / static_cast<float>(s.current_width)) * 2.0F - 1.0F,
+        1.0F - (static_cast<float>(py) / static_cast<float>(s.current_height)) * 2.0F
+    };
+}
+
+void Context::handle_move(double px, double py)
+{
+    const glm::vec2 ndc = to_ndc(px, py);
+    const auto hit = m_layer->hit_test(ndc);
+
+    if (hit != m_hovered) {
+        if (m_hovered) {
+            auto it = m_callbacks.find(*m_hovered);
+            if (it != m_callbacks.end() && it->second.leave)
+                it->second.leave(*m_hovered);
+        }
+        if (hit) {
+            auto it = m_callbacks.find(*hit);
+            if (it != m_callbacks.end() && it->second.enter)
+                it->second.enter(*hit);
+        }
+        m_hovered = hit;
+    }
+
+    if (hit) {
+        auto it = m_callbacks.find(*hit);
+        if (it != m_callbacks.end() && it->second.move)
+            it->second.move(*hit, ndc);
+    }
+}
+
+void Context::handle_press(double px, double py, IO::MouseButtons btn)
+{
+    const glm::vec2 ndc = to_ndc(px, py);
+    const auto hit = m_layer->hit_test(ndc);
+    if (!hit)
+        return;
+
+    auto it = m_callbacks.find(*hit);
+    if (it == m_callbacks.end())
+        return;
+
+    auto btn_it = it->second.press.find(static_cast<int>(btn));
+    if (btn_it != it->second.press.end() && btn_it->second)
+        btn_it->second(*hit, ndc);
+}
+
+void Context::handle_release(double px, double py, IO::MouseButtons btn)
+{
+    const glm::vec2 ndc = to_ndc(px, py);
+    const auto hit = m_layer->hit_test(ndc);
+    if (!hit)
+        return;
+
+    auto it = m_callbacks.find(*hit);
+    if (it == m_callbacks.end())
+        return;
+
+    auto btn_it = it->second.release.find(static_cast<int>(btn));
+    if (btn_it != it->second.release.end() && btn_it->second)
+        btn_it->second(*hit, ndc);
+}
+
+void Context::handle_scroll(double dx, double dy)
+{
+    if (!m_hovered)
+        return;
+
+    auto it = m_callbacks.find(*m_hovered);
+    if (it == m_callbacks.end() || !it->second.scroll)
+        return;
+
+    const auto [px, py] = m_window->get_event_source().get_mouse_position();
+    it->second.scroll(*m_hovered, to_ndc(px, py), dx, dy);
+}
+
+} // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Context.hpp
+++ b/src/MayaFlux/Portal/Forma/Context.hpp
@@ -1,0 +1,147 @@
+#pragma once
+
+#include "Layer.hpp"
+
+#include "MayaFlux/IO/Keys.hpp"
+
+namespace MayaFlux::Core {
+class Window;
+}
+
+namespace MayaFlux::Vruta {
+class EventManager;
+class EventSource;
+}
+
+namespace MayaFlux::Portal::Forma {
+
+/**
+ * @class Context
+ * @brief Event wiring between a Layer and a window surface.
+ *
+ * Subscribes to mouse events on a window by constructing Kriya input
+ * coroutines and registering them with a Vruta::EventManager, following
+ * the same pattern as Nexus::Fabric. The EventManager and Window are
+ * injected; Context holds no engine-level singletons.
+ *
+ * Callbacks fire on the scheduler tick. They must not touch GPU resources
+ * directly. State intended for the graphics tick should be written through
+ * shared_ptr captures and read on the next graphics cycle.
+ *
+ * All registered events are cancelled on destruction via
+ * EventManager::cancel_event, keyed by names scoped to this Context.
+ *
+ * Window dimensions are read from window->get_state() at event time,
+ * so resize is handled automatically.
+ */
+class MAYAFLUX_API Context {
+public:
+    using PressFn = std::function<void(uint32_t id, glm::vec2 ndc)>;
+    using MoveFn = std::function<void(uint32_t id, glm::vec2 ndc)>;
+    using EnterFn = std::function<void(uint32_t id)>;
+    using LeaveFn = std::function<void(uint32_t id)>;
+    using ScrollFn = std::function<void(uint32_t id, glm::vec2 ndc, double dx, double dy)>;
+
+    /**
+     * @brief Construct and immediately register event coroutines.
+     * @param layer         Layer to hit-test against. Must outlive Context.
+     * @param window        Window whose surface the layer lives on.
+     * @param event_manager Engine EventManager for coroutine registration.
+     * @param name          Unique name scoping all registered event handlers.
+     *                      Must be unique across all live Contexts.
+     */
+    Context(std::shared_ptr<Layer> layer,
+        std::shared_ptr<Core::Window> window,
+        Vruta::EventManager& event_manager,
+        std::string name);
+
+    /**
+     * @brief Cancel all registered event coroutines.
+     */
+    ~Context();
+
+    Context(const Context&) = delete;
+    Context& operator=(const Context&) = delete;
+    Context(Context&&) = delete;
+    Context& operator=(Context&&) = delete;
+
+    // =========================================================================
+    // Per-element callbacks
+    // =========================================================================
+
+    /**
+     * @brief Called when a mouse button is pressed over an element.
+     * @param id  Element id to bind to.
+     * @param btn Mouse button.
+     * @param fn  Callback receiving element id and NDC press position.
+     */
+    void on_press(uint32_t id, IO::MouseButtons btn, PressFn fn);
+
+    /**
+     * @brief Called when a mouse button is released over an element.
+     */
+    void on_release(uint32_t id, IO::MouseButtons btn, PressFn fn);
+
+    /**
+     * @brief Called each move event while the cursor is over an element.
+     */
+    void on_move(uint32_t id, MoveFn fn);
+
+    /**
+     * @brief Called once when the cursor enters an element's region.
+     */
+    void on_enter(uint32_t id, EnterFn fn);
+
+    /**
+     * @brief Called once when the cursor leaves an element's region.
+     */
+    void on_leave(uint32_t id, LeaveFn fn);
+
+    /**
+     * @brief Called on scroll while the cursor is over an element.
+     */
+    void on_scroll(uint32_t id, ScrollFn fn);
+
+    /**
+     * @brief Remove all callbacks registered for an element id.
+     */
+    void unbind(uint32_t id);
+
+    // =========================================================================
+    // State query
+    // =========================================================================
+
+    [[nodiscard]] std::optional<uint32_t> hovered() const { return m_hovered; }
+
+    [[nodiscard]] const Vruta::EventSource& event_source() const;
+
+private:
+    struct ElementCallbacks {
+        std::unordered_map<int, PressFn> press;
+        std::unordered_map<int, PressFn> release;
+        MoveFn move;
+        EnterFn enter;
+        LeaveFn leave;
+        ScrollFn scroll;
+    };
+
+    std::shared_ptr<Layer> m_layer;
+    std::shared_ptr<Core::Window> m_window;
+    Vruta::EventManager& m_event_manager;
+    std::string m_name;
+    std::optional<uint32_t> m_hovered;
+
+    std::unordered_map<uint32_t, ElementCallbacks> m_callbacks;
+
+    void register_handlers();
+    void cancel_handlers();
+
+    [[nodiscard]] glm::vec2 to_ndc(double px, double py) const noexcept;
+
+    void handle_move(double px, double py);
+    void handle_press(double px, double py, IO::MouseButtons btn);
+    void handle_release(double px, double py, IO::MouseButtons btn);
+    void handle_scroll(double dx, double dy);
+};
+
+} // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Element.hpp
+++ b/src/MayaFlux/Portal/Forma/Element.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "MayaFlux/Buffers/VKBuffer.hpp"
+#include "MayaFlux/Buffers/Forma/FormaBuffer.hpp"
 #include "MayaFlux/Kinesis/Spatial/Bounds.hpp"
 
 namespace MayaFlux::Portal::Forma {
@@ -45,8 +45,9 @@ struct Element {
     ///        When absent, @c bounds_hint is used as the sole test.
     std::function<bool(glm::vec2)> contains;
 
-    /// @brief GPU buffer whose rendered output occupies this region.
-    std::shared_ptr<Buffers::VKBuffer> buffer;
+    /// @brief Buffer whose rendered output occupies this region.
+    ///        nullptr for non-rendering elements (pure hit-test regions).
+    std::shared_ptr<Buffers::FormaBuffer> buffer;
 
     /// @brief When false, hit testing skips this element.
     bool interactive { true };

--- a/src/MayaFlux/Portal/Forma/Element.hpp
+++ b/src/MayaFlux/Portal/Forma/Element.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "MayaFlux/Buffers/VKBuffer.hpp"
+#include "MayaFlux/Kinesis/Spatial/Bounds.hpp"
+
+namespace MayaFlux::Portal::Forma {
+
+/**
+ * @struct Element
+ * @brief A bounded, renderable region on a window surface.
+ *
+ * An Element pairs a spatial description with a GPU buffer whose output
+ * occupies that region. The spatial description is deliberately open:
+ *
+ * - @c bounds_hint: optional AABB2D in NDC space, used as a fast-reject
+ *   pre-filter before @c contains is evaluated. Not required.
+ *
+ * - @c contains: authoritative point-in-element test. If absent and
+ *   @c bounds_hint is set, @c bounds_hint::contains is used directly.
+ *   If both are absent the element never hits. For a rectangle, set only
+ *   @c bounds_hint. For a circle, arbitrary polygon, or curve region, set
+ *   @c contains (and optionally @c bounds_hint as the circumscribed rect
+ *   for performance).
+ *
+ * The buffer field accepts any VKBuffer subclass: a plain geometry buffer,
+ * a TextureBuffer, a TextBuffer, or a custom buffer. Portal::Forma::Layer
+ * owns elements and drives their lifecycle; callers work with element ids
+ * returned by Layer::add.
+ *
+ * @note Elements do not participate in the graphics subsystem scheduler
+ *       directly. The caller registers the underlying buffer with the
+ *       BufferManager and attaches a RenderProcessor as usual. Element
+ *       holds only the spatial and identity metadata that Layer and
+ *       Context need.
+ */
+struct Element {
+    /// @brief Stable id assigned by Layer::add. Never zero.
+    uint32_t id { 0 };
+
+    /// @brief Optional fast-reject bounds in NDC space.
+    ///        When set, Layer evaluates this before @c contains.
+    std::optional<Kinesis::AABB2D> bounds_hint;
+
+    /// @brief Authoritative containment test in NDC space.
+    ///        When absent, @c bounds_hint is used as the sole test.
+    std::function<bool(glm::vec2)> contains;
+
+    /// @brief GPU buffer whose rendered output occupies this region.
+    std::shared_ptr<Buffers::VKBuffer> buffer;
+
+    /// @brief When false, hit testing skips this element.
+    bool interactive { true };
+
+    /// @brief When false, the element is excluded from Layer iteration.
+    bool visible { true };
+
+    /// @brief Optional human-readable label for Lila introspection and
+    ///        debug logging. Not used by Layer or Context internally.
+    std::string name;
+};
+
+} // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Forma.cpp
+++ b/src/MayaFlux/Portal/Forma/Forma.cpp
@@ -1,7 +1,6 @@
 #include "Forma.hpp"
 
 #include "MayaFlux/Buffers/BufferManager.hpp"
-#include "MayaFlux/Journal/Archivist.hpp"
 #include "MayaFlux/Transitive/Memory/Persist.hpp"
 #include "MayaFlux/Vruta/EventManager.hpp"
 

--- a/src/MayaFlux/Portal/Forma/Forma.cpp
+++ b/src/MayaFlux/Portal/Forma/Forma.cpp
@@ -1,0 +1,46 @@
+#include "Forma.hpp"
+
+#include "MayaFlux/Buffers/BufferManager.hpp"
+#include "MayaFlux/Journal/Archivist.hpp"
+#include "MayaFlux/Transitive/Memory/Persist.hpp"
+#include "MayaFlux/Vruta/EventManager.hpp"
+
+namespace MayaFlux::Portal::Forma {
+
+// =============================================================================
+// Layer
+// =============================================================================
+
+std::pair<std::shared_ptr<Layer>, std::shared_ptr<Context>>
+create_layer(
+    const std::shared_ptr<Core::Window>& window,
+    std::string name,
+    Vruta::EventManager& event_manager)
+{
+    auto layer = std::make_shared<Layer>();
+    auto ctx = std::make_shared<Context>(layer, window, event_manager, std::move(name));
+    MayaFlux::store(ctx);
+
+    return { std::move(layer), std::move(ctx) };
+}
+
+// =============================================================================
+// Standalone buffer
+// =============================================================================
+
+std::shared_ptr<Buffers::FormaBuffer> create_buffer(
+    std::shared_ptr<Core::Window> window,
+    Buffers::BufferManager& buffer_manager,
+    size_t capacity,
+    Graphics::PrimitiveTopology topology)
+{
+    auto buf = std::make_shared<Buffers::FormaBuffer>(capacity, topology);
+
+    buffer_manager.add_buffer(buf, Buffers::ProcessingToken::GRAPHICS_BACKEND);
+
+    buf->setup_rendering({ .target_window = std::move(window) });
+
+    return buf;
+}
+
+} // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Forma.cpp
+++ b/src/MayaFlux/Portal/Forma/Forma.cpp
@@ -14,6 +14,7 @@ namespace {
     std::shared_ptr<Buffers::BufferManager> g_buffer_manager;
     std::shared_ptr<Vruta::TaskScheduler> g_scheduler;
     std::shared_ptr<Vruta::EventManager> g_event_manager;
+    std::unique_ptr<Bridge> g_bridge;
 }
 
 // =============================================================================
@@ -34,6 +35,7 @@ bool initialize(
     g_buffer_manager = std::move(buffer_manager);
     g_scheduler = std::move(scheduler);
     g_event_manager = std::move(event_manager);
+    g_bridge = std::make_unique<Bridge>(*g_scheduler, *g_buffer_manager);
     g_initialized = true;
 
     MF_INFO(Journal::Component::Portal, Journal::Context::API,
@@ -47,6 +49,7 @@ void shutdown()
         return;
     }
 
+    g_bridge.reset();
     g_buffer_manager = nullptr;
     g_scheduler = nullptr;
     g_event_manager = nullptr;
@@ -100,9 +103,9 @@ std::shared_ptr<Buffers::FormaBuffer> create_buffer(
 // Bridge
 // =============================================================================
 
-Bridge create_bridge()
+Bridge& get_bridge()
 {
-    return { *g_scheduler, *g_buffer_manager };
+    return *g_bridge;
 }
 
 } // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Forma.cpp
+++ b/src/MayaFlux/Portal/Forma/Forma.cpp
@@ -3,8 +3,63 @@
 #include "MayaFlux/Buffers/BufferManager.hpp"
 #include "MayaFlux/Transitive/Memory/Persist.hpp"
 #include "MayaFlux/Vruta/EventManager.hpp"
+#include "MayaFlux/Vruta/Scheduler.hpp"
+
+#include "MayaFlux/Journal/Archivist.hpp"
 
 namespace MayaFlux::Portal::Forma {
+
+namespace {
+    bool g_initialized {};
+    std::shared_ptr<Buffers::BufferManager> g_buffer_manager;
+    std::shared_ptr<Vruta::TaskScheduler> g_scheduler;
+    std::shared_ptr<Vruta::EventManager> g_event_manager;
+}
+
+// =============================================================================
+// Lifecycle
+// =============================================================================
+
+bool initialize(
+    std::shared_ptr<Buffers::BufferManager> buffer_manager,
+    std::shared_ptr<Vruta::TaskScheduler> scheduler,
+    std::shared_ptr<Vruta::EventManager> event_manager)
+{
+    if (g_initialized) {
+        MF_WARN(Journal::Component::Portal, Journal::Context::API,
+            "Portal::Forma already initialized");
+        return true;
+    }
+
+    g_buffer_manager = std::move(buffer_manager);
+    g_scheduler = std::move(scheduler);
+    g_event_manager = std::move(event_manager);
+    g_initialized = true;
+
+    MF_INFO(Journal::Component::Portal, Journal::Context::API,
+        "Portal::Forma initialized");
+    return true;
+}
+
+void shutdown()
+{
+    if (!g_initialized) {
+        return;
+    }
+
+    g_buffer_manager = nullptr;
+    g_scheduler = nullptr;
+    g_event_manager = nullptr;
+    g_initialized = false;
+
+    MF_INFO(Journal::Component::Portal, Journal::Context::API,
+        "Portal::Forma shutdown");
+}
+
+bool is_initialized()
+{
+    return g_initialized;
+}
 
 // =============================================================================
 // Layer
@@ -13,11 +68,11 @@ namespace MayaFlux::Portal::Forma {
 std::pair<std::shared_ptr<Layer>, std::shared_ptr<Context>>
 create_layer(
     const std::shared_ptr<Core::Window>& window,
-    std::string name,
-    Vruta::EventManager& event_manager)
+    std::string name)
 {
     auto layer = std::make_shared<Layer>();
-    auto ctx = std::make_shared<Context>(layer, window, event_manager, std::move(name));
+    auto ctx = std::make_shared<Context>(layer, window, *g_event_manager, std::move(name));
+
     MayaFlux::store(ctx);
 
     return { std::move(layer), std::move(ctx) };
@@ -29,17 +84,25 @@ create_layer(
 
 std::shared_ptr<Buffers::FormaBuffer> create_buffer(
     std::shared_ptr<Core::Window> window,
-    Buffers::BufferManager& buffer_manager,
     size_t capacity,
     Graphics::PrimitiveTopology topology)
 {
     auto buf = std::make_shared<Buffers::FormaBuffer>(capacity, topology);
 
-    buffer_manager.add_buffer(buf, Buffers::ProcessingToken::GRAPHICS_BACKEND);
+    g_buffer_manager->add_buffer(buf, Buffers::ProcessingToken::GRAPHICS_BACKEND);
 
     buf->setup_rendering({ .target_window = std::move(window) });
 
     return buf;
+}
+
+// =============================================================================
+// Bridge
+// =============================================================================
+
+Bridge create_bridge()
+{
+    return { *g_scheduler, *g_buffer_manager };
 }
 
 } // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Forma.hpp
+++ b/src/MayaFlux/Portal/Forma/Forma.hpp
@@ -162,7 +162,7 @@ template <typename T>
 {
     auto buf = create_buffer(std::move(window), capacity, topology);
     auto mapped = make_mapped<T>(initial, std::move(geom), buf);
-    layer.add(mapped.element);
+    mapped.element.id = layer.add(mapped.element);
     get_bridge().register_element(mapped);
     return mapped;
 }

--- a/src/MayaFlux/Portal/Forma/Forma.hpp
+++ b/src/MayaFlux/Portal/Forma/Forma.hpp
@@ -1,0 +1,147 @@
+#pragma once
+
+#include "Context.hpp"
+#include "Layer.hpp"
+#include "Primitives/Mapped.hpp"
+
+#include "MayaFlux/Buffers/Forma/FormaBuffer.hpp"
+#include "MayaFlux/Portal/Graphics/GraphicsUtils.hpp"
+
+namespace MayaFlux::Core {
+class Window;
+}
+
+namespace MayaFlux::Vruta {
+class EventManager;
+}
+
+namespace MayaFlux::Buffers {
+class BufferManager;
+}
+
+namespace MayaFlux::Portal::Forma {
+
+/**
+ * @file Forma.hpp
+ * @brief Factory free functions for the Forma surface system.
+ *
+ * Forma is not a class. It is a set of free functions that construct
+ * the right objects in the right order and return them to the caller.
+ * The caller owns everything. Nothing is tracked centrally.
+ *
+ * Typical sequence:
+ * @code
+ * auto [layer, ctx] = create_layer(window, "hud", event_manager);
+ *
+ * auto el = create_element<float>(
+ *     *layer, window, buffer_manager, geom_fn, 0.5f);
+ *
+ * ctx->on_press(el.element.id, IO::MouseButtons::LEFT,
+ *     [](uint32_t, glm::vec2){});
+ *
+ * bridge.bind(el.state, envelope);
+ * bridge.write(el.state, compute_proc, offsetof(PC, cutoff));
+ * @endcode
+ */
+// =============================================================================
+// Layer
+// =============================================================================
+
+/**
+ * @brief Construct a Layer and a Context wired to @p window.
+ *
+ * The caller owns both. The Context cancels its event coroutines on
+ * destruction. The Layer and Context must outlive any element ids
+ * registered against them.
+ *
+ * @param window        Target window surface.
+ * @param name          Unique name scoping the Context's event coroutines.
+ * @param event_manager Engine EventManager for Context coroutine registration.
+ * @return Pair of { shared_ptr<Layer>, shared_ptr<Context> }.
+ */
+[[nodiscard]] MAYAFLUX_API
+    std::pair<std::shared_ptr<Layer>, std::shared_ptr<Context>>
+    create_layer(
+        const std::shared_ptr<Core::Window>& window,
+        std::string name,
+        Vruta::EventManager& event_manager);
+
+// =============================================================================
+// Element
+// =============================================================================
+
+/**
+ * @brief Build a FormaBuffer, register it, construct a Mapped<T>, and add
+ *        the element to @p layer.
+ *
+ * Returns the fully constructed Mapped<T>. The caller holds it.
+ * element.id is stable and can be passed to Context callbacks.
+ * state is what Bridge::bind() and Bridge::write() accept.
+ *
+ * @tparam T         MappedState value type: float, glm::vec2, etc.
+ * @param layer          Layer to register the element on.
+ * @param window         Target window for rendering.
+ * @param buffer_manager Engine BufferManager for buffer registration.
+ * @param geom           Geometry function producing vertex bytes from T.
+ * @param initial        Starting value written into MappedState.
+ * @param capacity       Initial FormaBuffer capacity in bytes.
+ * @param topology       Primitive topology for the FormaBuffer.
+ * @return Fully constructed Mapped<T> with element registered in @p layer.
+ */
+template <typename T>
+[[nodiscard]] Mapped<T> create_element(
+    Layer& layer,
+    std::shared_ptr<Core::Window> window,
+    Buffers::BufferManager& buffer_manager,
+    GeometryFn<T> geom,
+    T initial,
+    size_t capacity = 4096,
+    Graphics::PrimitiveTopology topology = Graphics::PrimitiveTopology::TRIANGLE_STRIP);
+
+// =============================================================================
+// Standalone buffer
+// =============================================================================
+
+/**
+ * @brief Construct and register a FormaBuffer without creating a Mapped<T>.
+ *
+ * For callers that manage Mapped<T> themselves or use FormaBuffer in a
+ * custom pipeline.
+ *
+ * @param window         Target window.
+ * @param buffer_manager Engine BufferManager.
+ * @param capacity       Buffer capacity in bytes.
+ * @param topology       Primitive topology.
+ * @return Registered, render-ready FormaBuffer.
+ */
+[[nodiscard]] MAYAFLUX_API
+    std::shared_ptr<Buffers::FormaBuffer>
+    create_buffer(
+        std::shared_ptr<Core::Window> window,
+        Buffers::BufferManager& buffer_manager,
+        size_t capacity,
+        Graphics::PrimitiveTopology topology);
+
+// =============================================================================
+// create_element — template body
+// =============================================================================
+
+template <typename T>
+Mapped<T> create_element(
+    Layer& layer,
+    std::shared_ptr<Core::Window> window,
+    Buffers::BufferManager& buffer_manager,
+    GeometryFn<T> geom,
+    T initial,
+    size_t capacity,
+    Graphics::PrimitiveTopology topology)
+{
+    auto buf = create_buffer(window, buffer_manager, capacity, topology);
+
+    auto mapped = make_mapped<T>(initial, std::move(geom), buf);
+    layer.add(mapped.element);
+
+    return mapped;
+}
+
+} // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Forma.hpp
+++ b/src/MayaFlux/Portal/Forma/Forma.hpp
@@ -163,7 +163,7 @@ template <typename T>
     auto buf = create_buffer(std::move(window), capacity, topology);
     auto mapped = make_mapped<T>(initial, std::move(geom), buf);
     layer.add(mapped.element);
-    get_bridge().register_element(mapped.state, mapped.element.id, buf);
+    get_bridge().register_element(mapped);
     return mapped;
 }
 

--- a/src/MayaFlux/Portal/Forma/Forma.hpp
+++ b/src/MayaFlux/Portal/Forma/Forma.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Bridge.hpp"
 #include "Context.hpp"
 #include "Layer.hpp"
 #include "Primitives/Mapped.hpp"
@@ -12,6 +13,7 @@ class Window;
 }
 
 namespace MayaFlux::Vruta {
+class TaskScheduler;
 class EventManager;
 }
 
@@ -25,24 +27,60 @@ namespace MayaFlux::Portal::Forma {
  * @file Forma.hpp
  * @brief Factory free functions for the Forma surface system.
  *
- * Forma is not a class. It is a set of free functions that construct
- * the right objects in the right order and return them to the caller.
- * The caller owns everything. Nothing is tracked centrally.
+ * Call initialize() once after engine startup to store BufferManager,
+ * TaskScheduler, and EventManager references. Subsequent factory calls
+ * require only the arguments that legitimately vary per call (Window,
+ * geometry function, initial value). This matches the Portal::Text and
+ * Portal::Graphics initialization contracts.
  *
  * Typical sequence:
  * @code
- * auto [layer, ctx] = create_layer(window, "hud", event_manager);
+ * Portal::Forma::initialize(buffer_manager, scheduler, event_manager);
  *
- * auto el = create_element<float>(
- *     *layer, window, buffer_manager, geom_fn, 0.5f);
+ * auto [layer, ctx] = Forma::create_layer(window, "hud");
+ *
+ * auto el = Forma::create_element<float>(
+ *     *layer, window, geom_fn, 0.5f);
+ *
+ * auto bridge = Forma::create_bridge();
+ * bridge.bind(el.state, envelope);
+ * bridge.write(el.state, compute_proc, offsetof(PC, cutoff));
  *
  * ctx->on_press(el.element.id, IO::MouseButtons::LEFT,
  *     [](uint32_t, glm::vec2){});
- *
- * bridge.bind(el.state, envelope);
- * bridge.write(el.state, compute_proc, offsetof(PC, cutoff));
  * @endcode
  */
+
+// =============================================================================
+// Lifecycle
+// =============================================================================
+
+/**
+ * @brief Store engine-level references for use by all subsequent Forma calls.
+ *
+ * Must be called before any create_* call. Safe to call multiple times;
+ * subsequent calls are no-ops and log a warning.
+ *
+ * @param buffer_manager  Engine BufferManager. Must outlive all Forma objects.
+ * @param scheduler       Engine TaskScheduler. Must outlive all Bridge instances.
+ * @param event_manager   Engine EventManager. Must outlive all Context instances.
+ * @return True on success, false if any argument is null.
+ */
+MAYAFLUX_API bool initialize(
+    std::shared_ptr<Buffers::BufferManager> buffer_manager,
+    std::shared_ptr<Vruta::TaskScheduler> scheduler,
+    std::shared_ptr<Vruta::EventManager> event_manager);
+
+/**
+ * @brief Release stored references. Does not destroy any Forma objects.
+ *
+ * Call after all Forma objects have been destroyed, before engine shutdown.
+ */
+MAYAFLUX_API void shutdown();
+
+/** @brief Whether initialize() has been called successfully. */
+MAYAFLUX_API bool is_initialized();
+
 // =============================================================================
 // Layer
 // =============================================================================
@@ -50,21 +88,53 @@ namespace MayaFlux::Portal::Forma {
 /**
  * @brief Construct a Layer and a Context wired to @p window.
  *
- * The caller owns both. The Context cancels its event coroutines on
- * destruction. The Layer and Context must outlive any element ids
- * registered against them.
+ * EventManager is taken from the stored initialize() state.
+ * The caller owns both returned objects. The Context cancels its event
+ * coroutines on destruction.
  *
- * @param window        Target window surface.
- * @param name          Unique name scoping the Context's event coroutines.
- * @param event_manager Engine EventManager for Context coroutine registration.
+ * @param window  Target window surface.
+ * @param name    Unique name scoping the Context's event coroutines.
  * @return Pair of { shared_ptr<Layer>, shared_ptr<Context> }.
  */
 [[nodiscard]] MAYAFLUX_API
     std::pair<std::shared_ptr<Layer>, std::shared_ptr<Context>>
     create_layer(
         const std::shared_ptr<Core::Window>& window,
-        std::string name,
-        Vruta::EventManager& event_manager);
+        std::string name);
+
+// =============================================================================
+// Standalone buffer
+// =============================================================================
+
+/**
+ * @brief Construct and register a FormaBuffer without creating a Mapped<T>.
+ *
+ * BufferManager is taken from the stored initialize() state.
+ *
+ * @param window    Target window.
+ * @param capacity  Buffer capacity in bytes.
+ * @param topology  Primitive topology.
+ * @return Registered, render-ready FormaBuffer.
+ */
+[[nodiscard]] MAYAFLUX_API
+    std::shared_ptr<Buffers::FormaBuffer>
+    create_buffer(
+        std::shared_ptr<Core::Window> window,
+        size_t capacity,
+        Graphics::PrimitiveTopology topology);
+
+// =============================================================================
+// Bridge
+// =============================================================================
+
+/**
+ * @brief Construct a Bridge using the stored TaskScheduler and BufferManager.
+ *
+ * One Bridge instance typically serves the full application.
+ *
+ * @return Fully constructed Bridge.
+ */
+[[nodiscard]] MAYAFLUX_API Bridge create_bridge();
 
 // =============================================================================
 // Element
@@ -74,73 +144,31 @@ namespace MayaFlux::Portal::Forma {
  * @brief Build a FormaBuffer, register it, construct a Mapped<T>, and add
  *        the element to @p layer.
  *
+ * BufferManager is taken from the stored initialize() state.
  * Returns the fully constructed Mapped<T>. The caller holds it.
- * element.id is stable and can be passed to Context callbacks.
- * state is what Bridge::bind() and Bridge::write() accept.
+ * element.id is stable and can be passed to Context callbacks and Bridge.
  *
  * @tparam T         MappedState value type: float, glm::vec2, etc.
- * @param layer          Layer to register the element on.
- * @param window         Target window for rendering.
- * @param buffer_manager Engine BufferManager for buffer registration.
- * @param geom           Geometry function producing vertex bytes from T.
- * @param initial        Starting value written into MappedState.
- * @param capacity       Initial FormaBuffer capacity in bytes.
- * @param topology       Primitive topology for the FormaBuffer.
+ * @param layer      Layer to register the element on.
+ * @param window     Target window for rendering.
+ * @param geom       Geometry function producing vertex bytes from T.
+ * @param initial    Starting value written into MappedState.
+ * @param capacity   Initial FormaBuffer capacity in bytes.
+ * @param topology   Primitive topology for the FormaBuffer.
  * @return Fully constructed Mapped<T> with element registered in @p layer.
  */
 template <typename T>
 [[nodiscard]] Mapped<T> create_element(
     Layer& layer,
     std::shared_ptr<Core::Window> window,
-    Buffers::BufferManager& buffer_manager,
     GeometryFn<T> geom,
     T initial,
     size_t capacity = 4096,
-    Graphics::PrimitiveTopology topology = Graphics::PrimitiveTopology::TRIANGLE_STRIP);
-
-// =============================================================================
-// Standalone buffer
-// =============================================================================
-
-/**
- * @brief Construct and register a FormaBuffer without creating a Mapped<T>.
- *
- * For callers that manage Mapped<T> themselves or use FormaBuffer in a
- * custom pipeline.
- *
- * @param window         Target window.
- * @param buffer_manager Engine BufferManager.
- * @param capacity       Buffer capacity in bytes.
- * @param topology       Primitive topology.
- * @return Registered, render-ready FormaBuffer.
- */
-[[nodiscard]] MAYAFLUX_API
-    std::shared_ptr<Buffers::FormaBuffer>
-    create_buffer(
-        std::shared_ptr<Core::Window> window,
-        Buffers::BufferManager& buffer_manager,
-        size_t capacity,
-        Graphics::PrimitiveTopology topology);
-
-// =============================================================================
-// create_element — template body
-// =============================================================================
-
-template <typename T>
-Mapped<T> create_element(
-    Layer& layer,
-    const std::shared_ptr<Core::Window>& window,
-    Buffers::BufferManager& buffer_manager,
-    GeometryFn<T> geom,
-    T initial,
-    size_t capacity,
-    Graphics::PrimitiveTopology topology)
+    Graphics::PrimitiveTopology topology = Graphics::PrimitiveTopology::TRIANGLE_STRIP)
 {
-    auto buf = create_buffer(window, buffer_manager, capacity, topology);
-
+    auto buf = create_buffer(std::move(window), capacity, topology);
     auto mapped = make_mapped<T>(initial, std::move(geom), buf);
     layer.add(mapped.element);
-
     return mapped;
 }
 

--- a/src/MayaFlux/Portal/Forma/Forma.hpp
+++ b/src/MayaFlux/Portal/Forma/Forma.hpp
@@ -81,6 +81,13 @@ MAYAFLUX_API void shutdown();
 /** @brief Whether initialize() has been called successfully. */
 MAYAFLUX_API bool is_initialized();
 
+/**
+ * @brief Return the application-level Bridge instance.
+ *
+ * Valid only after initialize(). Lifetime is tied to the Forma module.
+ */
+[[nodiscard]] MAYAFLUX_API Bridge& get_bridge();
+
 // =============================================================================
 // Layer
 // =============================================================================
@@ -124,19 +131,6 @@ MAYAFLUX_API bool is_initialized();
         Graphics::PrimitiveTopology topology);
 
 // =============================================================================
-// Bridge
-// =============================================================================
-
-/**
- * @brief Construct a Bridge using the stored TaskScheduler and BufferManager.
- *
- * One Bridge instance typically serves the full application.
- *
- * @return Fully constructed Bridge.
- */
-[[nodiscard]] MAYAFLUX_API Bridge create_bridge();
-
-// =============================================================================
 // Element
 // =============================================================================
 
@@ -169,6 +163,7 @@ template <typename T>
     auto buf = create_buffer(std::move(window), capacity, topology);
     auto mapped = make_mapped<T>(initial, std::move(geom), buf);
     layer.add(mapped.element);
+    get_bridge().register_element(mapped.state, mapped.element.id, buf);
     return mapped;
 }
 

--- a/src/MayaFlux/Portal/Forma/Forma.hpp
+++ b/src/MayaFlux/Portal/Forma/Forma.hpp
@@ -129,7 +129,7 @@ template <typename T>
 template <typename T>
 Mapped<T> create_element(
     Layer& layer,
-    std::shared_ptr<Core::Window> window,
+    const std::shared_ptr<Core::Window>& window,
     Buffers::BufferManager& buffer_manager,
     GeometryFn<T> geom,
     T initial,

--- a/src/MayaFlux/Portal/Forma/Layer.cpp
+++ b/src/MayaFlux/Portal/Forma/Layer.cpp
@@ -1,7 +1,5 @@
 #include "Layer.hpp"
 
-#include <ranges>
-
 namespace MayaFlux::Portal::Forma {
 
 // =============================================================================

--- a/src/MayaFlux/Portal/Forma/Layer.cpp
+++ b/src/MayaFlux/Portal/Forma/Layer.cpp
@@ -1,0 +1,170 @@
+#include "Layer.hpp"
+
+#include <ranges>
+
+namespace MayaFlux::Portal::Forma {
+
+// =============================================================================
+// Element registration
+// =============================================================================
+
+uint32_t Layer::add(Element element)
+{
+    element.id = m_next_id++;
+    m_elements.push_back(std::move(element));
+    return m_elements.back().id;
+}
+
+bool Layer::remove(uint32_t id)
+{
+    auto it = std::ranges::find_if(m_elements,
+        [id](const Element& e) { return e.id == id; });
+    if (it == m_elements.end())
+        return false;
+    m_elements.erase(it);
+    return true;
+}
+
+void Layer::clear()
+{
+    m_elements.clear();
+}
+
+// =============================================================================
+// Element mutation
+// =============================================================================
+
+bool Layer::set_bounds(uint32_t id, Kinesis::AABB2D bounds)
+{
+    if (auto* el = get(id)) {
+        el->bounds_hint = bounds;
+        return true;
+    }
+    return false;
+}
+
+bool Layer::set_contains(uint32_t id, std::function<bool(glm::vec2)> fn)
+{
+    if (auto* el = get(id)) {
+        el->contains = std::move(fn);
+        return true;
+    }
+    return false;
+}
+
+bool Layer::set_interactive(uint32_t id, bool interactive)
+{
+    if (auto* el = get(id)) {
+        el->interactive = interactive;
+        return true;
+    }
+    return false;
+}
+
+bool Layer::set_visible(uint32_t id, bool visible)
+{
+    if (auto* el = get(id)) {
+        el->visible = visible;
+        return true;
+    }
+    return false;
+}
+
+bool Layer::bring_to_front(uint32_t id)
+{
+    auto it = std::ranges::find_if(m_elements,
+        [id](const Element& e) { return e.id == id; });
+    if (it == m_elements.end())
+        return false;
+    std::rotate(it, it + 1, m_elements.end());
+    return true;
+}
+
+bool Layer::send_to_back(uint32_t id)
+{
+    auto it = std::ranges::find_if(m_elements,
+        [id](const Element& e) { return e.id == id; });
+    if (it == m_elements.end())
+        return false;
+    std::rotate(m_elements.begin(), it, it + 1);
+    return true;
+}
+
+// =============================================================================
+// Spatial queries
+// =============================================================================
+
+std::optional<uint32_t> Layer::hit_test(glm::vec2 ndc) const
+{
+    for (const auto& m_element : std::views::reverse(m_elements)) {
+        if (test_element(m_element, ndc))
+            return m_element.id;
+    }
+    return std::nullopt;
+}
+
+std::vector<uint32_t> Layer::hit_test_all(glm::vec2 ndc) const
+{
+    std::vector<uint32_t> result;
+    for (const auto& m_element : std::views::reverse(m_elements)) {
+        if (test_element(m_element, ndc))
+            result.push_back(m_element.id);
+    }
+    return result;
+}
+
+std::optional<uint32_t> Layer::hit_test(
+    double px, double py, uint32_t win_w, uint32_t win_h) const
+{
+    return hit_test(to_ndc(px, py, win_w, win_h));
+}
+
+std::vector<uint32_t> Layer::hit_test_all(
+    double px, double py, uint32_t win_w, uint32_t win_h) const
+{
+    return hit_test_all(to_ndc(px, py, win_w, win_h));
+}
+
+// =============================================================================
+// Introspection
+// =============================================================================
+
+const Element* Layer::get(uint32_t id) const
+{
+    auto it = std::ranges::find_if(m_elements,
+        [id](const Element& e) { return e.id == id; });
+    return it != m_elements.end() ? &*it : nullptr;
+}
+
+Element* Layer::get(uint32_t id)
+{
+    auto it = std::ranges::find_if(m_elements,
+        [id](const Element& e) { return e.id == id; });
+    return it != m_elements.end() ? &*it : nullptr;
+}
+
+// =============================================================================
+// Internal
+// =============================================================================
+
+glm::vec2 Layer::to_ndc(
+    double px, double py, uint32_t win_w, uint32_t win_h) noexcept
+{
+    return {
+        (static_cast<float>(px) / static_cast<float>(win_w)) * 2.0F - 1.0F,
+        1.0F - (static_cast<float>(py) / static_cast<float>(win_h)) * 2.0F
+    };
+}
+
+bool Layer::test_element(const Element& el, glm::vec2 ndc) noexcept
+{
+    if (!el.interactive || !el.visible)
+        return false;
+    if (el.bounds_hint && !el.bounds_hint->contains(ndc))
+        return false;
+    if (el.contains)
+        return el.contains(ndc);
+    return el.bounds_hint.has_value();
+}
+
+} // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Layer.cpp
+++ b/src/MayaFlux/Portal/Forma/Layer.cpp
@@ -28,6 +28,7 @@ bool Layer::remove(uint32_t id)
 void Layer::clear()
 {
     m_elements.clear();
+    m_relations.clear();
 }
 
 // =============================================================================
@@ -65,6 +66,13 @@ bool Layer::set_visible(uint32_t id, bool visible)
 {
     if (auto* el = get(id)) {
         el->visible = visible;
+        if (auto it = m_relations.find(id); it != m_relations.end()) {
+            for (uint32_t rel_id : it->second) {
+                if (auto* rel = get(rel_id))
+                    rel->visible = visible;
+            }
+        }
+
         return true;
     }
     return false;
@@ -72,6 +80,14 @@ bool Layer::set_visible(uint32_t id, bool visible)
 
 bool Layer::bring_to_front(uint32_t id)
 {
+    if (auto rit = m_relations.find(id); rit != m_relations.end()) {
+        for (uint32_t rel_id : rit->second) {
+            auto it = std::ranges::find_if(m_elements,
+                [rel_id](const Element& e) { return e.id == rel_id; });
+            if (it != m_elements.end())
+                std::rotate(it, it + 1, m_elements.end());
+        }
+    }
     auto it = std::ranges::find_if(m_elements,
         [id](const Element& e) { return e.id == id; });
     if (it == m_elements.end())
@@ -82,6 +98,11 @@ bool Layer::bring_to_front(uint32_t id)
 
 bool Layer::send_to_back(uint32_t id)
 {
+    if (auto rit = m_relations.find(id); rit != m_relations.end()) {
+        for (uint32_t rel_id : rit->second)
+            send_to_back(rel_id);
+    }
+
     auto it = std::ranges::find_if(m_elements,
         [id](const Element& e) { return e.id == id; });
     if (it == m_elements.end())
@@ -123,6 +144,42 @@ std::vector<uint32_t> Layer::hit_test_all(
     double px, double py, uint32_t win_w, uint32_t win_h) const
 {
     return hit_test_all(to_ndc(px, py, win_w, win_h));
+}
+
+// =========================================================================
+// Relations
+// =========================================================================
+
+bool Layer::relate(uint32_t primary_id, uint32_t related_id)
+{
+    if (!get(primary_id) || !get(related_id) || primary_id == related_id)
+        return false;
+
+    auto& rel = m_relations[primary_id];
+    if (std::ranges::find(rel, related_id) == rel.end())
+        rel.push_back(related_id);
+    return true;
+}
+
+bool Layer::unrelate(uint32_t primary_id, uint32_t related_id)
+{
+    auto it = m_relations.find(primary_id);
+    if (it == m_relations.end())
+        return false;
+    auto& rel = it->second;
+    auto rit = std::ranges::find(rel, related_id);
+    if (rit == rel.end())
+        return false;
+    rel.erase(rit);
+    if (rel.empty())
+        m_relations.erase(it);
+    return true;
+}
+
+std::vector<uint32_t> Layer::related_ids(uint32_t primary_id) const
+{
+    auto it = m_relations.find(primary_id);
+    return it != m_relations.end() ? it->second : std::vector<uint32_t> {};
 }
 
 // =============================================================================

--- a/src/MayaFlux/Portal/Forma/Layer.hpp
+++ b/src/MayaFlux/Portal/Forma/Layer.hpp
@@ -121,6 +121,31 @@ public:
         uint32_t win_w, uint32_t win_h) const;
 
     // =========================================================================
+    // Relations
+    // =========================================================================
+
+    /**
+     * @brief Record that @p related_id belongs with @p primary_id.
+     *
+     * Both ids must already exist in the layer. The related element has
+     * no special spatial or hit-test role — the relation is purely for
+     * cascaded lifecycle operations (remove, set_visible, bring_to_front,
+     * send_to_back). Returns false if either id is not found.
+     */
+    bool relate(uint32_t primary_id, uint32_t related_id);
+
+    /**
+     * @brief Remove a specific relation between two elements.
+     *        Does not remove either element from the layer.
+     */
+    bool unrelate(uint32_t primary_id, uint32_t related_id);
+
+    /**
+     * @brief Return the ids related to @p primary_id, or empty if none.
+     */
+    [[nodiscard]] std::vector<uint32_t> related_ids(uint32_t primary_id) const;
+
+    // =========================================================================
     // Introspection
     // =========================================================================
 
@@ -134,6 +159,8 @@ public:
 private:
     std::vector<Element> m_elements;
     uint32_t m_next_id { 1 };
+
+    std::unordered_map<uint32_t, std::vector<uint32_t>> m_relations;
 
     [[nodiscard]] static glm::vec2 to_ndc(
         double px, double py,

--- a/src/MayaFlux/Portal/Forma/Layer.hpp
+++ b/src/MayaFlux/Portal/Forma/Layer.hpp
@@ -1,0 +1,146 @@
+#pragma once
+
+#include "Element.hpp"
+
+namespace MayaFlux::Portal::Forma {
+
+/**
+ * @class Layer
+ * @brief Flat registry of Elements on a surface.
+ *
+ * Owns a collection of Elements and provides spatial queries against them
+ * in NDC space. Does not drive rendering, scheduling, or event wiring.
+ *
+ * Elements are stored and traversed back-to-front so later-added elements
+ * are considered on top during hit testing, matching typical draw order.
+ *
+ * Pixel-space query overloads accept window dimensions and convert to NDC
+ * internally using the same convention as Kinesis::to_ndc: top-left origin,
+ * +Y down in pixel space, +Y up in NDC.
+ */
+class MAYAFLUX_API Layer {
+public:
+    Layer() = default;
+    ~Layer() = default;
+
+    Layer(const Layer&) = delete;
+    Layer& operator=(const Layer&) = delete;
+    Layer(Layer&&) = default;
+    Layer& operator=(Layer&&) = default;
+
+    // =========================================================================
+    // Element registration
+    // =========================================================================
+
+    /**
+     * @brief Add an element to the layer.
+     * @return The stable id assigned to the element. Never zero.
+     */
+    uint32_t add(Element element);
+
+    /**
+     * @brief Remove an element by id.
+     * @return True if found and removed.
+     */
+    bool remove(uint32_t id);
+
+    /**
+     * @brief Remove all elements.
+     */
+    void clear();
+
+    // =========================================================================
+    // Element mutation
+    // =========================================================================
+
+    /**
+     * @brief Replace the bounds_hint on an existing element.
+     * @return True if found.
+     */
+    bool set_bounds(uint32_t id, Kinesis::AABB2D bounds);
+
+    /**
+     * @brief Replace the contains callable on an existing element.
+     * @return True if found.
+     */
+    bool set_contains(uint32_t id, std::function<bool(glm::vec2)> fn);
+
+    bool set_interactive(uint32_t id, bool interactive);
+    bool set_visible(uint32_t id, bool visible);
+
+    /**
+     * @brief Move element to the top of the hit-test order (drawn last).
+     */
+    bool bring_to_front(uint32_t id);
+
+    /**
+     * @brief Move element to the bottom of the hit-test order (drawn first).
+     */
+    bool send_to_back(uint32_t id);
+
+    // =========================================================================
+    // Spatial queries - NDC space
+    // =========================================================================
+
+    /**
+     * @brief Return the topmost interactive, visible element containing @p ndc.
+     *
+     * Traverses back-to-front. An element passes if:
+     *   1. bounds_hint is absent OR bounds_hint.contains(ndc) is true.
+     *   2. contains is absent OR contains(ndc) is true.
+     * An element with neither set never hits.
+     *
+     * @param ndc Point in NDC space (x, y in [-1, +1]).
+     * @return Element id, or nullopt if no element hit.
+     */
+    [[nodiscard]] std::optional<uint32_t> hit_test(glm::vec2 ndc) const;
+
+    /**
+     * @brief Return all interactive, visible elements containing @p ndc,
+     *        ordered back-to-front.
+     */
+    [[nodiscard]] std::vector<uint32_t> hit_test_all(glm::vec2 ndc) const;
+
+    // =========================================================================
+    // Spatial queries - pixel space
+    // =========================================================================
+
+    /**
+     * @brief hit_test with pixel-space input, converted to NDC internally.
+     * @param px       Cursor x in pixels (top-left origin).
+     * @param py       Cursor y in pixels (top-left origin).
+     * @param win_w    Window width in pixels.
+     * @param win_h    Window height in pixels.
+     */
+    [[nodiscard]] std::optional<uint32_t> hit_test(
+        double px, double py,
+        uint32_t win_w, uint32_t win_h) const;
+
+    [[nodiscard]] std::vector<uint32_t> hit_test_all(
+        double px, double py,
+        uint32_t win_w, uint32_t win_h) const;
+
+    // =========================================================================
+    // Introspection
+    // =========================================================================
+
+    [[nodiscard]] const Element* get(uint32_t id) const;
+    [[nodiscard]] Element* get(uint32_t id);
+
+    [[nodiscard]] const std::vector<Element>& elements() const { return m_elements; }
+    [[nodiscard]] size_t size() const { return m_elements.size(); }
+    [[nodiscard]] bool empty() const { return m_elements.empty(); }
+
+private:
+    std::vector<Element> m_elements;
+    uint32_t m_next_id { 1 };
+
+    [[nodiscard]] static glm::vec2 to_ndc(
+        double px, double py,
+        uint32_t win_w, uint32_t win_h) noexcept;
+
+    [[nodiscard]] static bool test_element(
+        const Element& el, glm::vec2 ndc) noexcept;
+};
+
+} // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Primitives/Geometry.hpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/Geometry.hpp
@@ -1,0 +1,178 @@
+#pragma once
+
+#include "Mapped.hpp"
+
+#include "MayaFlux/Kinesis/Spatial/Bounds.hpp"
+#include "MayaFlux/Nodes/Graphics/VertexSpec.hpp"
+
+namespace MayaFlux::Portal::Forma::Geometry {
+
+/**
+ * @file Geometry.hpp
+ * @brief Illustrative geometry functions for common Mapped use cases.
+ *
+ * These are starting points for reading and understanding the GeometryFn
+ * contract, not the primary or idiomatic way to use Mapped in MayaFlux.
+ *
+ * The idiomatic use is a custom geometry function that writes from whatever
+ * data source makes sense: mouse pixel coordinates written directly as buffer
+ * data, microphone energy mapped to a spatial form, a node output driving
+ * vertex positions, a tendency field evaluated at runtime. The function
+ * receives a value and an output byte buffer — what it does with those is
+ * unconstrained.
+ *
+ * The helpers below demonstrate the pattern concretely. They are not
+ * privileged and carry no special status in the framework.
+ */
+
+namespace detail {
+
+    template <typename V>
+    void write_verts(std::vector<uint8_t>& out, const std::vector<V>& verts)
+    {
+        out.resize(verts.size() * sizeof(V));
+        std::memcpy(out.data(), verts.data(), out.size());
+    }
+
+} // namespace detail
+
+// =============================================================================
+// Horizontal fader
+//
+// Value in [0, 1] moves a handle quad along a track quad.
+// Two quads: track (static) and handle (value-driven).
+// Both written as TRIANGLE_STRIP pairs into a single buffer.
+//
+// Track: full extent of bounds.
+// Handle: small square at x = bounds.min.x + value * bounds.width().
+//
+// Hit region follows the handle, updated on every sync().
+// =============================================================================
+
+/**
+ * @brief Geometry function for a horizontal fader in NDC space.
+ * @param bounds      Full extent of the fader in NDC.
+ * @param handle_w    Handle width in NDC units.
+ * @param track_color Track quad color.
+ * @param handle_color Handle quad color.
+ */
+[[nodiscard]] inline GeometryFn<float> horizontal_fader(
+    Kinesis::AABB2D bounds,
+    float handle_w,
+    glm::vec3 track_color = glm::vec3(0.3F),
+    glm::vec3 handle_color = glm::vec3(0.9F))
+{
+    return [bounds, handle_w, track_color, handle_color](
+               float v, std::vector<uint8_t>& out, Element& el) {
+        float x = bounds.min.x + v * (bounds.width() - handle_w);
+        float yt = bounds.min.y + bounds.height() * 0.35F;
+        float yb = bounds.min.y + bounds.height() * 0.65F;
+
+        using V = Nodes::LineVertex;
+        std::vector<V> verts;
+        verts.reserve(8);
+
+        // track — two triangles as TRIANGLE_STRIP
+        verts.push_back({ .position = { bounds.min.x, yt, 0 }, .color = track_color });
+        verts.push_back({ .position = { bounds.min.x, yb, 0 }, .color = track_color });
+        verts.push_back({ .position = { bounds.max.x, yt, 0 }, .color = track_color });
+        verts.push_back({ .position = { bounds.max.x, yb, 0 }, .color = track_color });
+
+        // handle — two triangles as TRIANGLE_STRIP
+        verts.push_back({ .position = { x, bounds.min.y, 0 }, .color = handle_color });
+        verts.push_back({ .position = { x, bounds.max.y, 0 }, .color = handle_color });
+        verts.push_back({ .position = { x + handle_w, bounds.min.y, 0 }, .color = handle_color });
+        verts.push_back({ .position = { x + handle_w, bounds.max.y, 0 }, .color = handle_color });
+
+        detail::write_verts(out, verts);
+
+        el.bounds_hint = Kinesis::AABB2D {
+            .min = glm::vec2(x, bounds.min.y),
+            .max = glm::vec2(x + handle_w, bounds.max.y)
+        };
+        el.contains = {};
+    };
+}
+
+// =============================================================================
+// Radial / arc
+//
+// Value in [0, 1] sweeps an indicator line around a center point.
+// angle_start and angle_end in radians, measured from +X, CCW.
+// Produces a LINE_LIST of two vertices: center to indicator tip.
+// =============================================================================
+
+/**
+ * @brief Geometry function for a radial indicator in NDC space.
+ * @param center      Arc center in NDC.
+ * @param radius      Arc radius in NDC units.
+ * @param angle_start Start angle in radians (value = 0).
+ * @param angle_end   End angle in radians (value = 1).
+ * @param color       Line color.
+ */
+[[nodiscard]] inline GeometryFn<float> radial(
+    glm::vec2 center,
+    float radius,
+    float angle_start,
+    float angle_end,
+    glm::vec3 color = glm::vec3(0.9F))
+{
+    return [center, radius, angle_start, angle_end, color](
+               float v, std::vector<uint8_t>& out, Element& el) {
+        float angle = angle_start + v * (angle_end - angle_start);
+        glm::vec2 tip = center + radius * glm::vec2(std::cos(angle), std::sin(angle));
+
+        using V = Nodes::LineVertex;
+        std::vector<V> verts = {
+            { .position = { center.x, center.y, 0 }, .color = color },
+            { .position = { tip.x, tip.y, 0 }, .color = color },
+        };
+
+        detail::write_verts(out, verts);
+
+        el.bounds_hint = Kinesis::AABB2D::from_ndc(center, glm::vec2(radius));
+        el.contains = Kinesis::circular_bounds(center, radius);
+    };
+}
+
+// =============================================================================
+// 2D position picker
+//
+// Value is glm::vec2 in [0,1]x[0,1], mapped to a point inside bounds.
+// Produces a single POINT_LIST vertex at the mapped position.
+// =============================================================================
+
+/**
+ * @brief Geometry function for a 2D position picker in NDC space.
+ * @param bounds Full extent of the pick area in NDC.
+ * @param color  Point color.
+ * @param size   Point size in pixels.
+ */
+[[nodiscard]] inline GeometryFn<glm::vec2> position_picker(
+    Kinesis::AABB2D bounds,
+    glm::vec3 color = glm::vec3(0.9F),
+    float size = 8.0F)
+{
+    return [bounds, color, size](
+               glm::vec2 v, std::vector<uint8_t>& out, Element& el) {
+        float x = bounds.min.x + v.x * bounds.width();
+        float y = bounds.min.y + v.y * bounds.height();
+
+        using V = Nodes::PointVertex;
+        std::vector<V> verts = {
+            { .position = { x, y, 0 }, .color = color, .size = size },
+        };
+
+        detail::write_verts(out, verts);
+
+        el.bounds_hint = bounds;
+        el.contains = Kinesis::polygon_bounds(std::span<const glm::vec2> {
+            std::array<glm::vec2, 4> {
+                bounds.min,
+                glm::vec2(bounds.max.x, bounds.min.y),
+                bounds.max,
+                glm::vec2(bounds.min.x, bounds.max.y) } });
+    };
+}
+
+} // namespace MayaFlux::Portal::Forma::Geometry

--- a/src/MayaFlux/Portal/Forma/Primitives/Mapped.hpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/Mapped.hpp
@@ -1,0 +1,156 @@
+#pragma once
+
+#include "MayaFlux/Portal/Forma/Element.hpp"
+
+namespace MayaFlux::Buffers {
+class VKBuffer;
+}
+
+namespace MayaFlux::Portal::Forma {
+
+/**
+ * @brief Version counter incremented on every value write.
+ *
+ * Plain uint64_t behind a shared_ptr. The graphics tick compares against
+ * its last-seen version to detect changes without polling the value itself.
+ * Not atomic — same scheduler tick, no concurrent access.
+ */
+using Version = uint64_t;
+
+/**
+ * @struct MappedState
+ * @brief Value carrier for a Mapped primitive.
+ *
+ * Owns the current value and a version counter. Any writer increments
+ * version after updating value. The graphics tick reads both and decides
+ * whether to regenerate geometry.
+ *
+ * Exposed as shared_ptr<MappedState<T>> so any external system — a node
+ * output reader, a buffer writer, a scheduler callback — can hold a
+ * reference and read or write without knowing about the primitive.
+ *
+ * @tparam T Value type. float for a single continuous parameter,
+ *           glm::vec2 for a 2D position, any plain data type.
+ */
+template <typename T>
+struct MappedState {
+    T value {};
+    Version version { 0 };
+
+    void write(T v)
+    {
+        value = v;
+        ++version;
+    }
+};
+
+/**
+ * @brief Geometry function signature.
+ *
+ * Called by the graphics tick when the version has advanced. Receives the
+ * current value and an output byte vector to fill with interleaved vertex
+ * data. Layout, stride, and topology are determined by how the caller
+ * constructed the VKBuffer and RenderProcessor — the function is agnostic
+ * to all of those.
+ *
+ * The function is also responsible for updating the Element's spatial
+ * description if the geometry change affects hit testing (e.g. a handle
+ * that moves). It receives the Element by reference for that purpose.
+ *
+ * @tparam T Value type matching the MappedState.
+ */
+template <typename T>
+using GeometryFn = std::function<void(T value, std::vector<uint8_t>& out_bytes, Element& element)>;
+
+/**
+ * @struct Mapped
+ * @brief Infrastructure for a continuously-mapped value whose GPU geometry
+ *        tracks it.
+ *
+ * The geometry function IS the primitive. Mapped provides only the
+ * mechanism: a shared value carrier, a version counter, and a sync()
+ * call that invokes the geometry function when the value changes.
+ *
+ * The geometry function decides everything about shape, topology, and
+ * vertex layout. It can write from any source — mouse pixel coordinates,
+ * microphone energy, another node's output, a tendency field, a computed
+ * function of time — by whatever means the caller chooses. The common
+ * geometry helpers in Geometry.hpp are illustrative, not idiomatic.
+ *
+ * Orchestration (node binding, buffer mapping, scheduler-driven update,
+ * input capture) attaches externally by writing to state and calling
+ * state->write(v). Mapped has no knowledge of or dependency on any
+ * orchestration layer.
+ *
+ * @tparam T Value type.
+ */
+template <typename T>
+struct Mapped {
+    /// @brief Shared value carrier. External systems hold a copy of this ptr.
+    std::shared_ptr<MappedState<T>> state;
+
+    /// @brief Geometry regeneration function. Set once at construction.
+    GeometryFn<T> geometry_fn;
+
+    /// @brief The Element registered with the Layer.
+    ///        element.id is valid after Layer::add(element) has been called.
+    Element element;
+
+    /// @brief Last version seen by sync(). Initialised to a sentinel that
+    ///        guarantees one geometry generation on the first sync() call.
+    Version last_version { static_cast<Version>(-1) };
+
+    /**
+     * @brief Call once per graphics tick.
+     *
+     * If state->version has advanced since last_version, invokes geometry_fn
+     * with the current value into a local byte buffer, then passes the result
+     * to VKBuffer::set_data so the existing upload path handles GPU transfer.
+     *
+     * The caller is responsible for driving the graphics tick — Mapped does
+     * not register itself with any scheduler.
+     */
+    void sync()
+    {
+        if (!state || !geometry_fn || !element.buffer)
+            return;
+        if (state->version == last_version)
+            return;
+
+        geometry_fn(state->value, m_bytes, element);
+        element.buffer->set_data({ m_bytes });
+        last_version = state->version;
+    }
+
+private:
+    std::vector<uint8_t> m_bytes;
+};
+
+/**
+ * @brief Construct a Mapped<T> with a freshly allocated MappedState.
+ * @param initial   Starting value.
+ * @param geometry  Geometry function producing vertex bytes from a value.
+ * @param buffer    VKBuffer whose raw bytes the geometry function writes into.
+ * @return Ready-to-use Mapped. Register element with a Layer before first sync().
+ */
+template <typename T>
+[[nodiscard]] Mapped<T> make_mapped(
+    T initial,
+    GeometryFn<T> geometry,
+    std::shared_ptr<Buffers::VKBuffer> buffer)
+{
+    auto st = std::make_shared<MappedState<T>>();
+    st->write(initial);
+
+    Element el;
+    el.buffer = std::move(buffer);
+
+    return Mapped<T> {
+        .state = std::move(st),
+        .geometry_fn = std::move(geometry),
+        .element = std::move(el),
+        .last_version = static_cast<Version>(-1)
+    };
+}
+
+} // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Primitives/Mapped.hpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/Mapped.hpp
@@ -37,6 +37,7 @@ template <typename T>
 struct MappedState {
     T value {};
     Version version { 0 };
+    uint32_t id { 0 };
 
     void write(T v)
     {

--- a/src/MayaFlux/Portal/Forma/Primitives/Mapped.hpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/Mapped.hpp
@@ -119,7 +119,7 @@ struct Mapped {
             return;
 
         geometry_fn(state->value, m_bytes, element);
-        element.buffer->write_bytes(m_bytes);
+        element.buffer->submit(m_bytes);
         last_version = state->version;
     }
 

--- a/src/MayaFlux/Portal/Forma/Primitives/Mapped.hpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/Mapped.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "MayaFlux/Buffers/Forma/FormaBuffer.hpp"
 #include "MayaFlux/Portal/Forma/Element.hpp"
 
 namespace MayaFlux::Buffers {
@@ -137,7 +138,7 @@ template <typename T>
 [[nodiscard]] Mapped<T> make_mapped(
     T initial,
     GeometryFn<T> geometry,
-    std::shared_ptr<Buffers::VKBuffer> buffer)
+    std::shared_ptr<Buffers::FormaBuffer> buffer)
 {
     auto st = std::make_shared<MappedState<T>>();
     st->write(initial);

--- a/src/MayaFlux/Portal/Forma/Primitives/Mapped.hpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/Mapped.hpp
@@ -119,7 +119,7 @@ struct Mapped {
             return;
 
         geometry_fn(state->value, m_bytes, element);
-        element.buffer->set_data({ m_bytes });
+        element.buffer->write_bytes(m_bytes);
         last_version = state->version;
     }
 
@@ -146,12 +146,12 @@ template <typename T>
     Element el;
     el.buffer = std::move(buffer);
 
-    return Mapped<T> {
-        .state = std::move(st),
-        .geometry_fn = std::move(geometry),
-        .element = std::move(el),
-        .last_version = static_cast<Version>(-1)
-    };
+    Mapped<T> m;
+    m.state = std::move(st);
+    m.geometry_fn = std::move(geometry);
+    m.element = std::move(el);
+    m.last_version = static_cast<Version>(-1);
+    return m;
 }
 
 } // namespace MayaFlux::Portal::Forma


### PR DESCRIPTION

Adds `Portal::Forma`: the layer where rendered screen regions and pointer events meet. It is not a widget toolkit. It does not manage layout, own interaction policy, or enforce shape conventions. It is the infrastructure through which any value (audio energy, node output, a tendency field, a cursor position) can be expressed geometrically on the window surface, respond to pointer input, and feed back into the signal graph without any special routing.

---

**Context**

"User interaction" has been narrowed, by convention, to mean clicking things in a window. That narrowing is not a property of the domain. Stirring a pot is user interaction. The spatial logic of modal text editing is user interaction. A pressure sensor under a floor tile is user interaction. The category is: an entity expresses intent, a system reads it.

What software frameworks did was collapse that category down to a specific substrate (the windowed GUI) and then build a class hierarchy around the collapsed version. The result is that the widget and the signal are always separate things. A fader value has to be extracted and manually routed. A rendered region cannot be a data source. Interaction sits outside computation.

In MayaFlux, a rendered screen region and a node output are the same kind of thing. Both carry a value. Both can write into the graph. The question Forma addresses is: how do you describe a region of the window surface such that it can receive pointer input, maintain a value, express that value geometrically, and route it wherever any other signal goes? Not as a special case. As a first-class participant in the same scheduler, the same buffer infrastructure, the same binding machinery.

The geometry function is the primitive answer. A value, a function from value to vertex bytes, and a spatial description. That is the complete model. `horizontal_fader`, `radial`, `position_picker` exist as named starting points, not as the intended idiom. The intended idiom is: write the geometry function that fits the situation.

---

**What is built**

**`Kinesis/Spatial/Bounds.hpp`**

Single include for all 2D containment math. `AABB2D` with named constructors for NDC and pixel space. `circular_bounds`, `polygon_bounds` (winding number, handles concave shapes), `stroke_bounds` (open and closed curves with thickness threshold). Combinator functions `union_bounds`, `intersect_bounds`, `subtract_bounds`. All factories return `std::function<bool(glm::vec2)>` matching `Element::contains` directly. No shape is privileged.

**`FormaBuffer` (`Buffers::Forma`)**

`FormaBuffer : VKBuffer`. Encodes the invariants that hold for all Forma geometry: no depth test, no depth write, no view transform, alpha blending always on, topology fixed at construction. `submit(const vector<uint8_t>&)` is the vertex byte upload path. `set_texture(shared_ptr<VKImage>, string binding)` binds any externally-owned image on the next tick: a `TextBuffer` glyph atlas, a loaded asset, a render target. `FormaProcessor` handles the CPU-to-GPU upload cycle behind an `atomic_flag` dirty check.

**`Element`**

Pairs a spatial description with a `FormaBuffer`. The description is open: `bounds_hint` (optional `AABB2D`, fast-reject only) and `contains` (authoritative `std::function<bool(glm::vec2)>`). Neither is required to be a rectangle. An element with neither set never hits. `Element` is a pure spatial and identity construct. It encodes no rendering preferences.

**`Layer`**

Flat registry of `Element`s. Back-to-front traversal for hit testing. `bring_to_front` / `send_to_back` for explicit ordering. `relate(primary_id, related_id)` records a hierarchical relation: `remove`, `set_visible`, `bring_to_front`, `send_to_back` all cascade from primary to related elements. No window dependency.

**`Context`**

Wires a `shared_ptr<Layer>` against a window's mouse events via `Kriya` input coroutines registered with `Vruta::EventManager` by name. Per-element callbacks: `on_press`, `on_release`, `on_move`, `on_enter`, `on_leave`, `on_scroll`. All coroutines cancelled by name on destruction.

**`MappedState<T>` and `Mapped<T>` (`Primitives/`)**

The geometry function is the primitive. `MappedState<T>` is a shared value carrier (`value` + `version` counter + `id`). Any external system holds a `shared_ptr<MappedState<T>>` and calls `state->write(v)`. `GeometryFn<T>` is `std::function<void(T, vector<uint8_t>&, Element&)>`. `Mapped<T>::sync()` compares version, invokes the geometry function only on change, and calls `buffer->submit`. `Mapped` has no knowledge of any orchestration layer. Orchestration attaches externally.

`Geometry.hpp` provides three illustrative `GeometryFn` factories (`horizontal_fader`, `radial`, `position_picker`) as demonstrations of the contract, not as canonical implementations.

**`FormaBindingsProcessor`**

`ShaderProcessor` subclass that attaches to a `FormaBuffer` as a secondary processor. Owns no pipeline. Reads type-erased `std::function<float()>` readers each tick and routes the projected value to push constant staging on an external `ShaderProcessor` or to a descriptor buffer registered on the attached buffer's `pipeline_context`. Templated `bind_push_constant` and `bind_descriptor` overloads accept any `MappedState<T>` and a projection function; the type-erased reader is constructed internally.

**`Forma.hpp/cpp` (free functions, `Portal::Forma` namespace)**

No class, no singleton, no tracked state. `create_layer(window, name)` returns a `pair<shared_ptr<Layer>, shared_ptr<Context>>`. `create_element<T>(layer, window, geom, initial, capacity, topology)` constructs the buffer, the `Mapped<T>`, registers the element on the layer, registers it with the application Bridge, and returns the `Mapped<T>` to the caller. `create_buffer(window, capacity, topology)` for callers managing geometry directly. Lifecycle via `initialize(buffer_manager, scheduler, event_manager)` and `shutdown()`, matching `Portal::Text` and `Portal::Graphics`.

**`Bridge`**

Two-way binding orchestrator. One instance per application, owned by the Forma module and accessible via `get_bridge()`. Owns inbound `GraphicsRoutine` tasks and outbound `FormaBindingsProcessor` instances. Does not own `Layer` or `Context`.

Inbound: `bind(id, Node)` reads `get_last_output()` each tick via `GraphicsRoutine` and writes into `MappedState`. `bind(id, std::function<float()>)` for arbitrary per-frame callables.

Outbound: `write(id, VKBuffer, shader_path, offset)` for push constants. `write(id, descriptor_name, binding, set, role)` for descriptor bindings. `write(id, AudioWriteProcessor)` and `write(id, GeometryWriteProcessor)` via per-frame coroutines. `write(id, Constant)` to feed a node graph value carrier.

All overloads also accept `shared_ptr<MappedState<T>>` in place of the element id, resolving via `state->id`.

---

**Engine integration**

`Portal::Forma::initialize` called in `Engine::Start` after subsystems. `Portal::Forma::shutdown` called at the top of `Engine::End` before node graph teardown. Both `FormaBuffer.hpp` and `FormaBindingsProcessor.hpp` added to the global `MayaFlux.hpp` header alongside `Forma.hpp` and `Primitives/Geometry.hpp`.

---

**Trials passing**

1. Static point at fixed NDC: `FormaBuffer`, one `Element`, `Layer` hit test, `Context` press callback. Verifies the full stack end-to-end with nothing moving.
2. Point following cursor via `Mapped<glm::vec2>`: `on_move` writes to state, `schedule_metro` calls `sync()` each frame. Verifies `Mapped` + `GeometryFn` + `sync()`.
3. Horizontal bar width driven by noise node output via `Mapped<float>`: no user interaction, pure data-to-geometry path.
4. Clickable quad with hover tint and press/release color change via `Context` callbacks.
5. Composed: `TextBuffer` `VKImage` as background texture on one `FormaBuffer`, geometry quad as primary interactive element on a second. `Layer::relate` cascade verified: `set_visible` and `bring_to_front` on the primary propagate to the background correctly.
6. Bridge inbound: `create_element<float>` with `horizontal_fader`, `Bridge::bind(state, Node)` drives the fader from a sine node each frame.
7. Bridge outbound to `Constant` node: fader drag writes to `MappedState`, `Bridge::write(state, Constant)` routes the value into the node graph each frame.
8. Bridge outbound to push constant: fader drives a `brightness` push constant on an external shader pipeline via `Bridge::write(state, VKBuffer, shader_path, offset)`.
9. Bridge outbound to descriptor UBO: fader drives `TintBlock` at `set=1 binding=0` on a full-screen `FormaBuffer` running a custom fragment shader via `Bridge::write(state, VKBuffer, shader_path, descriptor_name, binding, set, role)`.

---

**Design decisions**

- No widget class hierarchy. No button class, no slider class. There is a value, a geometry function, and an element.
- Shape is not privileged. The geometry function decides everything about topology and vertex layout. `horizontal_fader` and `radial` exist because they are convenient, not because they are the intended idiom.
- `FormaBuffer` is `VKBuffer`, not `TextureBuffer`. Texture data enters via `set_texture(VKImage)` from any externally-managed image.
- `Mapped` knows nothing about orchestration. `Bridge` attaches externally without modifying any Forma primitive.
- The `Mapped<T>` overload of `register_element` takes by value and moves into the sync coroutine. The sync loop is owned by `Bridge`, not the caller. The by-value capture is deliberate: ref was not safe across the callsite boundary.
- No `Panel` layout engine. The philosophy is anti-menu-diving. Contributor PRs are welcome; the core will not build one.

---

**What is explicitly not Forma's concern**

MIDI, HID, OSC, gestural sensors: those are `Nexus` and `IO`. Constraint-based layout, scrollable containers, text input with IME, cable/patch-bay rendering: deferred. These are not limitations of the model. The model is deliberately substrate-agnostic. Forma covers the window surface case.