### PR TITLE
Runtime introspection layer

### DIFF
--- a/src/MayaFlux/Buffers/BufferProcessingChain.cpp
+++ b/src/MayaFlux/Buffers/BufferProcessingChain.cpp
@@ -226,6 +226,27 @@ const std::vector<std::shared_ptr<BufferProcessor>>& BufferProcessingChain::get_
     return empty_vector;
 }
 
+std::shared_ptr<BufferProcessor>
+BufferProcessingChain::get_preprocessor(const std::shared_ptr<Buffer>& buffer) const
+{
+    auto it = m_preprocessors.find(buffer);
+    return it != m_preprocessors.end() ? it->second : nullptr;
+}
+
+std::shared_ptr<BufferProcessor>
+BufferProcessingChain::get_postprocessor(const std::shared_ptr<Buffer>& buffer) const
+{
+    auto it = m_postprocessors.find(buffer);
+    return it != m_postprocessors.end() ? it->second : nullptr;
+}
+
+std::shared_ptr<BufferProcessor>
+BufferProcessingChain::get_final_processor(const std::shared_ptr<Buffer>& buffer) const
+{
+    auto it = m_final_processors.find(buffer);
+    return it != m_final_processors.end() ? it->second : nullptr;
+}
+
 void BufferProcessingChain::preprocess(const std::shared_ptr<Buffer>& buffer)
 {
     auto pre_it = m_preprocessors.find(buffer);
@@ -300,13 +321,10 @@ void BufferProcessingChain::cleanup_rejected_processors(const std::shared_ptr<Bu
 {
     auto& processors = m_buffer_processors[buffer];
 
-    processors.erase(
-        std::remove_if(processors.begin(), processors.end(),
-            [this](const std::shared_ptr<BufferProcessor>& processor) {
-                auto processor_token = processor->get_processing_token();
-                return !are_tokens_compatible(m_token_filter_mask, processor_token);
-            }),
-        processors.end());
+    std::erase_if(processors, [this](const std::shared_ptr<BufferProcessor>& processor) {
+        auto processor_token = processor->get_processing_token();
+        return !are_tokens_compatible(m_token_filter_mask, processor_token);
+    });
 
     m_pending_removal[buffer].clear();
 }

--- a/src/MayaFlux/Buffers/BufferProcessingChain.hpp
+++ b/src/MayaFlux/Buffers/BufferProcessingChain.hpp
@@ -167,6 +167,27 @@ public:
     const std::vector<std::shared_ptr<BufferProcessor>>& get_processors(const std::shared_ptr<Buffer>& buffer) const;
 
     /**
+     * @brief Returns the preprocessor for a buffer, or nullptr if none is set.
+     * @param buffer Buffer to query
+     */
+    [[nodiscard]] std::shared_ptr<BufferProcessor>
+    get_preprocessor(const std::shared_ptr<Buffer>& buffer) const;
+
+    /**
+     * @brief Returns the postprocessor for a buffer, or nullptr if none is set.
+     * @param buffer Buffer to query
+     */
+    [[nodiscard]] std::shared_ptr<BufferProcessor>
+    get_postprocessor(const std::shared_ptr<Buffer>& buffer) const;
+
+    /**
+     * @brief Returns the final processor for a buffer, or nullptr if none is set.
+     * @param buffer Buffer to query
+     */
+    [[nodiscard]] std::shared_ptr<BufferProcessor>
+    get_final_processor(const std::shared_ptr<Buffer>& buffer) const;
+
+    /**
      * @brief Gets the entire transformation pipeline structure
      * @return Map of buffers to their processor sequences
      *

--- a/src/MayaFlux/Core/Input/InputManager.cpp
+++ b/src/MayaFlux/Core/Input/InputManager.cpp
@@ -294,6 +294,12 @@ size_t InputManager::get_registered_node_count() const
 #endif
 }
 
+std::vector<std::shared_ptr<Nodes::Input::InputNode>> InputManager::get_nodes() const
+{
+    std::lock_guard lock(m_registry_mutex);
+    return m_tracked_nodes;
+}
+
 size_t InputManager::get_queue_depth() const
 {
     return m_queue.snapshot().size();

--- a/src/MayaFlux/Core/Input/InputManager.cpp
+++ b/src/MayaFlux/Core/Input/InputManager.cpp
@@ -248,9 +248,7 @@ void InputManager::unregister_node(const std::shared_ptr<Nodes::Input::InputNode
 
         m_registrations.store(new_list);
 #endif
-        m_tracked_nodes.erase(
-            std::remove(m_tracked_nodes.begin(), m_tracked_nodes.end(), node),
-            m_tracked_nodes.end());
+        std::erase_if(m_tracked_nodes, [&node](const auto& n) { return n == node; });
     }
 
     MF_DEBUG(Journal::Component::Core, Journal::Context::InputManagement,

--- a/src/MayaFlux/Core/Input/InputManager.hpp
+++ b/src/MayaFlux/Core/Input/InputManager.hpp
@@ -177,7 +177,7 @@ private:
 
     std::vector<std::shared_ptr<Nodes::Input::InputNode>> m_tracked_nodes; ///< To keep nodes alive
 
-    std::mutex m_registry_mutex;
+    mutable std::mutex m_registry_mutex;
 
 #ifdef MAYAFLUX_PLATFORM_MACOS
     // Apple's broken LLVM doesn't support std::atomic<std::shared_ptr<T>>

--- a/src/MayaFlux/Core/Input/InputManager.hpp
+++ b/src/MayaFlux/Core/Input/InputManager.hpp
@@ -115,6 +115,12 @@ public:
      */
     [[nodiscard]] size_t get_registered_node_count() const;
 
+    /**
+     * @brief Returns a snapshot of all currently tracked input nodes.
+     * @return Vector of active InputNode instances.
+     */
+    [[nodiscard]] std::vector<std::shared_ptr<Nodes::Input::InputNode>> get_nodes() const;
+
     // ─────────────────────────────────────────────────────────────────────
     // Statistics
     // ─────────────────────────────────────────────────────────────────────

--- a/src/MayaFlux/IO/IOManager.cpp
+++ b/src/MayaFlux/IO/IOManager.cpp
@@ -780,4 +780,38 @@ void IOManager::wait_for_pending_saves()
     }
 }
 
+std::vector<uint64_t> IOManager::get_video_reader_ids() const
+{
+    std::shared_lock lock(m_readers_mutex);
+    std::vector<uint64_t> ids;
+    ids.reserve(m_video_readers.size());
+    for (const auto& [id, _] : m_video_readers)
+        ids.push_back(id);
+    return ids;
+}
+
+std::shared_ptr<VideoFileReader> IOManager::get_video_reader(uint64_t id) const
+{
+    std::shared_lock lock(m_readers_mutex);
+    auto it = m_video_readers.find(id);
+    return it != m_video_readers.end() ? it->second : nullptr;
+}
+
+std::vector<uint64_t> IOManager::get_camera_reader_ids() const
+{
+    std::shared_lock lock(m_camera_mutex);
+    std::vector<uint64_t> ids;
+    ids.reserve(m_camera_readers.size());
+    for (const auto& [id, _] : m_camera_readers)
+        ids.push_back(id);
+    return ids;
+}
+
+std::shared_ptr<CameraReader> IOManager::get_camera_reader(uint64_t id) const
+{
+    std::shared_lock lock(m_camera_mutex);
+    auto it = m_camera_readers.find(id);
+    return it != m_camera_readers.end() ? it->second : nullptr;
+}
+
 } // namespace MayaFlux::IO

--- a/src/MayaFlux/IO/IOManager.hpp
+++ b/src/MayaFlux/IO/IOManager.hpp
@@ -444,6 +444,45 @@ public:
      */
     void wait_for_pending_saves();
 
+    // ─────────────────────────────────────────────────────────────────────────
+    // Image — save
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * @brief Returns all active video reader IDs.
+     */
+    [[nodiscard]] std::vector<uint64_t> get_video_reader_ids() const;
+
+    /**
+     * @brief Returns the video reader assigned to the given ID, or nullptr.
+     */
+    [[nodiscard]] std::shared_ptr<VideoFileReader> get_video_reader(uint64_t id) const;
+
+    /**
+     * @brief Returns all active camera reader IDs.
+     */
+    [[nodiscard]] std::vector<uint64_t> get_camera_reader_ids() const;
+
+    /**
+     * @brief Returns the camera reader assigned to the given ID, or nullptr.
+     */
+    [[nodiscard]] std::shared_ptr<CameraReader> get_camera_reader(uint64_t id) const;
+
+    /**
+     * @brief Returns all retained audio readers.
+     */
+    [[nodiscard]] std::vector<std::shared_ptr<SoundFileReader>> get_audio_readers() const { return m_audio_readers; };
+
+    /**
+     * @brief Returns all retained image readers.
+     */
+    [[nodiscard]] std::vector<std::shared_ptr<ImageReader>> get_image_readers() const { return m_image_readers; };
+
+    /**
+     * @brief Returns all retained model readers.
+     */
+    [[nodiscard]] std::vector<std::shared_ptr<ModelReader>> get_model_readers() const { return m_model_readers; };
+
 private:
     uint64_t m_sample_rate;
 

--- a/src/MayaFlux/Nodes/Conduit/NodeChain.cpp
+++ b/src/MayaFlux/Nodes/Conduit/NodeChain.cpp
@@ -209,4 +209,14 @@ NodeContext& ChainNode::get_last_context()
     return m_nodes.back()->get_last_context();
 }
 
+std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>>
+ChainNode::get_modulators() const
+{
+    std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>> result;
+    result.reserve(m_nodes.size());
+    for (const auto& n : m_nodes)
+        result.emplace_back(ModulatorRole::ChainLink, n);
+    return result;
+}
+
 }

--- a/src/MayaFlux/Nodes/Conduit/NodeChain.hpp
+++ b/src/MayaFlux/Nodes/Conduit/NodeChain.hpp
@@ -123,6 +123,12 @@ public:
     void save_state() override;
     void restore_state() override;
 
+    /**
+     * @brief Retrieves the current modulators connected to this node
+     * @return Vector of pairs containing the modulator role and the corresponding node
+     */
+    [[nodiscard]] std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>> get_modulators() const override;
+
 protected:
     inline void notify_tick(double) override { }
     inline void update_context(double) override { }

--- a/src/MayaFlux/Nodes/Conduit/NodeCombine.cpp
+++ b/src/MayaFlux/Nodes/Conduit/NodeCombine.cpp
@@ -233,6 +233,17 @@ bool BinaryOpNode::is_initialized() const
     return !is_lhs_registered && !is_rhs_registered;
 }
 
+std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>>
+BinaryOpNode::get_modulators() const
+{
+    std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>> result;
+    if (m_lhs)
+        result.emplace_back(ModulatorRole::Lhs, m_lhs);
+    if (m_rhs)
+        result.emplace_back(ModulatorRole::Rhs, m_rhs);
+    return result;
+}
+
 namespace detail {
 
     void composite_initialize(

--- a/src/MayaFlux/Nodes/Conduit/NodeCombine.hpp
+++ b/src/MayaFlux/Nodes/Conduit/NodeCombine.hpp
@@ -200,6 +200,12 @@ public:
     void save_state() override;
     void restore_state() override;
 
+    /**
+     * @brief Retrieves the current modulators connected to this node
+     * @return Vector of pairs containing the modulator role and the corresponding node
+     */
+    [[nodiscard]] std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>> get_modulators() const override;
+
 protected:
     /**
      * @brief Notifies all registered callbacks about a new output value
@@ -500,6 +506,20 @@ public:
                 return false;
         }
         return m_is_initialized;
+    }
+
+    /**
+     * @brief Retrieves the current modulators connected to this node
+     * @return Vector of pairs containing the modulator role and the corresponding node
+     */
+    [[nodiscard]] std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>>
+    get_modulators() const override
+    {
+        std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>> result;
+        result.reserve(m_inputs.size());
+        for (const auto& n : m_inputs)
+            result.emplace_back(ModulatorRole::SignalMod, n);
+        return result;
     }
 
 protected:

--- a/src/MayaFlux/Nodes/Filters/Filter.cpp
+++ b/src/MayaFlux/Nodes/Filters/Filter.cpp
@@ -298,4 +298,12 @@ void Filter::on_tick_if(const NodeCondition& condition, const TypedHook<FilterCo
         condition);
 }
 
+std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>>
+Filter::get_modulators() const
+{
+    if (m_input_node)
+        return { { ModulatorRole::SignalMod, m_input_node } };
+    return {};
+}
+
 }

--- a/src/MayaFlux/Nodes/Filters/Filter.hpp
+++ b/src/MayaFlux/Nodes/Filters/Filter.hpp
@@ -510,6 +510,12 @@ public:
      */
     void on_tick_if(const NodeCondition& condition, const TypedHook<FilterContext>& callback);
 
+    /**
+     * @brief Retrieves the current modulators connected to this node
+     * @return Vector of pairs containing the modulator role and the corresponding node
+     */
+    [[nodiscard]] std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>> get_modulators() const override;
+
 protected:
     /**
      * @brief Modifies a specific coefficient in a coefficient buffer

--- a/src/MayaFlux/Nodes/Generators/Counter.cpp
+++ b/src/MayaFlux/Nodes/Generators/Counter.cpp
@@ -178,4 +178,12 @@ void Counter::restore_state()
     m_state_saved = false;
 }
 
+std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>>
+Counter::get_modulators() const
+{
+    if (m_reset_trigger)
+        return { { ModulatorRole::SignalMod, m_reset_trigger } };
+    return {};
+}
+
 } // namespace MayaFlux::Nodes::Generatorx::Nodes::Generator

--- a/src/MayaFlux/Nodes/Generators/Counter.hpp
+++ b/src/MayaFlux/Nodes/Generators/Counter.hpp
@@ -111,6 +111,12 @@ public:
     void save_state() override;
     void restore_state() override;
 
+    /**
+     * @brief Retrieves the current modulators connected to this node
+     * @return Vector of pairs containing the modulator role and the corresponding node
+     */
+    [[nodiscard]] std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>> get_modulators() const override;
+
 protected:
     void notify_tick(double value) override;
     void update_context(double value) override;

--- a/src/MayaFlux/Nodes/Generators/Impulse.cpp
+++ b/src/MayaFlux/Nodes/Generators/Impulse.cpp
@@ -228,4 +228,15 @@ void Impulse::restore_state()
     m_state_saved = false;
 }
 
+std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>>
+Impulse::get_modulators() const
+{
+    std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>> result;
+    if (m_frequency_modulator)
+        result.emplace_back(ModulatorRole::FrequencyMod, m_frequency_modulator);
+    if (m_amplitude_modulator)
+        result.emplace_back(ModulatorRole::AmplitudeMod, m_amplitude_modulator);
+    return result;
+}
+
 } // namespace MayaFlux::Nodes::Generator

--- a/src/MayaFlux/Nodes/Generators/Impulse.hpp
+++ b/src/MayaFlux/Nodes/Generators/Impulse.hpp
@@ -210,6 +210,12 @@ public:
     void save_state() override;
     void restore_state() override;
 
+    /**
+     * @brief Retrieves the current modulators connected to this node
+     * @return Vector of pairs containing the modulator role and the corresponding node
+     */
+    [[nodiscard]] std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>> get_modulators() const override;
+
 protected:
     /**
      * @brief Notifies all registered callbacks about a new sample

--- a/src/MayaFlux/Nodes/Generators/Logic.cpp
+++ b/src/MayaFlux/Nodes/Generators/Logic.cpp
@@ -667,4 +667,12 @@ void Logic::restore_state()
     m_state_saved = false;
 }
 
+std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>>
+Logic::get_modulators() const
+{
+    if (m_input_node)
+        return { { ModulatorRole::SignalMod, m_input_node } };
+    return {};
+}
+
 }

--- a/src/MayaFlux/Nodes/Generators/Logic.hpp
+++ b/src/MayaFlux/Nodes/Generators/Logic.hpp
@@ -565,6 +565,12 @@ public:
         }
     }
 
+    /**
+     * @brief Retrieves the current modulators connected to this node
+     * @return Vector of pairs containing the modulator role and the corresponding node
+     */
+    [[nodiscard]] std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>> get_modulators() const override;
+
 protected:
     /**
      * @brief Updates the context with the latest sample value

--- a/src/MayaFlux/Nodes/Generators/Phasor.cpp
+++ b/src/MayaFlux/Nodes/Generators/Phasor.cpp
@@ -260,4 +260,15 @@ void Phasor::restore_state()
     m_state_saved = false;
 }
 
+std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>>
+Phasor::get_modulators() const
+{
+    std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>> result;
+    if (m_frequency_modulator)
+        result.emplace_back(ModulatorRole::FrequencyMod, m_frequency_modulator);
+    if (m_amplitude_modulator)
+        result.emplace_back(ModulatorRole::AmplitudeMod, m_amplitude_modulator);
+    return result;
+}
+
 } // namespace MayaFlux::Nodes::Generator

--- a/src/MayaFlux/Nodes/Generators/Phasor.hpp
+++ b/src/MayaFlux/Nodes/Generators/Phasor.hpp
@@ -247,6 +247,12 @@ public:
     void save_state() override;
     void restore_state() override;
 
+    /**
+     * @brief Retrieves the current modulators connected to this node
+     * @return Vector of pairs containing the modulator role and the corresponding node
+     */
+    [[nodiscard]] std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>> get_modulators() const override;
+
 protected:
     /**
      * @brief Notifies all registered callbacks about a new sample

--- a/src/MayaFlux/Nodes/Generators/Polynomial.cpp
+++ b/src/MayaFlux/Nodes/Generators/Polynomial.cpp
@@ -237,4 +237,12 @@ void Polynomial::restore_state()
     m_state_saved = false;
 }
 
+std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>>
+Polynomial::get_modulators() const
+{
+    if (m_input_node)
+        return { { ModulatorRole::SignalMod, m_input_node } };
+    return {};
+}
+
 } // namespace MayaFlux::Nodes::Generator

--- a/src/MayaFlux/Nodes/Generators/Polynomial.hpp
+++ b/src/MayaFlux/Nodes/Generators/Polynomial.hpp
@@ -353,6 +353,12 @@ public:
         }
     }
 
+    /**
+     * @brief Retrieves the current modulators connected to this node
+     * @return Vector of pairs containing the modulator role and the corresponding node
+     */
+    [[nodiscard]] std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>> get_modulators() const override;
+
 protected:
     /**
      * @brief Updates the context object with the current node state

--- a/src/MayaFlux/Nodes/Generators/Sine.cpp
+++ b/src/MayaFlux/Nodes/Generators/Sine.cpp
@@ -185,4 +185,15 @@ void Sine::restore_state()
     m_state_saved = false;
 }
 
+std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>>
+Sine::get_modulators() const
+{
+    std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>> result;
+    if (m_frequency_modulator)
+        result.emplace_back(ModulatorRole::FrequencyMod, m_frequency_modulator);
+    if (m_amplitude_modulator)
+        result.emplace_back(ModulatorRole::AmplitudeMod, m_amplitude_modulator);
+    return result;
+}
+
 }

--- a/src/MayaFlux/Nodes/Generators/Sine.hpp
+++ b/src/MayaFlux/Nodes/Generators/Sine.hpp
@@ -175,6 +175,12 @@ public:
     void save_state() override;
     void restore_state() override;
 
+    /**
+     * @brief Retrieves the current modulators connected to this node
+     * @return Vector of pairs containing the modulator role and the corresponding node
+     */
+    [[nodiscard]] std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>> get_modulators() const override;
+
 private:
     /**
      * @brief Phase increment per sample

--- a/src/MayaFlux/Nodes/Node.hpp
+++ b/src/MayaFlux/Nodes/Node.hpp
@@ -15,6 +15,29 @@
 namespace MayaFlux::Nodes {
 
 /**
+ * @enum ModulatorRole
+ * @brief Describes the role a modulator node plays relative to its owner.
+ */
+enum class ModulatorRole : uint8_t {
+    SignalMod,
+    FrequencyMod,
+    AmplitudeMod,
+    Lhs,
+    Rhs,
+    ChainLink,
+};
+
+/**
+ * @struct ModulatorTree
+ * @brief Recursive tree node describing a modulator and all of its own modulators.
+ */
+struct ModulatorTree {
+    ModulatorRole role {};
+    std::shared_ptr<Node> node;
+    std::vector<ModulatorTree> modulators;
+};
+
+/**
  * @class NodeContext
  * @brief Base context class for node callbacks
  *
@@ -650,6 +673,36 @@ public:
     [[nodiscard]] bool has_capability(NodeCapability cap) const
     {
         return (m_node_capability & cap) != 0U;
+    }
+
+    /**
+     * @brief Returns direct modulator nodes and their roles.
+     *
+     * Each entry pairs the role the modulator plays in this node's processing
+     * with the modulator node itself. Default returns empty. Concrete nodes
+     * override to expose their held modulator references.
+     */
+    [[nodiscard]] virtual std::vector<std::pair<ModulatorRole, std::shared_ptr<Node>>>
+    get_modulators() const { return {}; }
+
+    /**
+     * @brief Returns the full modulator tree rooted at this node.
+     *
+     * Calls get_modulators() on this node, then recursively on each returned
+     * node, building the complete tree. The caller receives the entire
+     * hierarchy in one call.
+     */
+    [[nodiscard]] std::vector<ModulatorTree> get_modulator_tree() const
+    {
+        std::vector<ModulatorTree> result;
+        for (auto& [role, node] : get_modulators()) {
+            ModulatorTree entry;
+            entry.role = role;
+            entry.node = node;
+            entry.modulators = node->get_modulator_tree();
+            result.push_back(std::move(entry));
+        }
+        return result;
     }
 
 private:

--- a/src/MayaFlux/Nodes/NodeGraphManager.cpp
+++ b/src/MayaFlux/Nodes/NodeGraphManager.cpp
@@ -8,6 +8,10 @@
 
 namespace MayaFlux::Nodes {
 
+namespace {
+    const std::vector<std::shared_ptr<Node>> empty {};
+}
+
 NodeGraphManager::NodeGraphManager(uint32_t sample_rate, uint32_t block_size, uint32_t frame_rate)
     : m_registered_sample_rate(sample_rate)
     , m_registered_block_size(block_size)
@@ -40,6 +44,31 @@ void NodeGraphManager::remove_from_root(const std::shared_ptr<Node>& node,
 
     auto& root = get_root_node(token, channel);
     root.unregister_node(node);
+}
+
+const std::vector<std::shared_ptr<Node>>&
+NodeGraphManager::get_nodes(ProcessingToken token, uint32_t channel) const
+{
+
+    auto token_it = m_token_roots.find(token);
+    if (token_it == m_token_roots.end()) {
+        MF_ERROR(Journal::Component::Nodes,
+            Journal::Context::NodeProcessing,
+            "Attempted to get nodes for non-existent token {}. Returning empty vector.",
+            Reflect::enum_to_string(token));
+        return empty;
+    }
+    auto channel_it = token_it->second.find(channel);
+
+    if (channel_it == token_it->second.end()) {
+        MF_ERROR(Journal::Component::Nodes,
+            Journal::Context::NodeProcessing,
+            "Attempted to get nodes for token {} channel {} which does not exist. Returning empty vector.",
+            Reflect::enum_to_string(token), channel);
+        return empty;
+    }
+
+    return channel_it->second->nodes();
 }
 
 void NodeGraphManager::register_token_processor(ProcessingToken token,
@@ -472,19 +501,26 @@ void NodeGraphManager::remove_network(const std::shared_ptr<Network::NodeNetwork
 }
 
 std::vector<std::shared_ptr<Network::NodeNetwork>>
-NodeGraphManager::get_networks(ProcessingToken token, unsigned int channel) const
+NodeGraphManager::get_networks(ProcessingToken token, uint32_t channel) const
 {
-    auto token_it = m_audio_networks.find(token);
-    if (token_it != m_audio_networks.end()) {
-        std::vector<std::shared_ptr<Network::NodeNetwork>> networks_on_channel;
-        for (const auto& network : token_it->second) {
-            if (network && network->is_registered_on_channel(channel)) {
-                networks_on_channel.push_back(network);
-            }
+    if (token == ProcessingToken::AUDIO_RATE) {
+        auto it = m_audio_networks.find(token);
+        if (it == m_audio_networks.end())
+            return {};
+
+        std::vector<std::shared_ptr<Network::NodeNetwork>> result;
+
+        for (const auto& n : it->second) {
+            if (n && n->is_registered_on_channel(channel))
+                result.push_back(n);
         }
-        return networks_on_channel;
+        return result;
     }
-    return {};
+
+    auto it = m_token_networks.find(token);
+    if (it == m_token_networks.end())
+        return {};
+    return it->second;
 }
 
 std::vector<std::shared_ptr<Network::NodeNetwork>>

--- a/src/MayaFlux/Nodes/NodeGraphManager.hpp
+++ b/src/MayaFlux/Nodes/NodeGraphManager.hpp
@@ -90,6 +90,15 @@ public:
     void remove_from_root(const std::shared_ptr<Node>& node, ProcessingToken token, unsigned int channel = 0);
 
     /**
+     * @brief Get all nodes from their respective root nodes for a specific token and/or channel
+     * @param token Processing domain (AUDIO_RATE, VISUAL_RATE, etc.)
+     * @param channel Channel within that domain
+     * @return Vector of shared pointers to the nodes for that token and channel root
+     */
+    [[nodiscard]] const std::vector<std::shared_ptr<Node>>&
+    get_nodes(ProcessingToken token, uint32_t channel = 0) const;
+
+    /**
      * @brief Register subsystem processor for a specific token
      * @param token Processing domain to handle (e.g., AUDIO_RATE, VISUAL_RATE)
      * @param processor Function that receives a span of root nodes for that token
@@ -285,13 +294,6 @@ public:
      * @return Vector of networks registered to this token
      */
     [[nodiscard]] std::vector<std::shared_ptr<Network::NodeNetwork>> get_networks(ProcessingToken token, uint32_t channel = 0) const;
-
-    /**
-     * @brief Get all networks for a specific token across all channels
-     * @param token Processing domain
-     * @return Vector of networks registered to this token
-     */
-    [[nodiscard]] std::vector<std::shared_ptr<Network::NodeNetwork>> get_all_networks(ProcessingToken token) const;
 
     /**
      * @brief Get count of networks for a token
@@ -546,6 +548,13 @@ private:
      * @brief Check if network is registered globally
      */
     bool is_network_registered(const std::shared_ptr<Network::NodeNetwork>& network);
+
+    /**
+     * @brief Get all networks for a specific token across all channels
+     * @param token Processing domain
+     * @return Vector of networks registered to this token
+     */
+    [[nodiscard]] std::vector<std::shared_ptr<Network::NodeNetwork>> get_all_networks(ProcessingToken token) const;
 
     /**
      * @brief Resets the processing state of audio networks for a token and channel

--- a/src/MayaFlux/Nodes/RootNode.hpp
+++ b/src/MayaFlux/Nodes/RootNode.hpp
@@ -149,6 +149,12 @@ public:
      */
     void terminate_all_nodes();
 
+    /**
+     * @brief Gets the list of nodes registered with this root node
+     * @return Vector of shared pointers to registered nodes
+     */
+    [[nodiscard]] const std::vector<std::shared_ptr<Node>>& nodes() const { return m_Nodes; }
+
 private:
     /**
      * @brief Collection of nodes registered with this root node

--- a/src/MayaFlux/Vruta/EventManager.hpp
+++ b/src/MayaFlux/Vruta/EventManager.hpp
@@ -30,7 +30,7 @@ public:
     /**
      * @brief Get all managed events
      */
-    std::vector<std::shared_ptr<Event>> get_all_events() const;
+    std::vector<std::shared_ptr<Event>> get_all_events() const { return m_events; }
 
     /**
      * @brief Cancels and removes a event from the manager

--- a/src/MayaFlux/Vruta/Scheduler.cpp
+++ b/src/MayaFlux/Vruta/Scheduler.cpp
@@ -117,6 +117,26 @@ std::vector<std::shared_ptr<Routine>> TaskScheduler::get_tasks_for_token(Process
     return result;
 }
 
+std::vector<std::string> TaskScheduler::get_task_names() const
+{
+    std::vector<std::string> names;
+    for (const auto& entry : m_tasks) {
+        if (entry.routine)
+            names.push_back(entry.name);
+    }
+    return names;
+}
+
+std::vector<std::string> TaskScheduler::get_task_names(ProcessingToken token) const
+{
+    std::vector<std::string> names;
+    for (const auto& entry : m_tasks) {
+        if (entry.routine && entry.routine->get_processing_token() == token)
+            names.push_back(entry.name);
+    }
+    return names;
+}
+
 void TaskScheduler::process_token(ProcessingToken token, uint64_t processing_units)
 {
     drain_pending_tasks();

--- a/src/MayaFlux/Vruta/Scheduler.hpp
+++ b/src/MayaFlux/Vruta/Scheduler.hpp
@@ -290,6 +290,13 @@ public:
     std::vector<std::string> get_task_names() const;
 
     /**
+     * @brief Get task names for a specific processing domain.
+     * @param token Processing domain to filter by.
+     * @return Vector of task names active in that domain.
+     */
+    std::vector<std::string> get_task_names(ProcessingToken token) const;
+
+    /**
      * @brief Pause all active tasks
      */
     void pause_all_tasks();


### PR DESCRIPTION
Adds read-only access to live engine state across nodes, buffers, scheduling, input, and IO. This is the foundation that lets Lila scripts, the Forma UI, and workshop instruments query what is actually running without coupling to internal data structures or triggering processing side effects.

## What this enables

Any code with access to the engine can now traverse the full running state:

- Walk the node graph from `NodeGraphManager` down through root nodes to individual nodes and their modulator trees, without going through processing-path accessors that have side effects.
- Inspect active tasks and events by token, by name, or in full, from `TaskScheduler` and `EventManager`.
- See which input nodes are registered and which IO readers are live, including keyed video and camera readers by ID.
- Read the processing chain attached to any buffer.

The workshop introspection visual (`dl1.hpp`) drove the initial need, but the API is general enough to support any future tooling - a Lila-side graph inspector, a Forma debug overlay, or external OSC probing.

## Changes

**Nodes:** `Node::get_modulators()` returns direct modulator pairs with role labels; `get_modulator_tree()` recurses the full hierarchy. `RootNode::nodes()` exposes the registered node list. `NodeGraphManager` gains const query paths for nodes per token/channel and networks per token, none of which create roots as a side effect.

**Vruta:** `EventManager::get_all_events()` was declared but unimplemented; now returns `m_events`, the authoritative container covering both named and unnamed events. `TaskScheduler::get_task_names(ProcessingToken)` adds per-domain filtering alongside the existing all-token overload.

**Buffers:** `BufferProcessingChain` exposes its pre-, post-, and final-processor accessors.

**Core:** `InputManager::get_nodes()` returns a snapshot of tracked input nodes under the registry mutex.

**IO:** `IOManager` exposes keyed readers (video, camera) via `get_*_ids()` and `get_*(id)`, and unkeyed readers (audio, image, model) via `get_*()` returning the full retained vector.

## Out of scope

Per-hook introspection on `Node` subclasses (`Logic`, `Phasor`, `Counter`, `Impulse`). `std::function` is not meaningfully inspectable and returning raw callbacks is not useful to a display layer. Deferred to a later issue if a concrete need emerges.

## Linkage
- Closes #136 
- Closes #137 
- Closes #135 