### PR TITLE
refactor(nodes): node system cleanup and typed callback migration

### DIFF
--- a/cmake/pch_minimal.h
+++ b/cmake/pch_minimal.h
@@ -21,7 +21,6 @@
 #include "set"
 #include "shared_mutex"
 #include "span"
-#include "sstream"
 #include "string"
 #include "thread"
 #include "unordered_map"

--- a/src/MayaFlux/Nodes/Conduit/Constant.hpp
+++ b/src/MayaFlux/Nodes/Conduit/Constant.hpp
@@ -124,7 +124,7 @@ private:
      */
     struct ConstantContext final : NodeContext {
         ConstantContext()
-            : NodeContext(0.0, typeid(Constant).name())
+            : NodeContext(0.0)
         {
         }
     };

--- a/src/MayaFlux/Nodes/Conduit/NodeCombine.cpp
+++ b/src/MayaFlux/Nodes/Conduit/NodeCombine.cpp
@@ -7,7 +7,7 @@
 namespace MayaFlux::Nodes {
 
 BinaryOpContext::BinaryOpContext(double value, double lhs_value, double rhs_value)
-    : NodeContext(value, typeid(BinaryOpContext).name())
+    : NodeContext(value)
     , lhs_value(lhs_value)
     , rhs_value(rhs_value)
 {
@@ -17,11 +17,10 @@ BinaryOpContextGpu::BinaryOpContextGpu(double value, double lhs_value, double rh
     : BinaryOpContext(value, lhs_value, rhs_value)
     , GpuVectorData(gpu_data)
 {
-    type_id = typeid(BinaryOpContextGpu).name();
 }
 
 CompositeOpContext::CompositeOpContext(double value, std::vector<double> input_values)
-    : NodeContext(value, typeid(CompositeOpContext).name())
+    : NodeContext(value)
     , input_values(std::move(input_values))
 {
 }
@@ -30,7 +29,6 @@ CompositeOpContextGpu::CompositeOpContextGpu(double value, std::vector<double> i
     : CompositeOpContext(value, std::move(input_values))
     , GpuVectorData(gpu_data)
 {
-    type_id = typeid(CompositeOpContextGpu).name();
 }
 
 BinaryOpNode::BinaryOpNode(const std::shared_ptr<Node>& lhs, const std::shared_ptr<Node>& rhs, CombineFunc func)

--- a/src/MayaFlux/Nodes/Conduit/StreamReaderNode.hpp
+++ b/src/MayaFlux/Nodes/Conduit/StreamReaderNode.hpp
@@ -64,7 +64,7 @@ protected:
 private:
     struct StreamReaderContext final : NodeContext {
         StreamReaderContext()
-            : NodeContext(0.0, typeid(StreamReaderNode).name())
+            : NodeContext(0.0)
         {
         }
     };

--- a/src/MayaFlux/Nodes/Filters/Filter.cpp
+++ b/src/MayaFlux/Nodes/Filters/Filter.cpp
@@ -281,4 +281,21 @@ NodeContext& Filter::get_last_context()
     return m_context;
 }
 
+void Filter::on_tick(const TypedHook<FilterContext>& callback)
+{
+    m_callbacks.emplace_back([callback](NodeContext& ctx) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+        callback(static_cast<FilterContext&>(ctx));
+    });
+}
+
+void Filter::on_tick_if(const NodeCondition& condition, const TypedHook<FilterContext>& callback)
+{
+    m_conditional_callbacks.emplace_back([callback](NodeContext& ctx) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+        callback(static_cast<FilterContext&>(ctx));
+    },
+        condition);
+}
+
 }

--- a/src/MayaFlux/Nodes/Filters/Filter.hpp
+++ b/src/MayaFlux/Nodes/Filters/Filter.hpp
@@ -497,6 +497,19 @@ public:
         }
     }
 
+    /**
+     * @brief Registers a callback to be called on each tick with the filter context
+     * @param callback Typed hook that receives a FilterContext object
+     */
+    void on_tick(const TypedHook<FilterContext>& callback);
+
+    /**
+     * @brief Registers a conditional callback to be called on each tick if the condition is met
+     * @param condition NodeCondition that determines whether the callback should be called
+     * @param callback Typed hook that receives a FilterContext object
+     */
+    void on_tick_if(const NodeCondition& condition, const TypedHook<FilterContext>& callback);
+
 protected:
     /**
      * @brief Modifies a specific coefficient in a coefficient buffer

--- a/src/MayaFlux/Nodes/Filters/Filter.hpp
+++ b/src/MayaFlux/Nodes/Filters/Filter.hpp
@@ -45,7 +45,7 @@ public:
         const std::vector<double>& output_history,
         const std::vector<double>& coefs_a,
         const std::vector<double>& coefs_b)
-        : NodeContext(value, typeid(FilterContext).name())
+        : NodeContext(value)
         , input_history(input_history)
         , output_history(output_history)
         , coefs_a(coefs_a)

--- a/src/MayaFlux/Nodes/Generators/Counter.cpp
+++ b/src/MayaFlux/Nodes/Generators/Counter.cpp
@@ -8,6 +8,7 @@ Counter::Counter(uint32_t modulo, int32_t step)
 {
     m_amplitude = 1.0;
     m_frequency = 0.F;
+    m_context = GeneratorContext(0.0, m_frequency, m_amplitude, 0.F);
 }
 
 Counter::Counter(const std::shared_ptr<Node>& reset_trigger, uint32_t modulo, int32_t step)
@@ -17,6 +18,7 @@ Counter::Counter(const std::shared_ptr<Node>& reset_trigger, uint32_t modulo, in
 {
     m_amplitude = 1.0;
     m_frequency = 0.F;
+    m_context = GeneratorContext(0.0, m_frequency, m_amplitude, 0.F);
 }
 
 void Counter::set_modulo(uint32_t modulo) { m_modulo = modulo; }
@@ -148,11 +150,6 @@ void Counter::notify_tick(double value)
 void Counter::update_context(double value)
 {
     m_context = GeneratorContext(value, 0.F, m_amplitude, static_cast<double>(m_count));
-}
-
-NodeContext& Counter::get_last_context()
-{
-    return m_context;
 }
 
 void Counter::save_state()

--- a/src/MayaFlux/Nodes/Generators/Counter.hpp
+++ b/src/MayaFlux/Nodes/Generators/Counter.hpp
@@ -114,7 +114,6 @@ public:
 protected:
     void notify_tick(double value) override;
     void update_context(double value) override;
-    NodeContext& get_last_context() override;
 
 private:
     uint32_t m_count { 0 };
@@ -133,8 +132,6 @@ private:
     std::vector<TypedHook<GeneratorContext>> m_increment_callbacks;
     std::vector<TypedHook<GeneratorContext>> m_wrap_callbacks;
     std::vector<std::pair<uint32_t, TypedHook<GeneratorContext>>> m_count_callbacks;
-
-    GeneratorContext m_context { 0.0, 0.F, 1.0, 0.0 };
 };
 
 } // namespace MayaFlux::Nodes::Generator

--- a/src/MayaFlux/Nodes/Generators/Counter.hpp
+++ b/src/MayaFlux/Nodes/Generators/Counter.hpp
@@ -46,9 +46,6 @@ public:
 
     std::vector<double> process_batch(unsigned int num_samples) override;
 
-    inline void printGraph() override { }
-    inline void printCurrent() override { }
-
     /**
      * @brief Sets the wrap boundary
      * @param modulo New modulo value (0 = unbounded)

--- a/src/MayaFlux/Nodes/Generators/Generator.cpp
+++ b/src/MayaFlux/Nodes/Generators/Generator.cpp
@@ -67,4 +67,35 @@ void operator*(const std::shared_ptr<Node>& node, double value)
     }
 }
 
+void Generator::notify_tick(double value)
+{
+    update_context(value);
+    auto& ctx = get_last_context();
+    for (auto& cb : m_callbacks) {
+        cb(ctx);
+    }
+    for (auto& [cb, cond] : m_conditional_callbacks) {
+        if (cond(ctx)) {
+            cb(ctx);
+        }
+    }
+}
+
+void Generator::on_tick(const TypedHook<GeneratorContext>& callback)
+{
+    m_callbacks.emplace_back([callback](NodeContext& ctx) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+        callback(static_cast<GeneratorContext&>(ctx));
+    });
+}
+
+void Generator::on_tick_if(const NodeCondition& condition, const TypedHook<GeneratorContext>& callback)
+{
+    m_conditional_callbacks.emplace_back([callback](NodeContext& ctx) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+        callback(static_cast<GeneratorContext&>(ctx));
+    },
+        condition);
+}
+
 } // namespace MayaFlux::Nodes::Generator

--- a/src/MayaFlux/Nodes/Generators/Generator.hpp
+++ b/src/MayaFlux/Nodes/Generators/Generator.hpp
@@ -150,24 +150,6 @@ public:
     [[nodiscard]] virtual bool should_mock_process() const;
 
     /**
-     * @brief Prints a visual representation of the generated pattern
-     *
-     * This method should output a visual representation of the
-     * generator's output over time, useful for analysis and
-     * understanding the pattern characteristics.
-     */
-    virtual void printGraph() = 0;
-
-    /**
-     * @brief Prints the current state and parameters of the generator
-     *
-     * This method should output the current configuration and state
-     * of the generator, including parameters like frequency, amplitude,
-     * phase, or any other generator-specific settings.
-     */
-    virtual void printCurrent() = 0;
-
-    /**
      * @brief Updates the context object for callbacks
      * @param value The current generated sample
      *

--- a/src/MayaFlux/Nodes/Generators/Generator.hpp
+++ b/src/MayaFlux/Nodes/Generators/Generator.hpp
@@ -174,6 +174,20 @@ public:
      */
     NodeContext& get_last_context() override;
 
+    /**
+     * @brief Registers a typed callback receiving GeneratorContext directly
+     * @param callback Receives frequency, amplitude, and phase without casting
+     */
+    void on_tick(const TypedHook<GeneratorContext>& callback);
+
+    /**
+     * @brief Registers a conditional typed callback receiving GeneratorContext directly
+     * @param condition Predicate that determines when callback should be triggered
+     * @param callback Receives frequency, amplitude, and phase without casting when condition is met
+
+     */
+    void on_tick_if(const NodeCondition& condition, const TypedHook<GeneratorContext>& callback);
+
 protected:
     /**
      * @brief Base amplitude of the generator
@@ -192,6 +206,8 @@ protected:
 
     GeneratorContext m_context { 0., m_frequency, m_amplitude, m_phase };
     GeneratorContextGpu m_context_gpu { 0., m_frequency, m_amplitude, m_phase, get_gpu_data_buffer() };
+
+    void notify_tick(double value) override;
 };
 
 /**

--- a/src/MayaFlux/Nodes/Generators/Generator.hpp
+++ b/src/MayaFlux/Nodes/Generators/Generator.hpp
@@ -35,7 +35,7 @@ public:
      * and all parameters that define its oscillation behavior.
      */
     GeneratorContext(double value, float frequency, double amplitude, double phase)
-        : NodeContext(value, typeid(GeneratorContext).name())
+        : NodeContext(value)
         , frequency(frequency)
         , amplitude(amplitude)
         , phase(phase)
@@ -73,7 +73,6 @@ public:
         : GeneratorContext(value, frequency, amplitude, phase)
         , GpuVectorData(gpu_data)
     {
-        type_id = typeid(GeneratorContextGpu).name();
     }
 };
 

--- a/src/MayaFlux/Nodes/Generators/Impulse.cpp
+++ b/src/MayaFlux/Nodes/Generators/Impulse.cpp
@@ -164,22 +164,22 @@ void Impulse::reset(float frequency, float amplitude, float offset)
     m_last_output = 0.0;
 }
 
-void Impulse::on_impulse(const NodeHook& callback)
+void Impulse::on_impulse(const TypedHook<GeneratorContext>& callback)
 {
     safe_add_callback(m_impulse_callbacks, callback);
 }
 
-bool Impulse::remove_hook(const NodeHook& callback)
+bool Impulse::remove_hook(const TypedHook<GeneratorContext>& callback)
 {
-    bool removed_from_tick = safe_remove_callback(m_callbacks, callback);
-    bool removed_from_impulse = safe_remove_callback(m_impulse_callbacks, callback);
-    return removed_from_tick || removed_from_impulse;
+    return safe_remove_callback(m_impulse_callbacks, callback);
 }
 
 void Impulse::notify_tick(double value)
 {
     update_context(value);
-    auto& ctx = get_last_context();
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+    auto& ctx = static_cast<GeneratorContext&>(get_last_context());
 
     for (auto& callback : m_callbacks) {
         callback(ctx);

--- a/src/MayaFlux/Nodes/Generators/Impulse.hpp
+++ b/src/MayaFlux/Nodes/Generators/Impulse.hpp
@@ -105,22 +105,6 @@ public:
     std::vector<double> process_batch(unsigned int num_samples) override;
 
     /**
-     * @brief Prints a visual representation of the impulse train
-     *
-     * Outputs a text-based graph of the impulse pattern over time,
-     * useful for debugging and visualization.
-     */
-    inline void printGraph() override { }
-
-    /**
-     * @brief Prints the current parameters of the impulse generator
-     *
-     * Outputs the current frequency, amplitude, offset, and modulation
-     * settings of the generator.
-     */
-    inline void printCurrent() override { }
-
-    /**
      * @brief Sets the generator's frequency
      * @param frequency New frequency in Hz
      *

--- a/src/MayaFlux/Nodes/Generators/Impulse.hpp
+++ b/src/MayaFlux/Nodes/Generators/Impulse.hpp
@@ -180,7 +180,7 @@ public:
      * receives a GeneratorContext containing the generated value and
      * generator parameters like frequency, amplitude, and phase.
      */
-    void on_impulse(const NodeHook& callback);
+    void on_impulse(const TypedHook<GeneratorContext>& callback);
 
     /**
      * @brief Removes a previously registered callback
@@ -190,7 +190,7 @@ public:
      * Unregisters a callback previously added with on_tick(), stopping
      * it from receiving further notifications about generated samples.
      */
-    bool remove_hook(const NodeHook& callback) override;
+    bool remove_hook(const TypedHook<GeneratorContext>& callback);
 
     /**
      * @brief Removes all registered callbacks
@@ -257,7 +257,7 @@ private:
     /**
      * @brief Collection of impulse-specific callback functions
      */
-    std::vector<NodeHook> m_impulse_callbacks;
+    std::vector<TypedHook<GeneratorContext>> m_impulse_callbacks;
 
     bool m_impulse_occurred;
 

--- a/src/MayaFlux/Nodes/Generators/Logic.cpp
+++ b/src/MayaFlux/Nodes/Generators/Logic.cpp
@@ -504,7 +504,9 @@ void Logic::notify_tick(double value)
 {
     update_context(value);
     bool state_changed = (value != m_last_output);
-    auto& ctx = get_last_context();
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+    auto& ctx = static_cast<LogicContext&>(get_last_context());
 
     for (const auto& cb : m_all_callbacks) {
         bool should_call = false;
@@ -558,71 +560,61 @@ std::span<bool> Logic::get_history()
     return { reinterpret_cast<bool*>(m_history_linear.data()), m_history_count };
 }
 
-void Logic::on_tick(const NodeHook& callback)
+void Logic::on_tick(const TypedHook<LogicContext>& callback)
 {
     add_callback(callback, LogicEventType::TICK);
 }
 
-void Logic::on_tick_if(const NodeCondition& condition, const NodeHook& callback)
+void Logic::on_tick_if(const NodeCondition& condition, const TypedHook<LogicContext>& callback)
 {
     add_callback(callback, LogicEventType::CONDITIONAL, condition);
 }
 
-void Logic::while_true(const NodeHook& callback)
+void Logic::while_true(const TypedHook<LogicContext>& callback)
 {
     add_callback(callback, LogicEventType::WHILE_TRUE);
 }
 
-void Logic::while_false(const NodeHook& callback)
+void Logic::while_false(const TypedHook<LogicContext>& callback)
 {
     add_callback(callback, LogicEventType::WHILE_FALSE);
 }
 
-void Logic::on_change(const NodeHook& callback)
+void Logic::on_change(const TypedHook<LogicContext>& callback)
 {
     add_callback(callback, LogicEventType::CHANGE);
 }
 
-void Logic::on_change_to(bool target_state, const NodeHook& callback)
+void Logic::on_change_to(bool target_state, const TypedHook<LogicContext>& callback)
 {
     add_callback(callback, target_state ? LogicEventType::TRUE : LogicEventType::FALSE);
 }
 
-bool Logic::remove_hook(const NodeHook& callback)
+bool Logic::remove_hook(const TypedHook<LogicContext>& callback)
 {
-    auto it = std::remove_if(m_all_callbacks.begin(), m_all_callbacks.end(),
-        [&callback](const LogicCallback& cb) {
-            return cb.callback.target_type() == callback.target_type();
-        });
+    auto old_size = m_all_callbacks.size();
 
-    if (it != m_all_callbacks.end()) {
-        m_all_callbacks.erase(it, m_all_callbacks.end());
-        return true;
-    }
-    return false;
+    std::erase_if(m_all_callbacks, [&callback](const LogicCallback& cb) {
+        return cb.typed_callback.target_type() == callback.target_type();
+    });
+
+    return m_all_callbacks.size() < old_size;
 }
 
 bool Logic::remove_conditional_hook(const NodeCondition& callback)
 {
-    auto it = std::remove_if(m_all_callbacks.begin(), m_all_callbacks.end(),
-        [&callback](const LogicCallback& cb) {
-            return cb.event_type == LogicEventType::CONDITIONAL && cb.condition && cb.condition->target_type() == callback.target_type();
-        });
-
-    if (it != m_all_callbacks.end()) {
-        m_all_callbacks.erase(it, m_all_callbacks.end());
-        return true;
-    }
-    return false;
+    auto old_size = m_all_callbacks.size();
+    std::erase_if(m_all_callbacks, [&callback](const LogicCallback& cb) {
+        return cb.event_type == LogicEventType::CONDITIONAL && cb.condition && cb.condition->target_type() == callback.target_type();
+    });
+    return m_all_callbacks.size() < old_size;
 }
 
 void Logic::remove_hooks_of_type(LogicEventType type)
 {
-    auto it = std::remove_if(m_all_callbacks.begin(), m_all_callbacks.end(),
-        [type](const LogicCallback& cb) {
-            return cb.event_type == type;
-        });
-    m_all_callbacks.erase(it, m_all_callbacks.end());
+    std::erase_if(m_all_callbacks, [type](const LogicCallback& cb) {
+        return cb.event_type == type;
+    });
 }
 
 void Logic::history_push(bool val)

--- a/src/MayaFlux/Nodes/Generators/Logic.hpp
+++ b/src/MayaFlux/Nodes/Generators/Logic.hpp
@@ -447,16 +447,6 @@ public:
     EdgeType get_edge_type() const { return m_edge_type; }
 
     /**
-     * @brief Prints a visual representation of the logic function
-     */
-    inline void printGraph() override { }
-
-    /**
-     * @brief Prints the current state and parameters
-     */
-    inline void printCurrent() override { }
-
-    /**
      * @brief Registers a callback for every generated sample
      * @param callback Function to call when a new sample is generated
      */

--- a/src/MayaFlux/Nodes/Generators/Logic.hpp
+++ b/src/MayaFlux/Nodes/Generators/Logic.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <utility>
-
 #include "MayaFlux/Nodes/Generators/Generator.hpp"
 
 namespace MayaFlux::Nodes::Generator {
@@ -80,7 +78,7 @@ public:
         bool edge_detected = false,
         EdgeType edge_type = EdgeType::BOTH,
         const std::vector<double>& inputs = {})
-        : NodeContext(value, typeid(LogicContext).name())
+        : NodeContext(value)
         , m_mode(mode)
         , m_operator(operator_type)
         , m_history(history)
@@ -139,7 +137,6 @@ public:
         : LogicContext(value, mode, operator_type, history, threshold, edge_detected, edge_type, inputs)
         , GpuVectorData(gpu_data)
     {
-        type_id = typeid(LogicContextGpu).name();
     }
 
     friend class Logic;

--- a/src/MayaFlux/Nodes/Generators/Logic.hpp
+++ b/src/MayaFlux/Nodes/Generators/Logic.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "MayaFlux/Nodes/Generators/Generator.hpp"
 
 namespace MayaFlux::Nodes::Generator {
@@ -450,46 +452,46 @@ public:
      * @brief Registers a callback for every generated sample
      * @param callback Function to call when a new sample is generated
      */
-    void on_tick(const NodeHook& callback) override;
+    void on_tick(const TypedHook<LogicContext>& callback);
 
     /**
      * @brief Registers a conditional callback for generated samples
      * @param callback Function to call when condition is met
      * @param condition Predicate that determines when callback is triggered
      */
-    void on_tick_if(const NodeCondition& condition, const NodeHook& callback) override;
+    void on_tick_if(const NodeCondition& condition, const TypedHook<LogicContext>& callback);
 
     /**
      * @brief Registers a callback that executes continuously while output is true
      * @param callback Function to call on each tick when output is true (1.0)
      */
-    void while_true(const NodeHook& callback);
+    void while_true(const TypedHook<LogicContext>& callback);
 
     /**
      * @brief Registers a callback that executes continuously while output is false
      * @param callback Function to call on each tick when output is false (0.0)
      */
-    void while_false(const NodeHook& callback);
+    void while_false(const TypedHook<LogicContext>& callback);
 
     /**
      * @brief Registers a callback for when output changes to a specific state
      * @param target_state The state to detect (true for 1.0, false for 0.0)
      * @param callback Function to call when state changes to target_state
      */
-    void on_change_to(bool target_state, const NodeHook& callback);
+    void on_change_to(bool target_state, const TypedHook<LogicContext>& callback);
 
     /**
      * @brief Registers a callback for any state change (true↔false)
      * @param callback Function to call when output changes state
      */
-    void on_change(const NodeHook& callback);
+    void on_change(const TypedHook<LogicContext>& callback);
 
     /**
      * @brief Removes a previously registered callback
      * @param callback The callback function to remove
      * @return True if the callback was found and removed, false otherwise
      */
-    bool remove_hook(const NodeHook& callback) override;
+    bool remove_hook(const TypedHook<LogicContext>& callback);
 
     /**
      * @brief Removes a previously registered conditional callback
@@ -515,11 +517,28 @@ public:
 
     struct LogicCallback {
         NodeHook callback;
+        TypedHook<LogicContext> typed_callback;
         LogicEventType event_type;
-        std::optional<NodeCondition> condition; // Only used for CONDITIONAL type
+        std::optional<NodeCondition> condition;
 
-        LogicCallback(const NodeHook& cb, LogicEventType type, std::optional<NodeCondition> cond = std::nullopt)
-            : callback(cb)
+        LogicCallback(const LogicCallback&) = default;
+        LogicCallback& operator=(const LogicCallback&) = default;
+        LogicCallback(LogicCallback&&) = default;
+        LogicCallback& operator=(LogicCallback&&) = default;
+
+        LogicCallback(NodeHook cb, LogicEventType type, std::optional<NodeCondition> cond = std::nullopt)
+            : callback(std::move(cb))
+            , event_type(type)
+            , condition(std::move(cond))
+        {
+        }
+
+        LogicCallback(const TypedHook<LogicContext>& cb, LogicEventType type, std::optional<NodeCondition> cond = std::nullopt)
+            : callback([cb](NodeContext& ctx) {
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+                cb(static_cast<LogicContext&>(ctx));
+            })
+            , typed_callback(cb)
             , event_type(type)
             , condition(std::move(cond))
         {
@@ -599,7 +618,7 @@ private:
      * @param type The type of event to trigger the callback
      * @param condition Optional condition for conditional callbacks
      */
-    void add_callback(const NodeHook& callback, LogicEventType type, const std::optional<NodeCondition>& condition = std::nullopt)
+    void add_callback(const TypedHook<LogicContext>& callback, LogicEventType type, const std::optional<NodeCondition>& condition = std::nullopt)
     {
         m_all_callbacks.emplace_back(callback, type, condition);
     }

--- a/src/MayaFlux/Nodes/Generators/Phasor.cpp
+++ b/src/MayaFlux/Nodes/Generators/Phasor.cpp
@@ -163,14 +163,14 @@ void Phasor::reset(float frequency, float amplitude, float offset, double phase)
     m_last_output = 0.0;
 }
 
-void Phasor::on_phase_wrap(const NodeHook& callback)
+void Phasor::on_phase_wrap(const TypedHook<GeneratorContext>& callback)
 {
     safe_add_callback(m_phase_wrap_callbacks, callback);
 }
 
-void Phasor::on_threshold(const NodeHook& callback, double threshold, bool /*rising*/)
+void Phasor::on_threshold(const TypedHook<GeneratorContext>& callback, double threshold, bool /*rising*/)
 {
-    std::pair<NodeHook, double> entry = std::make_pair(callback, threshold);
+    std::pair<TypedHook<GeneratorContext>, double> entry = std::make_pair(callback, threshold);
     for (auto& pair : m_threshold_callbacks) {
         if (pair.first.target_type() == callback.target_type() && pair.second == threshold) {
             return;
@@ -179,7 +179,7 @@ void Phasor::on_threshold(const NodeHook& callback, double threshold, bool /*ris
     m_threshold_callbacks.push_back(entry);
 }
 
-bool Phasor::remove_threshold_callback(const NodeHook& callback)
+bool Phasor::remove_threshold_callback(const TypedHook<GeneratorContext>& callback)
 {
     for (auto it = m_threshold_callbacks.begin(); it != m_threshold_callbacks.end(); ++it) {
         if (it->first.target_type() == callback.target_type()) {
@@ -190,19 +190,18 @@ bool Phasor::remove_threshold_callback(const NodeHook& callback)
     return false;
 }
 
-bool Phasor::remove_hook(const NodeHook& callback)
+bool Phasor::remove_hook(const TypedHook<GeneratorContext>& callback)
 {
-    bool removed_from_tick = safe_remove_callback(m_callbacks, callback);
-    bool removed_from_phase_wrap = safe_remove_callback(m_phase_wrap_callbacks, callback);
-    bool removed_from_threshold = remove_threshold_callback(callback);
-    return removed_from_tick || removed_from_phase_wrap || removed_from_threshold;
+    return remove_threshold_callback(callback);
 }
 
 void Phasor::notify_tick(double value)
 {
     update_context(value);
 
-    auto& ctx = get_last_context();
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+    auto& ctx = static_cast<GeneratorContext&>(get_last_context());
+
     for (auto& callback : m_callbacks) {
         callback(ctx);
     }

--- a/src/MayaFlux/Nodes/Generators/Phasor.hpp
+++ b/src/MayaFlux/Nodes/Generators/Phasor.hpp
@@ -203,7 +203,7 @@ public:
      * The callback receives a GeneratorContext containing the generated
      * value and generator parameters like frequency, amplitude, and phase.
      */
-    void on_phase_wrap(const NodeHook& callback);
+    void on_phase_wrap(const TypedHook<GeneratorContext>& callback);
 
     /**
      * @brief Registers a callback for every time the phasor crosses a threshold
@@ -216,7 +216,7 @@ public:
      * receives a GeneratorContext containing the generated value and
      * generator parameters like frequency, amplitude, and phase.
      */
-    void on_threshold(const NodeHook& callback, double threshold, bool rising = true);
+    void on_threshold(const TypedHook<GeneratorContext>& callback, double threshold, bool rising = true);
 
     /**
      * @brief Removes a previously registered callback
@@ -226,7 +226,7 @@ public:
      * Unregisters a callback previously added with on_tick(), stopping
      * it from receiving further notifications about generated samples.
      */
-    bool remove_hook(const NodeHook& callback) override;
+    bool remove_hook(const TypedHook<GeneratorContext>& callback);
 
     /**
      * @brief Removes all registered callbacks
@@ -266,7 +266,7 @@ protected:
      * Unregisters a callback previously added with on_phase_wrap(),
      * stopping it from receiving further notifications about phase wraps.
      */
-    bool remove_threshold_callback(const NodeHook& callback);
+    bool remove_threshold_callback(const TypedHook<GeneratorContext>& callback);
 
 private:
     /**
@@ -304,12 +304,12 @@ private:
     /**
      * @brief Collection of phase wrap-specific callback functions
      */
-    std::vector<NodeHook> m_phase_wrap_callbacks;
+    std::vector<TypedHook<GeneratorContext>> m_phase_wrap_callbacks;
 
     /**
      * @brief Collection of threshold-specific callback functions with their thresholds
      */
-    std::vector<std::pair<NodeHook, double>> m_threshold_callbacks;
+    std::vector<std::pair<TypedHook<GeneratorContext>, double>> m_threshold_callbacks;
 
     /**
      * @brief Flag indicating whether the phase has wrapped in the current sample

--- a/src/MayaFlux/Nodes/Generators/Phasor.hpp
+++ b/src/MayaFlux/Nodes/Generators/Phasor.hpp
@@ -104,22 +104,6 @@ public:
     std::vector<double> process_batch(unsigned int num_samples) override;
 
     /**
-     * @brief Prints a visual representation of the phasor waveform
-     *
-     * Outputs a text-based graph of the phasor pattern over time,
-     * useful for debugging and visualization.
-     */
-    inline void printGraph() override { }
-
-    /**
-     * @brief Prints the current parameters of the phasor generator
-     *
-     * Outputs the current frequency, amplitude, offset, and modulation
-     * settings of the generator.
-     */
-    inline void printCurrent() override { }
-
-    /**
      * @brief Sets the generator's frequency
      * @param frequency New frequency in Hz
      *

--- a/src/MayaFlux/Nodes/Generators/Polynomial.cpp
+++ b/src/MayaFlux/Nodes/Generators/Polynomial.cpp
@@ -207,21 +207,6 @@ void Polynomial::update_context(double value)
     }
 }
 
-void Polynomial::notify_tick(double value)
-{
-    update_context(value);
-    auto& ctx = get_last_context();
-
-    for (auto& callback : m_callbacks) {
-        callback(ctx);
-    }
-    for (auto& [callback, condition] : m_conditional_callbacks) {
-        if (condition(ctx)) {
-            callback(ctx);
-        }
-    }
-}
-
 NodeContext& Polynomial::get_last_context()
 {
     if (m_gpu_compatible) {

--- a/src/MayaFlux/Nodes/Generators/Polynomial.hpp
+++ b/src/MayaFlux/Nodes/Generators/Polynomial.hpp
@@ -361,16 +361,6 @@ protected:
      */
     void update_context(double value) override;
 
-    /**
-     * @brief Notifies all registered callbacks about a new sample
-     * @param value The newly generated sample
-     *
-     * This method is called internally whenever a new sample is generated,
-     * creating the appropriate context and invoking all registered callbacks
-     * that should receive notification about this sample.
-     */
-    void notify_tick(double value) override;
-
 private:
     /**
      * @brief Converts coefficient vector to a polynomial function

--- a/src/MayaFlux/Nodes/Generators/Polynomial.hpp
+++ b/src/MayaFlux/Nodes/Generators/Polynomial.hpp
@@ -290,20 +290,6 @@ public:
     [[nodiscard]] std::span<double> get_output_buffer() { return m_history.linearized_view(); }
 
     /**
-     * @brief Prints a visual representation of the polynomial function
-     *
-     * Outputs a text-based graph of the polynomial function over a range of inputs.
-     */
-    inline void printGraph() override { }
-
-    /**
-     * @brief Prints the current state and parameters
-     *
-     * Outputs the current mode, buffer contents, and other relevant information.
-     */
-    inline void printCurrent() override { }
-
-    /**
      * @brief Sets the scaling factor for the output values
      */
     inline void set_amplitude(double amplitude) override { m_scale_factor = amplitude; }

--- a/src/MayaFlux/Nodes/Generators/Polynomial.hpp
+++ b/src/MayaFlux/Nodes/Generators/Polynomial.hpp
@@ -33,7 +33,7 @@ public:
         std::span<double> input_buffer,
         std::span<double> output_buffer,
         const std::vector<double>& coefficients)
-        : NodeContext(value, typeid(PolynomialContext).name())
+        : NodeContext(value)
         , m_mode(mode)
         , m_buffer_size(buffer_size)
         , m_input_buffer(input_buffer)
@@ -97,7 +97,6 @@ public:
         : PolynomialContext(value, mode, buffer_size, input_buffer, output_buffer, coefficients)
         , GpuVectorData(gpu_data)
     {
-        type_id = typeid(PolynomialContextGpu).name();
     }
 
     friend class Polynomial;

--- a/src/MayaFlux/Nodes/Generators/Random.cpp
+++ b/src/MayaFlux/Nodes/Generators/Random.cpp
@@ -73,21 +73,6 @@ void Random::update_context(double value)
     }
 }
 
-void Random::notify_tick(double value)
-{
-    update_context(value);
-    auto& ctx = get_last_context();
-
-    for (auto& callback : m_callbacks) {
-        callback(ctx);
-    }
-    for (auto& [callback, condition] : m_conditional_callbacks) {
-        if (condition(ctx)) {
-            callback(ctx);
-        }
-    }
-}
-
 NodeContext& Random::get_last_context()
 {
     if (m_gpu_compatible) {

--- a/src/MayaFlux/Nodes/Generators/Random.hpp
+++ b/src/MayaFlux/Nodes/Generators/Random.hpp
@@ -181,8 +181,6 @@ public:
      */
     void set_range(double start, double end);
 
-    void printGraph() override { }
-    void printCurrent() override { }
     void save_state() override { }
     void restore_state() override { }
 

--- a/src/MayaFlux/Nodes/Generators/Random.hpp
+++ b/src/MayaFlux/Nodes/Generators/Random.hpp
@@ -196,16 +196,6 @@ protected:
      */
     void update_context(double value) override;
 
-    /**
-     * @brief Notifies all registered callbacks about a new value
-     * @param value The newly generated value
-     *
-     * This method is called internally whenever a new value is generated,
-     * creating the appropriate context and invoking all registered callbacks
-     * that should receive notification about this value.
-     */
-    void notify_tick(double value) override;
-
     NodeContext& get_last_context() override;
 
 private:

--- a/src/MayaFlux/Nodes/Generators/Random.hpp
+++ b/src/MayaFlux/Nodes/Generators/Random.hpp
@@ -39,7 +39,7 @@ public:
      */
     RandomContext(double value, Kinesis::Stochastic::Algorithm type, double amplitude,
         double range_start, double range_end, double normal_spread)
-        : NodeContext(value, typeid(RandomContext).name())
+        : NodeContext(value)
         , distribution_type(type)
         , amplitude(amplitude)
         , range_start(range_start)
@@ -94,7 +94,6 @@ public:
         : RandomContext(value, type, amplitude, range_start, range_end, normal_spread)
         , GpuVectorData(gpu_data)
     {
-        type_id = typeid(RandomContextGpu).name();
     }
 };
 

--- a/src/MayaFlux/Nodes/Generators/Sine.cpp
+++ b/src/MayaFlux/Nodes/Generators/Sine.cpp
@@ -153,21 +153,6 @@ void Sine::reset(float frequency, double amplitude, float offset)
     update_phase_increment(frequency);
 }
 
-void Sine::notify_tick(double value)
-{
-    update_context(value);
-    auto& ctx = get_last_context();
-
-    for (auto& callback : m_callbacks) {
-        callback(ctx);
-    }
-    for (auto& [callback, condition] : m_conditional_callbacks) {
-        if (condition(ctx)) {
-            callback(ctx);
-        }
-    }
-}
-
 void Sine::save_state()
 {
     m_saved_phase = m_phase;

--- a/src/MayaFlux/Nodes/Generators/Sine.cpp
+++ b/src/MayaFlux/Nodes/Generators/Sine.cpp
@@ -200,12 +200,4 @@ void Sine::restore_state()
     m_state_saved = false;
 }
 
-void Sine::printGraph()
-{
-}
-
-void Sine::printCurrent()
-{
-}
-
 }

--- a/src/MayaFlux/Nodes/Generators/Sine.hpp
+++ b/src/MayaFlux/Nodes/Generators/Sine.hpp
@@ -105,22 +105,6 @@ public:
     std::vector<double> process_batch(unsigned int num_samples) override;
 
     /**
-     * @brief Prints a visual representation of the sine wave
-     *
-     * Outputs a text-based graph of the sine wave's shape over time,
-     * useful for debugging and visualization.
-     */
-    void printGraph() override;
-
-    /**
-     * @brief Prints the current parameters of the sine oscillator
-     *
-     * Outputs the current frequency, amplitude, offset, and modulation
-     * settings of the oscillator.
-     */
-    void printCurrent() override;
-
-    /**
      * @brief Sets the oscillator's frequency
      * @param frequency New frequency in Hz
      *

--- a/src/MayaFlux/Nodes/Generators/Sine.hpp
+++ b/src/MayaFlux/Nodes/Generators/Sine.hpp
@@ -175,17 +175,6 @@ public:
     void save_state() override;
     void restore_state() override;
 
-protected:
-    /**
-     * @brief Notifies all registered callbacks about a new sample
-     * @param value The newly generated sample
-     *
-     * This method is called internally whenever a new sample is generated,
-     * creating the appropriate context and invoking all registered callbacks
-     * that should receive notification about this sample.
-     */
-    void notify_tick(double value) override;
-
 private:
     /**
      * @brief Phase increment per sample

--- a/src/MayaFlux/Nodes/Graphics/ComputeOutNode.hpp
+++ b/src/MayaFlux/Nodes/Graphics/ComputeOutNode.hpp
@@ -15,7 +15,7 @@ namespace MayaFlux::Nodes::GpuSync {
 class MAYAFLUX_API ComputeOutContext : public NodeContext, public GpuVectorData {
 public:
     ComputeOutContext(double value, std::span<const float> readback_data, size_t element_count)
-        : NodeContext(value, typeid(ComputeOutContext).name())
+        : NodeContext(value)
         , GpuVectorData(readback_data)
         , element_count(element_count)
     {

--- a/src/MayaFlux/Nodes/Graphics/GeometryWriterNode.hpp
+++ b/src/MayaFlux/Nodes/Graphics/GeometryWriterNode.hpp
@@ -17,7 +17,7 @@ public:
         std::span<const uint8_t> vertex_data,
         size_t vertex_stride,
         uint32_t vertex_count)
-        : NodeContext(value, typeid(GeometryContext).name())
+        : NodeContext(value)
         , GpuStructuredData(vertex_data, vertex_stride, vertex_count)
         , vertex_count(vertex_count)
         , vertex_stride(vertex_stride)

--- a/src/MayaFlux/Nodes/Graphics/TextureNode.hpp
+++ b/src/MayaFlux/Nodes/Graphics/TextureNode.hpp
@@ -11,7 +11,7 @@ namespace MayaFlux::Nodes::GpuSync {
 class MAYAFLUX_API TextureContext : public NodeContext, public GpuVectorData {
 public:
     TextureContext(double value, uint32_t width, uint32_t height, std::span<const float> pixel_data)
-        : NodeContext(value, typeid(TextureContext).name())
+        : NodeContext(value)
         , GpuVectorData(pixel_data)
         , width(width)
         , height(height)

--- a/src/MayaFlux/Nodes/Input/InputNode.cpp
+++ b/src/MayaFlux/Nodes/Input/InputNode.cpp
@@ -134,42 +134,59 @@ double InputNode::apply_smoothing(double target, double current) const
     }
 }
 
-void InputNode::on_value_change(const NodeHook& callback, double epsilon)
+void InputNode::on_tick(const TypedHook<InputContext>& callback)
+{
+    m_callbacks.emplace_back([callback](NodeContext& ctx) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+        callback(static_cast<InputContext&>(ctx));
+    });
+}
+
+void InputNode::on_tick_if(const NodeCondition& condition, const TypedHook<InputContext>& callback)
+{
+    m_conditional_callbacks.emplace_back([callback](NodeContext& ctx) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+        callback(static_cast<InputContext&>(ctx));
+    },
+        condition);
+}
+
+void InputNode::on_value_change(const TypedHook<InputContext>& callback, double epsilon)
 {
     add_input_callback(callback, InputEventType::VALUE_CHANGE, epsilon);
 }
 
-void InputNode::on_threshold_rising(double threshold, const NodeHook& callback)
+void InputNode::on_threshold_rising(double threshold, const TypedHook<InputContext>& callback)
 {
     add_input_callback(callback, InputEventType::THRESHOLD_RISING, threshold);
 }
 
-void InputNode::on_threshold_falling(double threshold, const NodeHook& callback)
+void InputNode::on_threshold_falling(double threshold, const TypedHook<InputContext>& callback)
 {
     add_input_callback(callback, InputEventType::THRESHOLD_FALLING, threshold);
 }
 
-void InputNode::on_range_enter(double min, double max, const NodeHook& callback)
+void InputNode::on_range_enter(double min, double max, const TypedHook<InputContext>& callback)
 {
     add_input_callback(callback, InputEventType::RANGE_ENTER, {}, { { min, max } });
 }
 
-void InputNode::on_range_exit(double min, double max, const NodeHook& callback)
+void InputNode::on_range_exit(double min, double max, const TypedHook<InputContext>& callback)
 {
     add_input_callback(callback, InputEventType::RANGE_EXIT, {}, { { min, max } });
 }
 
-void InputNode::on_button_press(const NodeHook& callback)
+void InputNode::on_button_press(const TypedHook<InputContext>& callback)
 {
     add_input_callback(callback, InputEventType::BUTTON_PRESS);
 }
 
-void InputNode::on_button_release(const NodeHook& callback)
+void InputNode::on_button_release(const TypedHook<InputContext>& callback)
 {
     add_input_callback(callback, InputEventType::BUTTON_RELEASE);
 }
 
-void InputNode::while_in_range(double min, double max, const NodeHook& callback)
+void InputNode::while_in_range(double min, double max, const TypedHook<InputContext>& callback)
 {
     on_tick_if(
         [min, max](const NodeContext& ctx) {
@@ -179,23 +196,20 @@ void InputNode::while_in_range(double min, double max, const NodeHook& callback)
 }
 
 void InputNode::add_input_callback(
-    const NodeHook& callback,
+    const TypedHook<InputContext>& callback,
     InputEventType event_type,
     std::optional<double> threshold,
     std::optional<std::pair<double, double>> range,
     std::optional<NodeCondition> condition)
 {
-    m_input_callbacks.push_back({ .callback = callback,
-        .event_type = event_type,
-        .condition = std::move(condition),
-        .threshold = threshold,
-        .range = range });
+    m_input_callbacks.emplace_back(callback, event_type, std::move(condition), threshold, range);
 }
 
 void InputNode::notify_tick(double value)
 {
     update_context(value);
-    auto& ctx = get_last_context();
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+    auto& ctx = static_cast<InputContext&>(get_last_context());
 
     for (auto& callback : m_callbacks) {
         callback(ctx);

--- a/src/MayaFlux/Nodes/Input/InputNode.hpp
+++ b/src/MayaFlux/Nodes/Input/InputNode.hpp
@@ -23,18 +23,6 @@ enum class InputEventType : uint8_t {
     CONDITIONAL ///< User-provided condition
 };
 
-/**
- * @struct InputCallback
- * @brief Callback registration with event type and optional parameters
- */
-struct InputCallback {
-    NodeHook callback;
-    InputEventType event_type;
-    std::optional<NodeCondition> condition; // For CONDITIONAL
-    std::optional<double> threshold; // For THRESHOLD_*
-    std::optional<std::pair<double, double>> range; // For RANGE_*
-};
-
 // ─────────────────────────────────────────────────────────────────────────────
 // InputContext - Specialized context for input node callbacks
 // ─────────────────────────────────────────────────────────────────────────────
@@ -82,6 +70,18 @@ struct InputConfig {
     double slew_rate { 1.0 }; ///< Max change per sample (SLEW mode)
     double default_value { 0.0 }; ///< Initial output value
     size_t history_size { 8 }; ///< Input history buffer size
+};
+
+/**
+ * @struct InputCallback
+ * @brief Callback registration with event type and optional parameters
+ */
+struct InputCallback {
+    TypedHook<InputContext> callback;
+    InputEventType event_type;
+    std::optional<NodeCondition> condition;
+    std::optional<double> threshold;
+    std::optional<std::pair<double, double>> range;
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -202,11 +202,30 @@ public:
 
     /**
      * @brief Register callback for any input received
+     * @param callback Function to call on every tick
+     *
+     * The callback receives an InputContext with the current value and input details.
+     * Fires on every process_input() call, after smoothing is applied.
+     */
+    void on_tick(const TypedHook<InputContext>& callback);
+
+    /**
+     * @brief Register conditional callback for input received
+     * @param condition Predicate that determines when callback is triggered
+     * @param callback Function to call when condition is met
+     *
+     * The callback receives an InputContext with the current value and input details.
+     * Fires on every process_input() call where the condition returns true.
+     */
+    void on_tick_if(const NodeCondition& condition, const TypedHook<InputContext>& callback);
+
+    /**
+     * @brief Register callback for any input received
      * @param callback Function to call on every input
      *
      * Alias for on_tick() - fires on every process_input() call
      */
-    void on_input(const NodeHook& callback)
+    void on_input(const TypedHook<InputContext>& callback)
     {
         on_tick(callback);
     }
@@ -216,21 +235,21 @@ public:
      * @param callback Function to call when value differs from previous
      * @param epsilon Minimum change to trigger (default: 0.0001)
      */
-    void on_value_change(const NodeHook& callback, double epsilon = 0.0001);
+    void on_value_change(const TypedHook<InputContext>& callback, double epsilon = 0.0001);
 
     /**
      * @brief Register callback for threshold crossing (rising edge)
      * @param threshold Value threshold
      * @param callback Function to call when value crosses threshold upward
      */
-    void on_threshold_rising(double threshold, const NodeHook& callback);
+    void on_threshold_rising(double threshold, const TypedHook<InputContext>& callback);
 
     /**
      * @brief Register callback for threshold crossing (falling edge)
      * @param threshold Value threshold
      * @param callback Function to call when value crosses threshold downward
      */
-    void on_threshold_falling(double threshold, const NodeHook& callback);
+    void on_threshold_falling(double threshold, const TypedHook<InputContext>& callback);
 
     /**
      * @brief Register callback for entering a value range
@@ -238,7 +257,7 @@ public:
      * @param max Range maximum
      * @param callback Function to call when value enters range
      */
-    void on_range_enter(double min, double max, const NodeHook& callback);
+    void on_range_enter(double min, double max, const TypedHook<InputContext>& callback);
 
     /**
      * @brief Register callback for exiting a value range
@@ -246,7 +265,7 @@ public:
      * @param max Range maximum
      * @param callback Function to call when value exits range
      */
-    void on_range_exit(double min, double max, const NodeHook& callback);
+    void on_range_exit(double min, double max, const TypedHook<InputContext>& callback);
 
     /**
      * @brief Register callback for button press (0.0 → 1.0 transition)
@@ -254,7 +273,7 @@ public:
      *
      * Specialized for button inputs - fires once on press
      */
-    void on_button_press(const NodeHook& callback);
+    void on_button_press(const TypedHook<InputContext>& callback);
 
     /**
      * @brief Register callback for button release (1.0 → 0.0 transition)
@@ -262,7 +281,7 @@ public:
      *
      * Specialized for button inputs - fires once on release
      */
-    void on_button_release(const NodeHook& callback);
+    void on_button_release(const TypedHook<InputContext>& callback);
 
     /**
      * @brief Register callback while value is in range
@@ -270,7 +289,7 @@ public:
      * @param max Range maximum
      * @param callback Function to call continuously while in range
      */
-    void while_in_range(double min, double max, const NodeHook& callback);
+    void while_in_range(double min, double max, const TypedHook<InputContext>& callback);
 
 protected:
     /**
@@ -315,7 +334,7 @@ private:
     [[nodiscard]] double apply_smoothing(double target, double current) const;
 
     void add_input_callback(
-        const NodeHook& callback,
+        const TypedHook<InputContext>& callback,
         InputEventType event_type,
         std::optional<double> threshold = {},
         std::optional<std::pair<double, double>> range = {},

--- a/src/MayaFlux/Nodes/Input/InputNode.hpp
+++ b/src/MayaFlux/Nodes/Input/InputNode.hpp
@@ -39,7 +39,7 @@ class MAYAFLUX_API InputContext : public NodeContext {
 public:
     InputContext(double value, double raw_value,
         Core::InputType source, uint32_t device_id)
-        : NodeContext(value, typeid(InputContext).name())
+        : NodeContext(value)
         , raw_value(raw_value)
         , source_type(source)
         , device_id(device_id)

--- a/src/MayaFlux/Nodes/Node.hpp
+++ b/src/MayaFlux/Nodes/Node.hpp
@@ -40,14 +40,6 @@ public:
     double value;
 
     /**
-     * @brief Type identifier for runtime type checking
-     *
-     * String identifier that represents the concrete type of the context.
-     * Used for safe type casting with the as<T>() method.
-     */
-    std::string type_id;
-
-    /**
      * @brief Safely cast to a derived context type
      * @tparam T The derived context type to cast to
      * @return Pointer to the derived context or nullptr if types don't match
@@ -67,19 +59,13 @@ public:
     template <typename T>
     T* as()
     {
-        if (typeid(T).name() == type_id) {
-            return static_cast<T*>(this);
-        }
-        return nullptr;
+        return dynamic_cast<T*>(this);
     }
 
     template <typename T>
     const T* as() const
     {
-        if (typeid(T).name() == type_id) {
-            return static_cast<const T*>(this);
-        }
-        return nullptr;
+        return dynamic_cast<const T*>(this);
     }
 
 protected:
@@ -91,9 +77,8 @@ protected:
      * This constructor is protected to ensure that only derived classes
      * can create context objects, with proper type identification.
      */
-    NodeContext(double value, std::string type)
+    NodeContext(double value)
         : value(value)
-        , type_id(std::move(type))
     {
     }
 };

--- a/src/MayaFlux/Nodes/NodeGraphManager.cpp
+++ b/src/MayaFlux/Nodes/NodeGraphManager.cpp
@@ -339,12 +339,7 @@ void NodeGraphManager::ensure_token_exists(ProcessingToken token, uint32_t num_c
 
 void NodeGraphManager::register_global(const std::shared_ptr<Node>& node)
 {
-    if (!is_node_registered(node)) {
-        std::stringstream ss;
-        ss << "node_" << node.get();
-        std::string generated_id = ss.str();
-        m_Node_registry[generated_id] = node;
-    }
+    m_node_registry.insert(node);
 }
 
 void NodeGraphManager::set_channel_mask(const std::shared_ptr<Node>& node, uint32_t channel_id)
@@ -355,12 +350,7 @@ void NodeGraphManager::set_channel_mask(const std::shared_ptr<Node>& node, uint3
 
 void NodeGraphManager::unregister_global(const std::shared_ptr<Node>& node)
 {
-    for (const auto& pair : m_Node_registry) {
-        if (pair.second == node) {
-            m_Node_registry.erase(pair.first);
-            break;
-        }
-    }
+    m_node_registry.erase(node);
 }
 
 void NodeGraphManager::unset_channel_mask(const std::shared_ptr<Node>& node, uint32_t channel_id)
@@ -404,69 +394,9 @@ size_t NodeGraphManager::get_node_count(ProcessingToken token) const
     return count;
 }
 
-void NodeGraphManager::print_summary() const
-{
-    MF_PRINT(Journal::Component::Nodes,
-        Journal::Context::NodeProcessing,
-        "=== NodeGraphManager Summary ===");
-
-    for (auto token : get_active_tokens()) {
-        auto channels = get_all_channels(token);
-        size_t total_nodes = get_node_count(token);
-
-        MF_PRINT(Journal::Component::Nodes,
-            Journal::Context::NodeProcessing,
-            "Token {}: {} nodes across {} channels",
-            static_cast<int>(token), total_nodes, channels.size());
-
-        for (auto channel : channels) {
-            auto& root = const_cast<NodeGraphManager*>(this)->get_root_node(token, channel);
-            auto networks = get_networks(token, channel);
-
-            MF_PRINT(Journal::Component::Nodes,
-                Journal::Context::NodeProcessing,
-                "  Channel {}: {} nodes, {} networks",
-                channel, root.get_node_size(), networks.size());
-
-            for (const auto& network : networks) {
-                if (network) {
-                    MF_PRINT(Journal::Component::Nodes,
-                        Journal::Context::NodeProcessing,
-                        "    Network: {} internal nodes, mode={}, enabled={}",
-                        network->get_node_count(),
-                        static_cast<int>(network->get_output_mode()),
-                        network->is_enabled());
-                }
-            }
-        }
-    }
-}
-
-std::shared_ptr<Node> NodeGraphManager::get_node(const std::string& id)
-{
-    auto it = m_Node_registry.find(id);
-
-    if (it != m_Node_registry.end()) {
-        return it->second;
-    }
-    return nullptr;
-}
-
 bool NodeGraphManager::is_node_registered(const std::shared_ptr<Node>& node)
 {
-    return std::ranges::any_of(m_Node_registry,
-        [&node](const auto& pair) { return pair.second == node; });
-}
-
-void NodeGraphManager::connect(const std::string& source_id, const std::string& target_id)
-{
-    auto source = get_node(source_id);
-    auto target = get_node(target_id);
-
-    if (source && target) {
-        auto chain = std::make_shared<ChainNode>(source, target, *this);
-        chain->initialize();
-    }
+    return m_node_registry.contains(node);
 }
 
 //-----------------------------------------------------------------------------
@@ -604,11 +534,7 @@ void NodeGraphManager::clear_networks(ProcessingToken token)
 
 void NodeGraphManager::register_network_global(const std::shared_ptr<Network::NodeNetwork>& network)
 {
-    if (!is_network_registered(network)) {
-        std::stringstream ss;
-        ss << "network_" << network.get();
-        std::string generated_id = ss.str();
-        m_network_registry[generated_id] = network;
+    if (m_network_registry.insert(network).second) {
         network->set_sample_rate(m_registered_sample_rate);
         network->set_block_size(m_registered_block_size);
     }
@@ -616,18 +542,12 @@ void NodeGraphManager::register_network_global(const std::shared_ptr<Network::No
 
 void NodeGraphManager::unregister_network_global(const std::shared_ptr<Network::NodeNetwork>& network)
 {
-    for (const auto& pair : m_network_registry) {
-        if (pair.second == network) {
-            m_network_registry.erase(pair.first);
-            break;
-        }
-    }
+    m_network_registry.erase(network);
 }
 
 bool NodeGraphManager::is_network_registered(const std::shared_ptr<Network::NodeNetwork>& network)
 {
-    return std::ranges::any_of(m_network_registry,
-        [&network](const auto& pair) { return pair.second == network; });
+    return m_network_registry.contains(network);
 }
 
 void NodeGraphManager::terminate_active_processing()
@@ -668,13 +588,13 @@ NodeGraphManager::~NodeGraphManager()
     m_audio_networks.clear();
     m_token_networks.clear();
 
-    m_Node_registry.clear();
+    m_node_registry.clear();
     m_network_registry.clear();
 }
 
 void NodeGraphManager::update_routing_states_for_cycle(ProcessingToken token)
 {
-    for (const auto& [id, node] : m_Node_registry) {
+    for (const auto& node : m_node_registry) {
         if (!node->needs_channel_routing())
             continue;
         update_routing_state(node->get_routing_state());
@@ -758,7 +678,7 @@ void NodeGraphManager::route_network_to_channels(
     }
 
     uint32_t fade_blocks = (fade_cycles + m_registered_block_size - 1) / m_registered_block_size;
-    fade_blocks = std::max(1u, fade_blocks);
+    fade_blocks = std::max(1U, fade_blocks);
 
     RoutingState state;
     state.from_channels = current_channels;
@@ -777,7 +697,7 @@ void NodeGraphManager::cleanup_completed_routing(ProcessingToken token)
 {
     std::vector<std::pair<std::shared_ptr<Node>, uint32_t>> nodes_to_remove;
 
-    for (const auto& [id, node] : m_Node_registry) {
+    for (const auto& node : m_node_registry) {
         if (!node->needs_channel_routing())
             continue;
 

--- a/src/MayaFlux/Nodes/NodeGraphManager.hpp
+++ b/src/MayaFlux/Nodes/NodeGraphManager.hpp
@@ -24,8 +24,8 @@ namespace Network {
  * - Multi-modal (token-based) processing: Supports multiple independent processing domains
  *   (e.g., AUDIO_RATE, VISUAL_RATE, CUSTOM_RATE), each with its own set of channels and root nodes.
  * - Per-channel root nodes: Each processing domain can have multiple channels, each with its own RootNode.
- * - Node registry: Nodes are registered by string identifier for easy lookup and connection.
- * - Flexible connection: Nodes can be connected by reference or by identifier, supporting both direct and named graph construction.
+ * - Node registry: Tracks all registered nodes for lifecycle management and deduplication.
+ * - Flexible connection: Nodes are connected by shared_ptr reference via the >> and + operators.
  * - Subsystem token processors: Allows registration of custom processing functions for each token, enabling efficient backend-specific processing.
  *
  * This class provides methods to:
@@ -90,24 +90,6 @@ public:
     void remove_from_root(const std::shared_ptr<Node>& node, ProcessingToken token, unsigned int channel = 0);
 
     /**
-     * @brief Adds a node to a channel's root node by its identifier
-     * @param node_id Identifier of the node to add
-     @ param token Processing domain to add the node to (default is AUDIO_RATE)
-     * @param channel Channel index to add the node to (AUDIO_RATE domain)
-     *
-     * Looks up the node by its identifier and adds it to the specified
-     * channel's root node in the specified processing domain (default is AUDIO_RATE).
-     * Throws an exception if the node identifier is not found.
-     */
-    inline void add_to_root(const std::string& node_id, ProcessingToken token = ProcessingToken::AUDIO_RATE, unsigned int channel = 0)
-    {
-        auto node = get_node(node_id);
-        if (node) {
-            add_to_root(node, token, channel);
-        }
-    }
-
-    /**
      * @brief Register subsystem processor for a specific token
      * @param token Processing domain to handle (e.g., AUDIO_RATE, VISUAL_RATE)
      * @param processor Function that receives a span of root nodes for that token
@@ -130,60 +112,6 @@ public:
      * For multi-modal access, use get_token_roots().
      */
     const std::unordered_map<unsigned int, std::shared_ptr<RootNode>>& get_all_channel_root_nodes(ProcessingToken token = ProcessingToken::AUDIO_RATE) const;
-
-    /**
-     * @brief Creates and registers a new node of the specified type
-     * @tparam NodeType The type of node to create (must derive from Node)
-     * @tparam Args Parameter types for the node's constructor
-     * @param id String identifier for the node
-     * @param args Constructor arguments for the node
-     * @return Shared pointer to the created node
-     *
-     * This template method creates a node of any type that derives from Node,
-     * passing the provided arguments to its constructor. The created node is
-     * automatically registered with the given string identifier for later lookup.
-     *
-     * Example:
-     * ```cpp
-     * auto sine = manager.create_node<Generators::Sine>("my_sine", 440.0, 0.5);
-     * auto filter = manager.create_node<Filters::LowPass>("my_filter", sine, 1000.0);
-     * ```
-     */
-    template <typename NodeType, typename... Args>
-    inline std::shared_ptr<NodeType> create_node(const std::string& id, Args&&... args)
-    {
-        auto node = std::make_shared<NodeType>(std::forward<Args>(args)...);
-        m_Node_registry[id] = node;
-        return node;
-    }
-
-    /**
-     * @brief Looks up a node by its string identifier
-     * @param id The string identifier of the node
-     * @return Shared pointer to the node, or nullptr if not found
-     *
-     * Retrieves a previously registered node using its string identifier.
-     * This allows for connecting nodes by name rather than requiring direct
-     * references to node objects.
-     */
-    std::shared_ptr<Node> get_node(const std::string& id);
-
-    /**
-     * @brief Connects two nodes by their string identifiers
-     * @param source_id Identifier of the source node
-     * @param target_id Identifier of the target node
-     *
-     * Looks up both nodes by their identifiers and establishes a connection
-     * where the output of the source node becomes an input to the target node.
-     *
-     * Equivalent to:
-     * ```cpp
-     * connect(get_node(source_id), get_node(target_id));
-     * ```
-     *
-     * Throws an exception if either node identifier is not found.
-     */
-    void connect(const std::string& source_id, const std::string& target_id);
 
     /**
      * @brief Checks if a node is registered with this manager
@@ -328,15 +256,6 @@ public:
      * @return Total number of nodes across all channels for this token
      */
     size_t get_node_count(ProcessingToken token) const;
-
-    /**
-     * @brief Prints a summary of all tokens, channels, and node counts
-     *
-     * Outputs a human-readable summary of the current node graph structure,
-     * including the number of tokens, channels, and nodes per domain.
-     * Useful for debugging and introspection.
-     */
-    void print_summary() const;
 
     //-------------------------------------------------------------------------
     // NodeNetwork Management
@@ -483,21 +402,9 @@ public:
 
 private:
     /**
-     * @brief Map of channel indices to their root nodes (AUDIO_RATE domain)
-     *
-     * Each audio channel has its own root node that collects all nodes
-     * that should output to that channel. For multi-modal support,
-     * see m_token_roots.
-     */
-    std::unordered_map<unsigned int, std::shared_ptr<RootNode>> m_channel_root_nodes;
-
-    /**
      * @brief Registry of all nodes by their string identifiers
-     *
-     * This registry allows nodes to be looked up by their string identifiers
-     * for operations like connecting nodes by name.
      */
-    std::unordered_map<std::string, std::shared_ptr<Node>> m_Node_registry;
+    std::unordered_set<std::shared_ptr<Node>> m_node_registry;
 
     /**
      * @brief Multi-modal map of processing tokens to their channel root nodes
@@ -540,10 +447,8 @@ private:
 
     /**
      * @brief Global network registry (like m_Node_registry)
-     *
-     * Maps generated IDs to networks for lifecycle management
      */
-    std::unordered_map<std::string, std::shared_ptr<Network::NodeNetwork>> m_network_registry;
+    std::unordered_set<std::shared_ptr<Network::NodeNetwork>> m_network_registry;
 
     /**
      * @brief Audio-sink networks

--- a/tests/nodes/node_test.cpp
+++ b/tests/nodes/node_test.cpp
@@ -35,20 +35,6 @@ TEST_F(NodeTest, RootNodeOperations)
     EXPECT_EQ(root.get_node_size(), 0);
 }
 
-TEST_F(NodeTest, NodeRegistry)
-{
-    const std::string node_id = "test_sine";
-    auto sine = node_manager->create_node<Nodes::Generator::Sine>(node_id, 440.0f, 0.5f);
-
-    EXPECT_NE(sine, nullptr);
-
-    auto retrieved = node_manager->get_node(node_id);
-    EXPECT_EQ(retrieved, sine);
-
-    auto nonexistent = node_manager->get_node("nonexistent");
-    EXPECT_EQ(nonexistent, nullptr);
-}
-
 TEST_F(NodeTest, MultiChannelRootNodes)
 {
     auto& root0 = node_manager->get_root_node(token, 0);
@@ -94,51 +80,6 @@ TEST_F(NodeTest, SingleNodeMultipleChannels)
     EXPECT_TRUE(sine->is_used_by_channel(0));
     EXPECT_FALSE(sine->is_used_by_channel(1));
     EXPECT_TRUE(sine->is_used_by_channel(2));
-}
-
-TEST_F(NodeTest, AddNodeToRoot)
-{
-    const std::string node_id = "test_sine";
-    auto sine = node_manager->create_node<Nodes::Generator::Sine>(node_id, 440.0f, 0.5f);
-
-    node_manager->add_to_root(node_id);
-    EXPECT_EQ(node_manager->get_root_node(token, 0).get_node_size(), 1);
-
-    const std::string node_id2 = "test_sine2";
-    auto sine2 = node_manager->create_node<Nodes::Generator::Sine>(node_id2, 880.0f, 0.5f);
-
-    node_manager->add_to_root(node_id2, Nodes::ProcessingToken::AUDIO_RATE, 1);
-    EXPECT_EQ(node_manager->get_root_node(token, 1).get_node_size(), 1);
-
-    auto sine3 = std::make_shared<Nodes::Generator::Sine>(660.0f, 0.5f);
-    node_manager->add_to_root(sine3, token, 2);
-    EXPECT_EQ(node_manager->get_root_node(token, 2).get_node_size(), 1);
-}
-
-TEST_F(NodeTest, NodeConnections)
-{
-    const std::string sine_id = "sine";
-    const std::string filter_id = "filter";
-
-    auto sine = node_manager->create_node<Nodes::Generator::Sine>(sine_id, 440.0f, 0.5f);
-    auto filter = node_manager->create_node<Nodes::Filters::FIR>(filter_id, sine, "5_0");
-
-    node_manager->connect(sine_id, filter_id);
-
-    auto sine2 = std::make_shared<Nodes::Generator::Sine>(880.0f, 0.3f);
-    auto filter2 = std::make_shared<Nodes::Filters::FIR>(sine2, std::vector<double> { 0.2, 0.2, 0.2, 0.2, 0.2 });
-
-    auto chain_node = sine2 >> filter2;
-    EXPECT_NE(chain_node, nullptr);
-
-    auto sine3 = std::make_shared<Nodes::Generator::Sine>(220.0f, 0.4f);
-    auto sine4 = std::make_shared<Nodes::Generator::Sine>(330.0f, 0.4f);
-
-    auto add_node = sine3 + sine4;
-    EXPECT_NE(add_node, nullptr);
-
-    auto mul_node = sine3 * sine4;
-    EXPECT_NE(mul_node, nullptr);
 }
 
 TEST_F(NodeTest, ComplexMultiChannelChain)


### PR DESCRIPTION

The node system carried several patterns that were either vestigial from early design or never reached their intended purpose. This PR removes them and replaces the callback surface with one that reflects the actual type hierarchy rather than fighting it.

## **The core problem being solved**

Every node callback in the system received `NodeContext&`. To access any node-specific data - frequency, phase, filter history, logic state, input device ID - the caller had to either cast inside the lambda using the broken `typeid`-based `as<T>()`, or ignore the context entirely and close over the node pointer. Neither is acceptable as a primary API. The first is unsafe and implementation-defined; the second makes the context object pointless.

The `TypedHook<ContextT>` alias existed but was only used on `Counter`. This PR propagates it to every concrete node class so the callback surface matches what the node actually produces.

## **What is removed**

The string-keyed node registry was a lookup table with no callers. The only real function it served was deduplication, which an `unordered_set` handles without keys, string construction, or linear scans on removal. The full lookup API (`create_node<T>(string)`, `get_node(string)`, `connect(string, string)`, `add_to_root(string)`) is gone since Creator and the `>>` operator already provide the correct composition surface.

`printGraph()` and `printCurrent()` were pure virtual stubs on `Generator` with empty bodies on every subclass. Dead since introduction.

`type_id` was a `std::string` member on `NodeContext` allocated on every `notify_tick` call - audio rate, every sample, for every node with a callback registered. It powered `as<T>()` via `typeid(T).name()` string comparison which is implementation-defined and was already broken for GPU context variants. Both are gone. `as<T>()` now uses `dynamic_cast` which is correct for the hierarchy.

## **What this enables**

Callers registering callbacks on `Sine`, `Phasor`, `Impulse`, `Counter`, `Logic`, `Polynomial`, `Random`, `Filter`, and `InputNode` now receive the concrete context type directly. No casting, no closing over the node pointer to recover state that the context already carries. `Logic`'s semantic events (`on_change`, `while_true`, `on_change_to`) and `InputNode`'s input events (`on_button_press`, `on_threshold_rising`, etc.) are fully typed end to end.

The base `Node::on_tick(NodeHook)` remains for generic use and infrastructure nodes. The typed overloads are additions at each concrete class, not replacements of the base interface, so existing code is unaffected.

`Generator::notify_tick` is now a concrete base implementation rather than a pure virtual. Subclasses with semantic events (`Phasor`, `Impulse`, `Counter`) override it; those without (`Sine`, `Random`, `Polynomial`) inherit it. This eliminates three identical copy-pasted dispatch loops.

## Linkage
- Closes #130
- Closes #131
- Closes  #132
- Closes #133.
