### PR TITLE
Portal::Forma::Plot: signal-native plotting

### DIFF
--- a/src/MayaFlux/Kakshya/Processors/PlotProcessor.cpp
+++ b/src/MayaFlux/Kakshya/Processors/PlotProcessor.cpp
@@ -1,0 +1,251 @@
+#include "PlotProcessor.hpp"
+
+#include "MayaFlux/Buffers/AudioBuffer.hpp"
+#include "MayaFlux/Buffers/BufferUtils.hpp"
+
+#include "MayaFlux/Kakshya/Source/PlotContainer.hpp"
+
+#include "MayaFlux/Journal/Archivist.hpp"
+#include "MayaFlux/Nodes/Network/NodeNetwork.hpp"
+#include "MayaFlux/Nodes/Node.hpp"
+
+namespace MayaFlux::Kakshya {
+
+namespace {
+    constexpr auto C = Journal::Component::Kakshya;
+    constexpr auto X = Journal::Context::ContainerProcessing;
+}
+
+// =========================================================================
+// Binding
+// =========================================================================
+
+void PlotProcessor::bind_node(uint32_t series_index,
+    std::shared_ptr<Nodes::Node> node)
+{
+    if (!node) {
+        MF_ERROR(C, X, "PlotProcessor::bind_node: null node for series {}", series_index);
+        return;
+    }
+    auto& b = m_bindings[series_index];
+    b.source_type = SourceType::NODE;
+    b.node = std::move(node);
+    b.node->add_buffer_reference();
+    b.audio_buffer.reset();
+    b.network.reset();
+    b.callable = {};
+}
+
+void PlotProcessor::bind_audio_buffer(uint32_t series_index,
+    std::shared_ptr<Buffers::AudioBuffer> buffer)
+{
+    if (!buffer) {
+        MF_ERROR(C, X, "PlotProcessor::bind_audio_buffer: null buffer for series {}", series_index);
+        return;
+    }
+    auto& b = m_bindings[series_index];
+    b.source_type = SourceType::AUDIO_BUFFER;
+    b.audio_buffer = std::move(buffer);
+    b.node.reset();
+    b.network.reset();
+    b.callable = {};
+}
+
+void PlotProcessor::bind_network(uint32_t series_index,
+    std::shared_ptr<Nodes::Network::NodeNetwork> network)
+{
+    if (!network) {
+        MF_ERROR(C, X, "PlotProcessor::bind_network: null network for series {}", series_index);
+        return;
+    }
+
+    const auto mode = network->get_output_mode();
+    if (mode != Nodes::Network::OutputMode::AUDIO_SINK
+        && mode != Nodes::Network::OutputMode::AUDIO_COMPUTE) {
+        MF_ERROR(C, X,
+            "PlotProcessor::bind_network: network for series {} has no audio output mode", series_index);
+        return;
+    }
+
+    auto& b = m_bindings[series_index];
+    b.source_type = SourceType::NETWORK;
+    b.network = std::move(network);
+    b.node.reset();
+    b.audio_buffer.reset();
+    b.callable = {};
+}
+
+void PlotProcessor::bind_callable(uint32_t series_index,
+    std::function<void(std::vector<double>&)> fn)
+{
+    if (!fn) {
+        MF_ERROR(C, X, "PlotProcessor::bind_callable: null callable for series {}", series_index);
+        return;
+    }
+    auto& b = m_bindings[series_index];
+    b.source_type = SourceType::CALLABLE;
+    b.callable = std::move(fn);
+    b.node.reset();
+    b.audio_buffer.reset();
+    b.network.reset();
+}
+
+void PlotProcessor::set_raw(uint32_t series_index, std::vector<double> data)
+{
+    auto& b = m_bindings[series_index];
+    b.source_type = SourceType::RAW;
+    b.pending_raw = std::move(data);
+    b.raw_dirty.test_and_set(std::memory_order_release);
+}
+
+void PlotProcessor::unbind(uint32_t series_index)
+{
+    auto it = m_bindings.find(series_index);
+    if (it == m_bindings.end())
+        return;
+    if (it->second.source_type == SourceType::NODE && it->second.node)
+        it->second.node->remove_buffer_reference();
+    m_bindings.erase(it);
+}
+
+bool PlotProcessor::has_binding(uint32_t series_index) const
+{
+    return m_bindings.contains(series_index);
+}
+
+// =========================================================================
+// DataProcessor
+// =========================================================================
+
+void PlotProcessor::on_attach(const std::shared_ptr<SignalSourceContainer>& container)
+{
+    if (!std::dynamic_pointer_cast<PlotContainer>(container))
+        MF_ERROR(C, X, "PlotProcessor requires a PlotContainer");
+}
+
+void PlotProcessor::on_detach(const std::shared_ptr<SignalSourceContainer>&)
+{
+    for (auto& [idx, b] : m_bindings) {
+        if (b.source_type == SourceType::NODE && b.node)
+            b.node->remove_buffer_reference();
+    }
+    m_bindings.clear();
+}
+
+void PlotProcessor::process(const std::shared_ptr<SignalSourceContainer>& container)
+{
+    auto plot = std::dynamic_pointer_cast<PlotContainer>(container);
+    if (!plot) {
+        MF_ERROR(C, X, "PlotProcessor::process: container is not a PlotContainer");
+        return;
+    }
+
+    m_processing.store(true, std::memory_order_release);
+
+    for (auto& [idx, b] : m_bindings) {
+        if (idx >= plot->series_count())
+            continue;
+
+        thread_local std::vector<double> staging;
+        staging.resize(plot->series_size(idx));
+
+        {
+            auto frame = plot->get_frame(idx);
+            if (frame.size() == staging.size()) {
+                std::ranges::copy(frame, staging.begin());
+            } else {
+                std::ranges::fill(staging, 0.0);
+            }
+        }
+
+        switch (b.source_type) {
+        case SourceType::NODE:
+            acquire_from_node(b, staging);
+            break;
+        case SourceType::AUDIO_BUFFER:
+            acquire_from_audio_buffer(b, staging);
+            break;
+        case SourceType::NETWORK:
+            acquire_from_network(b, staging);
+            break;
+        case SourceType::CALLABLE:
+            acquire_from_callable(b, staging);
+            break;
+        case SourceType::RAW:
+            acquire_from_raw(b, staging);
+            break;
+        }
+
+        plot->write_series(idx, staging);
+    }
+
+    auto& src = plot->get_data();
+    auto& dst = plot->get_processed_data();
+    dst.resize(src.size());
+    for (size_t i = 0; i < src.size(); ++i)
+        dst[i] = src[i];
+
+    m_processing.store(false, std::memory_order_release);
+}
+
+// =========================================================================
+// Private acquisition
+// =========================================================================
+
+void PlotProcessor::acquire_from_node(SeriesBinding& b, std::vector<double>& series)
+{
+    if (!b.node)
+        return;
+
+    auto samples = Buffers::extract_multiple_samples(b.node, series.size());
+    const size_t n = std::min(series.size(), samples.size());
+    std::copy_n(samples.begin(), n, series.begin());
+    if (n < series.size())
+        std::fill(series.begin() + static_cast<ptrdiff_t>(n), series.end(), 0.0);
+}
+
+void PlotProcessor::acquire_from_audio_buffer(SeriesBinding& b, std::vector<double>& series)
+{
+    if (!b.audio_buffer)
+        return;
+
+    const auto& data = b.audio_buffer->get_data();
+    const size_t n = std::min(series.size(), data.size());
+    std::copy_n(data.begin(), n, series.begin());
+    if (n < series.size())
+        std::fill(series.begin() + static_cast<ptrdiff_t>(n), series.end(), 0.0);
+}
+
+void PlotProcessor::acquire_from_network(SeriesBinding& b, std::vector<double>& series)
+{
+    if (!b.network)
+        return;
+
+    auto buf = b.network->get_audio_buffer();
+    if (!buf)
+        return;
+
+    const size_t n = std::min(series.size(), buf->size());
+    std::copy_n(buf->begin(), n, series.begin());
+    if (n < series.size())
+        std::fill(series.begin() + static_cast<ptrdiff_t>(n), series.end(), 0.0);
+}
+
+void PlotProcessor::acquire_from_callable(SeriesBinding& b, std::vector<double>& series)
+{
+    if (b.callable)
+        b.callable(series);
+}
+
+void PlotProcessor::acquire_from_raw(SeriesBinding& b, std::vector<double>& series)
+{
+    if (!b.raw_dirty.test(std::memory_order_acquire))
+        return;
+    b.raw_dirty.clear(std::memory_order_release);
+    const size_t n = std::min(series.size(), b.pending_raw.size());
+    std::copy_n(b.pending_raw.begin(), n, series.begin());
+    if (n < series.size())
+        std::fill(series.begin() + static_cast<ptrdiff_t>(n), series.end(), 0.0);
+}
+
+} // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Processors/PlotProcessor.cpp
+++ b/src/MayaFlux/Kakshya/Processors/PlotProcessor.cpp
@@ -4,6 +4,7 @@
 #include "MayaFlux/Buffers/BufferUtils.hpp"
 
 #include "MayaFlux/Kakshya/Source/PlotContainer.hpp"
+#include "MayaFlux/Kakshya/Region/RegionGroup.hpp"
 
 #include "MayaFlux/Journal/Archivist.hpp"
 #include "MayaFlux/Nodes/Network/NodeNetwork.hpp"

--- a/src/MayaFlux/Kakshya/Processors/PlotProcessor.cpp
+++ b/src/MayaFlux/Kakshya/Processors/PlotProcessor.cpp
@@ -98,6 +98,17 @@ void PlotProcessor::set_raw(uint32_t series_index, std::vector<double> data)
     b.raw_dirty.test_and_set(std::memory_order_release);
 }
 
+void PlotProcessor::set_series_semantics(uint32_t series_index,
+    DataDimension::Role role,
+    DataModality modality)
+{
+    auto it = m_bindings.find(series_index);
+    if (it == m_bindings.end())
+        return;
+    it->second.role = role;
+    it->second.modality = modality;
+}
+
 void PlotProcessor::unbind(uint32_t series_index)
 {
     auto it = m_bindings.find(series_index);

--- a/src/MayaFlux/Kakshya/Processors/PlotProcessor.hpp
+++ b/src/MayaFlux/Kakshya/Processors/PlotProcessor.hpp
@@ -1,0 +1,171 @@
+#pragma once
+
+#include "MayaFlux/Kakshya/DataProcessor.hpp"
+
+namespace MayaFlux::Nodes {
+class Node;
+namespace Network {
+    class NodeNetwork;
+}
+}
+
+namespace MayaFlux::Buffers {
+class AudioBuffer;
+}
+
+namespace MayaFlux::Kakshya {
+
+/**
+ * @class PlotProcessor
+ * @brief DataProcessor that acquires per-series data from heterogeneous sources
+ *        and writes into PlotContainer::m_data each process() call.
+ *
+ * Mirrors the source-binding model of DescriptorBindingsProcessor but targets
+ * CPU-side DataVariant storage rather than GPU descriptor sets. Each series slot
+ * in the container has one binding. All reads are EXTERNAL — the processor never
+ * drives node or network processing; it only samples already-processed state.
+ *
+ * Source types per series:
+ *   NODE         — single Node, reads get_last_output() → scalar appended or
+ *                  overwrites the series depending on mode (rolling vs snapshot)
+ *   AUDIO_BUFFER — AudioBuffer, reads get_data() span → full series copy
+ *   NETWORK      — NodeNetwork with audio output, reads get_audio_buffer() → full series copy
+ *   CALLABLE     — std::function<void(std::vector<double>&)>, caller fills the series
+ *   RAW          — pending std::vector<double> pushed via set_raw(), swapped in on process()
+ *
+ * process() iterates all bindings, acquires from source, writes into the container's
+ * m_data variant at the bound series index, then copies m_data into processed_data.
+ * Called by Forma immediately before the geometry function runs.
+ */
+class MAYAFLUX_API PlotProcessor : public DataProcessor {
+public:
+    enum class SourceType : uint8_t {
+        NODE,
+        AUDIO_BUFFER,
+        NETWORK,
+        CALLABLE,
+        RAW,
+    };
+
+    struct SeriesBinding {
+        SourceType source_type { SourceType::RAW };
+
+        std::shared_ptr<Nodes::Node> node;
+        std::shared_ptr<Buffers::AudioBuffer> audio_buffer;
+        std::shared_ptr<Nodes::Network::NodeNetwork> network;
+        std::function<void(std::vector<double>&)> callable;
+
+        std::vector<double> pending_raw;
+        std::atomic_flag raw_dirty { ATOMIC_FLAG_INIT };
+    };
+
+    PlotProcessor() = default;
+    ~PlotProcessor() override = default;
+
+    // =========================================================================
+    // Binding
+    // =========================================================================
+
+    /**
+     * @brief Bind a series slot to a Node.
+     *
+     * Each process() calls Buffers::extract_multiple_samples(node, series_size),
+     * which handles snapshot context, save/restore state, and buffer lifecycle
+     * identically to NodeSourceProcessor. The series is filled with one full
+     * batch of node output per process() call.
+     *
+     * @param series_index  Index returned by PlotContainer::add_series().
+     * @param node          Node to read from.
+     */
+    void bind_node(uint32_t series_index,
+        std::shared_ptr<Nodes::Node> node);
+
+    /**
+     * @brief Bind a series slot to an AudioBuffer.
+     *
+     * Each process() copies the full buffer span into the series.
+     * Series size is resized to match the buffer on the first process() call.
+     *
+     * @param series_index  Index returned by PlotContainer::add_series().
+     * @param buffer        AudioBuffer to read from.
+     */
+    void bind_audio_buffer(uint32_t series_index,
+        std::shared_ptr<Buffers::AudioBuffer> buffer);
+
+    /**
+     * @brief Bind a series slot to a NodeNetwork with audio output.
+     *
+     * Each process() reads get_audio_buffer() and copies the result into the series.
+     * Fails at bind time if the network has no audio output mode.
+     *
+     * @param series_index  Index returned by PlotContainer::add_series().
+     * @param network       NodeNetwork to read from.
+     */
+    void bind_network(uint32_t series_index,
+        std::shared_ptr<Nodes::Network::NodeNetwork> network);
+
+    /**
+     * @brief Bind a series slot to a callable.
+     *
+     * Each process() calls fn with the series vector by reference. The callable
+     * fills or mutates it freely. Suitable for computed series, ring buffer views,
+     * and any source that does not fit the other patterns.
+     *
+     * @param series_index  Index returned by PlotContainer::add_series().
+     * @param fn            Callable invoked with the series vector each process().
+     */
+    void bind_callable(uint32_t series_index,
+        std::function<void(std::vector<double>&)> fn);
+
+    /**
+     * @brief Push raw sample data for a series.
+     *
+     * Lock-free pending swap. The data is committed into the container on the
+     * next process() call. Thread-safe: may be called from any thread.
+     *
+     * @param series_index  Index returned by PlotContainer::add_series().
+     * @param data          Samples to write. Copied into a pending buffer.
+     */
+    void set_raw(uint32_t series_index, std::vector<double> data);
+
+    /**
+     * @brief Remove a binding from a series slot.
+     * @param series_index Series index to unbind.
+     */
+    void unbind(uint32_t series_index);
+
+    [[nodiscard]] bool has_binding(uint32_t series_index) const;
+
+    // =========================================================================
+    // DataProcessor
+    // =========================================================================
+
+    void on_attach(const std::shared_ptr<SignalSourceContainer>& container) override;
+    void on_detach(const std::shared_ptr<SignalSourceContainer>& container) override;
+
+    /**
+     * @brief Acquire data from all bound sources and write into the container.
+     *
+     * For each bound series: acquires from source, writes into container m_data,
+     * then copies m_data into processed_data. Unbound series are left unchanged.
+     * Called from the graphics thread by Forma before the geometry function runs.
+     */
+    void process(const std::shared_ptr<SignalSourceContainer>& container) override;
+
+    [[nodiscard]] bool is_processing() const override
+    {
+        return m_processing.load(std::memory_order_acquire);
+    }
+
+private:
+    void acquire_from_node(SeriesBinding& b, std::vector<double>& series);
+    void acquire_from_audio_buffer(SeriesBinding& b, std::vector<double>& series);
+    void acquire_from_network(SeriesBinding& b, std::vector<double>& series);
+    void acquire_from_callable(SeriesBinding& b, std::vector<double>& series);
+    void acquire_from_raw(SeriesBinding& b, std::vector<double>& series);
+
+    std::unordered_map<uint32_t, SeriesBinding> m_bindings;
+    std::atomic<bool> m_processing { false };
+};
+
+} // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Processors/PlotProcessor.hpp
+++ b/src/MayaFlux/Kakshya/Processors/PlotProcessor.hpp
@@ -60,7 +60,7 @@ public:
         std::function<void(std::vector<double>&)> callable;
 
         std::vector<double> pending_raw;
-        std::atomic_flag raw_dirty { ATOMIC_FLAG_INIT };
+        std::atomic_flag raw_dirty = ATOMIC_FLAG_INIT;
     };
 
     PlotProcessor() = default;

--- a/src/MayaFlux/Kakshya/Processors/PlotProcessor.hpp
+++ b/src/MayaFlux/Kakshya/Processors/PlotProcessor.hpp
@@ -2,6 +2,8 @@
 
 #include "MayaFlux/Kakshya/DataProcessor.hpp"
 
+#include "MayaFlux/Kakshya/NDData/NDData.hpp"
+
 namespace MayaFlux::Nodes {
 class Node;
 namespace Network {
@@ -49,6 +51,8 @@ public:
 
     struct SeriesBinding {
         SourceType source_type { SourceType::RAW };
+        DataDimension::Role role { DataDimension::Role::CUSTOM };
+        DataModality modality { DataModality::TENSOR_ND };
 
         std::shared_ptr<Nodes::Node> node;
         std::shared_ptr<Buffers::AudioBuffer> audio_buffer;
@@ -133,6 +137,22 @@ public:
      * @param series_index Series index to unbind.
      */
     void unbind(uint32_t series_index);
+
+    /**
+     * @brief Set the role and modality for a series binding.
+     *
+     * Called by PlotContainer after every bind_* to propagate the semantic
+     * metadata declared on add_series() down into the binding. process() uses
+     * these values to tag each processed_data variant's dimension correctly,
+     * so DomainMapping can query by Role rather than by index.
+     *
+     * @param series_index  Series index.
+     * @param role          DataDimension::Role declared on add_series().
+     * @param modality      DataModality declared on add_series().
+     */
+    void set_series_semantics(uint32_t series_index,
+        DataDimension::Role role,
+        DataModality modality);
 
     [[nodiscard]] bool has_binding(uint32_t series_index) const;
 

--- a/src/MayaFlux/Kakshya/Source/PlotContainer.cpp
+++ b/src/MayaFlux/Kakshya/Source/PlotContainer.cpp
@@ -36,24 +36,25 @@ PlotProcessor& PlotContainer::ensure_processor()
 // Series management
 // =========================================================================
 
-uint32_t PlotContainer::add_series(std::string name, uint64_t count)
+uint32_t PlotContainer::add_series(std::string name, uint64_t count,
+    DataDimension::Role role, DataModality modality)
 {
-
-    m_names.push_back(std::move(name));
     m_data.emplace_back(std::vector<double>(count, 0.0));
     m_processed_data.emplace_back(std::vector<double>(count, 0.0));
+    m_structure.dimensions.emplace_back(std::move(name), count, 1, role);
+    m_structure.modality = DataModality::TENSOR_ND;
 
-    rebuild_dimensions();
+    const auto idx = static_cast<uint32_t>(m_structure.dimensions.size() - 1);
+    MF_INFO(C, X, "PlotContainer: added series '{}' at index {} ({} samples, role={}, modality={})",
+        m_structure.dimensions[idx].name, idx, count,
+        static_cast<int>(role),
+        modality_to_string(modality));
 
-    const auto idx = static_cast<uint32_t>(m_names.size() - 1);
-    MF_INFO(C, X, "PlotContainer: added series '{}' at index {} with {} samples",
-        m_names[idx], idx, count);
     return idx;
 }
 
 void PlotContainer::write_series(uint32_t index, std::span<const double> samples)
 {
-
     if (index >= m_data.size()) {
         MF_ERROR(C, X, "PlotContainer::write_series: index {} out of range", index);
         return;
@@ -71,7 +72,6 @@ void PlotContainer::write_series(uint32_t index, std::span<const double> samples
 
 void PlotContainer::write_sample(uint32_t index, uint64_t sample_index, double value)
 {
-
     if (index >= m_data.size()) {
         MF_ERROR(C, X, "PlotContainer::write_sample: series index {} out of range", index);
         return;
@@ -88,7 +88,6 @@ void PlotContainer::write_sample(uint32_t index, uint64_t sample_index, double v
 
 void PlotContainer::resize_series(uint32_t index, uint64_t count)
 {
-
     if (index >= m_data.size()) {
         MF_ERROR(C, X, "PlotContainer::resize_series: index {} out of range", index);
         return;
@@ -104,18 +103,20 @@ void PlotContainer::resize_series(uint32_t index, uint64_t count)
     if (pv)
         pv->resize(count, 0.0);
 
-    rebuild_dimensions();
+    m_structure.dimensions[index].size = count;
 }
 
 uint32_t PlotContainer::series_count() const
 {
-    return static_cast<uint32_t>(m_names.size());
+    return static_cast<uint32_t>(m_structure.dimensions.size());
 }
 
 const std::string& PlotContainer::series_name(uint32_t index) const
 {
     static const std::string empty;
-    return index < m_names.size() ? m_names[index] : empty;
+    return index < m_structure.dimensions.size()
+        ? m_structure.dimensions[index].name
+        : empty;
 }
 
 uint64_t PlotContainer::series_size(uint32_t index) const
@@ -126,25 +127,78 @@ uint64_t PlotContainer::series_size(uint32_t index) const
     return vec ? static_cast<uint64_t>(vec->size()) : 0;
 }
 
+DataDimension::Role PlotContainer::series_role(uint32_t index) const
+{
+    return index < m_structure.dimensions.size()
+        ? m_structure.dimensions[index].role
+        : DataDimension::Role::CUSTOM;
+}
+
+// =========================================================================
+// Source binding
+// =========================================================================
+
+void PlotContainer::bind_node(uint32_t series_index, std::shared_ptr<Nodes::Node> node)
+{
+    auto& p = ensure_processor();
+    p.bind_node(series_index, std::move(node));
+    p.set_series_semantics(series_index, m_structure.dimensions[series_index].role,
+        m_structure.modality);
+    mark_ready_for_processing(true);
+}
+
+void PlotContainer::bind_audio_buffer(uint32_t series_index,
+    std::shared_ptr<Buffers::AudioBuffer> buffer)
+{
+    auto& p = ensure_processor();
+    p.bind_audio_buffer(series_index, std::move(buffer));
+    p.set_series_semantics(series_index, m_structure.dimensions[series_index].role,
+        m_structure.modality);
+    mark_ready_for_processing(true);
+}
+
+void PlotContainer::bind_network(uint32_t series_index,
+    std::shared_ptr<Nodes::Network::NodeNetwork> network)
+{
+    auto& p = ensure_processor();
+    p.bind_network(series_index, std::move(network));
+    p.set_series_semantics(series_index, m_structure.dimensions[series_index].role,
+        m_structure.modality);
+    mark_ready_for_processing(true);
+}
+
+void PlotContainer::bind_callable(uint32_t series_index,
+    std::function<void(std::vector<double>&)> fn)
+{
+    auto& p = ensure_processor();
+    p.bind_callable(series_index, std::move(fn));
+    p.set_series_semantics(series_index, m_structure.dimensions[series_index].role,
+        m_structure.modality);
+    mark_ready_for_processing(true);
+}
+
+void PlotContainer::set_raw(uint32_t series_index, std::vector<double> data)
+{
+    auto& p = ensure_processor();
+    p.set_raw(series_index, std::move(data));
+    p.set_series_semantics(series_index, m_structure.dimensions[series_index].role,
+        m_structure.modality);
+    mark_ready_for_processing(true);
+}
+
+void PlotContainer::unbind(uint32_t series_index)
+{
+    if (m_processor)
+        std::static_pointer_cast<PlotProcessor>(m_processor)->unbind(series_index);
+}
+
 // =========================================================================
 // NDDataContainer
 // =========================================================================
 
-void PlotContainer::rebuild_dimensions()
-{
-    m_dimensions.clear();
-    m_dimensions.reserve(m_names.size());
-    for (size_t i = 0; i < m_names.size(); ++i) {
-        const auto* vec = std::get_if<std::vector<double>>(&m_data[i]);
-        uint64_t sz = vec ? static_cast<uint64_t>(vec->size()) : 0;
-        m_dimensions.emplace_back(m_names[i], sz, 1, DataDimension::Role::CUSTOM);
-    }
-    m_structure.dimensions = m_dimensions;
-}
-
 std::vector<DataDimension> PlotContainer::get_dimensions() const
 {
-    return m_dimensions;
+    return m_structure.dimensions;
 }
 
 uint64_t PlotContainer::get_total_elements() const
@@ -165,7 +219,6 @@ uint64_t PlotContainer::get_num_frames() const
 
 std::vector<DataVariant> PlotContainer::get_region_data(const Region& region) const
 {
-
     if (region.start_coordinates.empty() || region.end_coordinates.empty())
         return {};
 
@@ -294,10 +347,8 @@ std::vector<uint64_t> PlotContainer::linear_index_to_coordinates(uint64_t linear
 
 void PlotContainer::clear()
 {
-    m_names.clear();
     m_data.clear();
     m_processed_data.clear();
-    m_dimensions.clear();
     m_structure.dimensions.clear();
     update_processing_state(ProcessingState::IDLE);
 }
@@ -322,15 +373,19 @@ DataAccess PlotContainer::channel_data(size_t index)
         static std::vector<DataDimension> empty_dims;
         return { empty, empty_dims, DataModality::TENSOR_ND };
     }
-    return { m_data[index], { m_dimensions[index] }, DataModality::TENSOR_ND };
+    return { m_data[index], { m_structure.dimensions[index] }, DataModality::TENSOR_ND };
 }
 
 std::vector<DataAccess> PlotContainer::all_channel_data()
 {
     std::vector<DataAccess> result;
     result.reserve(m_data.size());
-    for (size_t i = 0; i < m_data.size(); ++i)
-        result.emplace_back(m_data[i], std::vector<DataDimension> { m_dimensions[i] }, DataModality::TENSOR_ND);
+    for (size_t i = 0; i < m_data.size(); ++i) {
+        result.emplace_back(m_data[i],
+            std::vector<DataDimension> { m_structure.dimensions[i] },
+            DataModality::TENSOR_ND);
+    }
+
     return result;
 }
 

--- a/src/MayaFlux/Kakshya/Source/PlotContainer.cpp
+++ b/src/MayaFlux/Kakshya/Source/PlotContainer.cpp
@@ -1,0 +1,425 @@
+#include "PlotContainer.hpp"
+
+#include "MayaFlux/Kakshya/NDData/DataAccess.hpp"
+#include "MayaFlux/Kakshya/Processors/PlotProcessor.hpp"
+#include "MayaFlux/Kakshya/Region/RegionGroup.hpp"
+
+#include "MayaFlux/Journal/Archivist.hpp"
+
+namespace MayaFlux::Kakshya {
+
+namespace {
+    constexpr auto C = Journal::Component::Kakshya;
+    constexpr auto X = Journal::Context::ContainerProcessing;
+}
+
+PlotContainer::PlotContainer()
+{
+    m_structure = ContainerDataStructure(
+        DataModality::TENSOR_ND,
+        OrganizationStrategy::PLANAR,
+        MemoryLayout::ROW_MAJOR);
+}
+
+// =========================================================================
+// ensure_processor
+// =========================================================================
+
+PlotProcessor& PlotContainer::ensure_processor()
+{
+    if (!m_processor)
+        create_default_processor();
+    return *std::static_pointer_cast<PlotProcessor>(m_processor);
+}
+
+// =========================================================================
+// Series management
+// =========================================================================
+
+uint32_t PlotContainer::add_series(std::string name, uint64_t count)
+{
+
+    m_names.push_back(std::move(name));
+    m_data.emplace_back(std::vector<double>(count, 0.0));
+    m_processed_data.emplace_back(std::vector<double>(count, 0.0));
+
+    rebuild_dimensions();
+
+    const auto idx = static_cast<uint32_t>(m_names.size() - 1);
+    MF_INFO(C, X, "PlotContainer: added series '{}' at index {} with {} samples",
+        m_names[idx], idx, count);
+    return idx;
+}
+
+void PlotContainer::write_series(uint32_t index, std::span<const double> samples)
+{
+
+    if (index >= m_data.size()) {
+        MF_ERROR(C, X, "PlotContainer::write_series: index {} out of range", index);
+        return;
+    }
+
+    auto* vec = std::get_if<std::vector<double>>(&m_data[index]);
+    if (!vec) {
+        MF_ERROR(C, X, "PlotContainer::write_series: series {} has unexpected variant type", index);
+        return;
+    }
+
+    const uint64_t n = std::min<uint64_t>(samples.size(), vec->size());
+    std::copy_n(samples.begin(), n, vec->begin());
+}
+
+void PlotContainer::write_sample(uint32_t index, uint64_t sample_index, double value)
+{
+
+    if (index >= m_data.size()) {
+        MF_ERROR(C, X, "PlotContainer::write_sample: series index {} out of range", index);
+        return;
+    }
+
+    auto* vec = std::get_if<std::vector<double>>(&m_data[index]);
+    if (!vec || sample_index >= vec->size()) {
+        MF_ERROR(C, X, "PlotContainer::write_sample: sample index {} out of range in series {}", sample_index, index);
+        return;
+    }
+
+    (*vec)[sample_index] = value;
+}
+
+void PlotContainer::resize_series(uint32_t index, uint64_t count)
+{
+
+    if (index >= m_data.size()) {
+        MF_ERROR(C, X, "PlotContainer::resize_series: index {} out of range", index);
+        return;
+    }
+
+    auto* vec = std::get_if<std::vector<double>>(&m_data[index]);
+    if (!vec)
+        return;
+
+    vec->resize(count, 0.0);
+
+    auto* pv = std::get_if<std::vector<double>>(&m_processed_data[index]);
+    if (pv)
+        pv->resize(count, 0.0);
+
+    rebuild_dimensions();
+}
+
+uint32_t PlotContainer::series_count() const
+{
+    return static_cast<uint32_t>(m_names.size());
+}
+
+const std::string& PlotContainer::series_name(uint32_t index) const
+{
+    static const std::string empty;
+    return index < m_names.size() ? m_names[index] : empty;
+}
+
+uint64_t PlotContainer::series_size(uint32_t index) const
+{
+    if (index >= m_data.size())
+        return 0;
+    const auto* vec = std::get_if<std::vector<double>>(&m_data[index]);
+    return vec ? static_cast<uint64_t>(vec->size()) : 0;
+}
+
+// =========================================================================
+// NDDataContainer
+// =========================================================================
+
+void PlotContainer::rebuild_dimensions()
+{
+    m_dimensions.clear();
+    m_dimensions.reserve(m_names.size());
+    for (size_t i = 0; i < m_names.size(); ++i) {
+        const auto* vec = std::get_if<std::vector<double>>(&m_data[i]);
+        uint64_t sz = vec ? static_cast<uint64_t>(vec->size()) : 0;
+        m_dimensions.emplace_back(m_names[i], sz, 1, DataDimension::Role::CUSTOM);
+    }
+    m_structure.dimensions = m_dimensions;
+}
+
+std::vector<DataDimension> PlotContainer::get_dimensions() const
+{
+    return m_dimensions;
+}
+
+uint64_t PlotContainer::get_total_elements() const
+{
+    uint64_t total = 0;
+    for (const auto& v : m_data) {
+        const auto* vec = std::get_if<std::vector<double>>(&v);
+        if (vec)
+            total += vec->size();
+    }
+    return total;
+}
+
+uint64_t PlotContainer::get_num_frames() const
+{
+    return static_cast<uint64_t>(m_data.size());
+}
+
+std::vector<DataVariant> PlotContainer::get_region_data(const Region& region) const
+{
+
+    if (region.start_coordinates.empty() || region.end_coordinates.empty())
+        return {};
+
+    const uint64_t series_idx = region.start_coordinates[0];
+    if (series_idx >= m_data.size())
+        return {};
+
+    const auto* src = std::get_if<std::vector<double>>(&m_data[series_idx]);
+    if (!src || src->empty())
+        return {};
+
+    const uint64_t s = (region.start_coordinates.size() > 1) ? region.start_coordinates[1] : 0;
+    const uint64_t e = (region.end_coordinates.size() > 1)
+        ? std::min(region.end_coordinates[1], static_cast<uint64_t>(src->size() - 1))
+        : static_cast<uint64_t>(src->size() - 1);
+
+    if (s > e)
+        return {};
+
+    std::vector<double> slice(src->begin() + static_cast<ptrdiff_t>(s),
+        src->begin() + static_cast<ptrdiff_t>(e + 1));
+    return { DataVariant(std::move(slice)) };
+}
+
+void PlotContainer::set_region_data(const Region& region, const std::vector<DataVariant>& data)
+{
+    if (data.empty() || region.start_coordinates.empty())
+        return;
+
+    const uint64_t series_idx = region.start_coordinates[0];
+    if (series_idx >= m_data.size())
+        return;
+
+    auto* dst = std::get_if<std::vector<double>>(&m_data[series_idx]);
+    if (!dst)
+        return;
+
+    const auto* src = std::get_if<std::vector<double>>(&data[0]);
+    if (!src || src->empty())
+        return;
+
+    const uint64_t s = (region.start_coordinates.size() > 1) ? region.start_coordinates[1] : 0;
+    const uint64_t e = (region.end_coordinates.size() > 1)
+        ? std::min(region.end_coordinates[1], static_cast<uint64_t>(dst->size() - 1))
+        : static_cast<uint64_t>(dst->size() - 1);
+
+    if (s > e)
+        return;
+
+    const uint64_t n = std::min<uint64_t>(src->size(), e - s + 1);
+    std::copy_n(src->begin(), n, dst->begin() + static_cast<ptrdiff_t>(s));
+}
+
+std::vector<DataVariant> PlotContainer::get_region_group_data(const RegionGroup& group) const
+{
+    std::vector<DataVariant> result;
+    for (const auto& r : group.regions) {
+        auto slice = get_region_data(r);
+        for (auto& v : slice)
+            result.push_back(std::move(v));
+    }
+    return result;
+}
+
+std::vector<DataVariant> PlotContainer::get_segments_data(const std::vector<RegionSegment>&) const
+{
+    return m_processed_data;
+}
+
+std::span<const double> PlotContainer::get_frame(uint64_t frame_index) const
+{
+    if (frame_index >= m_data.size())
+        return {};
+    const auto* vec = std::get_if<std::vector<double>>(&m_data[frame_index]);
+    if (!vec || vec->empty())
+        return {};
+    return { vec->data(), vec->size() };
+}
+
+void PlotContainer::get_frames(std::span<double> output, uint64_t start_frame, uint64_t num_frames) const
+{
+    size_t out = 0;
+    for (uint64_t i = start_frame; i < start_frame + num_frames && i < m_data.size(); ++i) {
+        const auto* vec = std::get_if<std::vector<double>>(&m_data[i]);
+        if (!vec)
+            continue;
+        for (double v : *vec) {
+            if (out >= output.size())
+                return;
+            output[out++] = v;
+        }
+    }
+}
+
+double PlotContainer::get_value_at(const std::vector<uint64_t>& coordinates) const
+{
+    if (coordinates.size() < 2 || coordinates[0] >= m_data.size())
+        return 0.0;
+    const auto* vec = std::get_if<std::vector<double>>(&m_data[coordinates[0]]);
+    if (!vec || coordinates[1] >= vec->size())
+        return 0.0;
+    return (*vec)[coordinates[1]];
+}
+
+void PlotContainer::set_value_at(const std::vector<uint64_t>& coordinates, double value)
+{
+    if (coordinates.size() < 2 || coordinates[0] >= m_data.size())
+        return;
+    auto* vec = std::get_if<std::vector<double>>(&m_data[coordinates[0]]);
+    if (!vec || coordinates[1] >= vec->size())
+        return;
+    (*vec)[coordinates[1]] = value;
+}
+
+uint64_t PlotContainer::coordinates_to_linear_index(const std::vector<uint64_t>& coordinates) const
+{
+    if (coordinates.size() < 2)
+        return 0;
+    return coordinates[1];
+}
+
+std::vector<uint64_t> PlotContainer::linear_index_to_coordinates(uint64_t linear) const
+{
+    return { 0, linear };
+}
+
+void PlotContainer::clear()
+{
+    m_names.clear();
+    m_data.clear();
+    m_processed_data.clear();
+    m_dimensions.clear();
+    m_structure.dimensions.clear();
+    update_processing_state(ProcessingState::IDLE);
+}
+
+const void* PlotContainer::get_raw_data() const
+{
+    if (m_data.empty())
+        return nullptr;
+    const auto* vec = std::get_if<std::vector<double>>(&m_data[0]);
+    return (vec && !vec->empty()) ? vec->data() : nullptr;
+}
+
+bool PlotContainer::has_data() const
+{
+    return !m_data.empty();
+}
+
+DataAccess PlotContainer::channel_data(size_t index)
+{
+    if (index >= m_data.size()) {
+        static DataVariant empty = std::vector<double> {};
+        static std::vector<DataDimension> empty_dims;
+        return { empty, empty_dims, DataModality::TENSOR_ND };
+    }
+    return { m_data[index], { m_dimensions[index] }, DataModality::TENSOR_ND };
+}
+
+std::vector<DataAccess> PlotContainer::all_channel_data()
+{
+    std::vector<DataAccess> result;
+    result.reserve(m_data.size());
+    for (size_t i = 0; i < m_data.size(); ++i)
+        result.emplace_back(m_data[i], std::vector<DataDimension> { m_dimensions[i] }, DataModality::TENSOR_ND);
+    return result;
+}
+
+void PlotContainer::add_region_group(const RegionGroup& group)
+{
+    m_region_groups[group.name] = group;
+}
+
+const RegionGroup& PlotContainer::get_region_group(const std::string& name) const
+{
+    static const RegionGroup empty;
+    auto it = m_region_groups.find(name);
+    return it != m_region_groups.end() ? it->second : empty;
+}
+
+std::unordered_map<std::string, RegionGroup> PlotContainer::get_all_region_groups() const
+{
+    return m_region_groups;
+}
+
+void PlotContainer::remove_region_group(const std::string& name)
+{
+    m_region_groups.erase(name);
+}
+
+// =========================================================================
+// SignalSourceContainer
+// =========================================================================
+
+ProcessingState PlotContainer::get_processing_state() const
+{
+    return m_processing_state.load(std::memory_order_acquire);
+}
+
+void PlotContainer::update_processing_state(ProcessingState state)
+{
+    m_processing_state.store(state, std::memory_order_release);
+    if (m_state_cb)
+        m_state_cb(shared_from_this(), state);
+}
+
+void PlotContainer::register_state_change_callback(
+    std::function<void(const std::shared_ptr<SignalSourceContainer>&, ProcessingState)> cb)
+{
+    m_state_cb = std::move(cb);
+}
+
+void PlotContainer::unregister_state_change_callback()
+{
+    m_state_cb = nullptr;
+}
+
+bool PlotContainer::is_ready_for_processing() const
+{
+    const auto s = get_processing_state();
+    return has_data() && (s == ProcessingState::READY || s == ProcessingState::PROCESSED);
+}
+
+void PlotContainer::mark_ready_for_processing(bool ready)
+{
+    update_processing_state(ready ? ProcessingState::READY : ProcessingState::IDLE);
+}
+
+void PlotContainer::create_default_processor()
+{
+    set_default_processor(std::make_shared<PlotProcessor>());
+}
+
+void PlotContainer::process_default()
+{
+    if (!m_processor || !is_ready_for_processing())
+        return;
+    update_processing_state(ProcessingState::PROCESSING);
+    m_processor->process(shared_from_this());
+    update_processing_state(ProcessingState::PROCESSED);
+}
+
+void PlotContainer::set_default_processor(const std::shared_ptr<DataProcessor>& processor)
+{
+    if (m_processor)
+        m_processor->on_detach(shared_from_this());
+    m_processor = processor;
+    if (m_processor)
+        m_processor->on_attach(shared_from_this());
+}
+
+std::shared_ptr<DataProcessor> PlotContainer::get_default_processor() const
+{
+    return m_processor;
+}
+
+} // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Source/PlotContainer.hpp
+++ b/src/MayaFlux/Kakshya/Source/PlotContainer.hpp
@@ -1,0 +1,311 @@
+#pragma once
+
+#include "MayaFlux/Kakshya/SignalSourceContainer.hpp"
+
+namespace MayaFlux::Nodes {
+class Node;
+namespace Network {
+    class NodeNetwork;
+}
+}
+
+namespace MayaFlux::Buffers {
+class AudioBuffer;
+}
+
+namespace MayaFlux::Kakshya {
+
+class PlotProcessor;
+
+/**
+ * @class PlotContainer
+ * @brief SignalSourceContainer holding N named scalar series for plotting and signal use.
+ *
+ * Each series is a named std::vector<double> stored as a DataVariant in m_data,
+ * with a corresponding DataDimension (Role::CUSTOM, size = sample count, name = series name).
+ * processed_data mirrors m_data after PlotProcessor::process() — one DataVariant per series,
+ * index-stable, suitable for direct consumption by Forma geometry functions.
+ *
+ * Series are append-only by index. Resize via resize_series() when the sample count changes.
+ * Region semantics apply per-series: a Region with start/end coordinates on the TIME-equivalent
+ * axis (dim 0) selects a sample range within that series. get_region_data() returns the
+ * selected slice as vector<double>, enabling wavetable read-back and drag-to-select interaction.
+ *
+ * Dimension tracking, frame/stream navigation, and processing-token machinery inherited from
+ * SignalSourceContainer are no-op stubs here, grown into as needed.
+ */
+class MAYAFLUX_API PlotContainer : public SignalSourceContainer {
+public:
+    /**
+     * @brief Construct an empty container. Series are added via add_series().
+     */
+    PlotContainer();
+
+    ~PlotContainer() override = default;
+
+    PlotContainer(const PlotContainer&) = delete;
+    PlotContainer& operator=(const PlotContainer&) = delete;
+    PlotContainer(PlotContainer&&) = delete;
+    PlotContainer& operator=(PlotContainer&&) = delete;
+
+    // =========================================================================
+    // Series management
+    // =========================================================================
+
+    /**
+     * @brief Add a named series with a given capacity, zero-initialised.
+     * @param name   Series name. Used as the DataDimension name and for lookup.
+     * @param count  Number of samples. Sets the DataDimension size.
+     * @return Index of the newly added series.
+     */
+    uint32_t add_series(std::string name, uint64_t count);
+
+    // =========================================================================
+    // Source binding — delegates to PlotProcessor, creating it if absent.
+    //
+    // Each bind_* call associates a data source with a series slot. The
+    // processor acquires from that source on every process() call and writes
+    // into m_data. Binding a slot that already has a source replaces it.
+    // =========================================================================
+
+    /**
+     * @brief Bind a series to a Node.
+     *
+     * Each process() fills the series by calling
+     * Buffers::extract_multiple_samples(node, series_size), which handles
+     * snapshot context and node lifecycle identically to NodeSourceProcessor.
+     *
+     * @param series_index  Index returned by add_series().
+     * @param node          Node to read from.
+     */
+    void bind_node(uint32_t series_index, std::shared_ptr<Nodes::Node> node);
+
+    /**
+     * @brief Bind a series to an AudioBuffer.
+     *
+     * Each process() copies get_data() span into the series.
+     * Series size is not automatically resized; allocate via add_series()
+     * to match the expected buffer frame count.
+     *
+     * @param series_index  Index returned by add_series().
+     * @param buffer        AudioBuffer to read from.
+     */
+    void bind_audio_buffer(uint32_t series_index,
+        std::shared_ptr<Buffers::AudioBuffer> buffer);
+
+    /**
+     * @brief Bind a series to a NodeNetwork with audio output.
+     *
+     * Each process() reads get_audio_buffer() from the network.
+     * Fails at bind time if the network has no audio output mode.
+     *
+     * @param series_index  Index returned by add_series().
+     * @param network       NodeNetwork to read from.
+     */
+    void bind_network(uint32_t series_index,
+        std::shared_ptr<Nodes::Network::NodeNetwork> network);
+
+    /**
+     * @brief Bind a series to a callable.
+     *
+     * Each process() calls fn(series_vector) by reference. The callable
+     * fills or mutates it freely. Use for computed series, ring buffer
+     * views, or any source that does not fit the other patterns.
+     *
+     * @param series_index  Index returned by add_series().
+     * @param fn            Callable invoked with the series vector each process().
+     */
+    void bind_callable(uint32_t series_index,
+        std::function<void(std::vector<double>&)> fn);
+
+    /**
+     * @brief Push raw sample data into a series.
+     *
+     * Lock-free pending swap committed on the next process() call.
+     * May be called from any thread.
+     *
+     * @param series_index  Index returned by add_series().
+     * @param data          Samples to write. Size should match series capacity.
+     */
+    void set_raw(uint32_t series_index, std::vector<double> data);
+
+    /**
+     * @brief Remove the source binding for a series.
+     * @param series_index Series to unbind.
+     */
+    void unbind(uint32_t series_index);
+
+    /**
+     * @brief Write the full sample buffer for a series.
+     * @param index   Series index from add_series().
+     * @param samples Source data. Must match the series sample count.
+     */
+    void write_series(uint32_t index, std::span<const double> samples);
+
+    /**
+     * @brief Write a single sample within a series.
+     * @param index        Series index.
+     * @param sample_index Sample position within the series.
+     * @param value        Value to write.
+     */
+    void write_sample(uint32_t index, uint64_t sample_index, double value);
+
+    /**
+     * @brief Resize a series. Truncates or zero-extends. Updates the DataDimension.
+     * @param index Series index.
+     * @param count New sample count.
+     */
+    void resize_series(uint32_t index, uint64_t count);
+
+    /**
+     * @brief Return the number of series.
+     */
+    [[nodiscard]] uint32_t series_count() const;
+
+    /**
+     * @brief Return the name of a series.
+     */
+    [[nodiscard]] const std::string& series_name(uint32_t index) const;
+
+    /**
+     * @brief Return the sample count of a series.
+     */
+    [[nodiscard]] uint64_t series_size(uint32_t index) const;
+
+    // =========================================================================
+    // NDDataContainer
+    // =========================================================================
+
+    [[nodiscard]] std::vector<DataDimension> get_dimensions() const override;
+    [[nodiscard]] uint64_t get_total_elements() const override;
+    [[nodiscard]] MemoryLayout get_memory_layout() const override { return MemoryLayout::ROW_MAJOR; }
+    void set_memory_layout(MemoryLayout) override { }
+
+    [[nodiscard]] uint64_t get_frame_size() const override { return 1; }
+    [[nodiscard]] uint64_t get_num_frames() const override;
+
+    /**
+     * @brief Extract a sample range from a single series.
+     *
+     * region.start_coordinates[0] = series index.
+     * region.start_coordinates[1] = first sample (inclusive).
+     * region.end_coordinates[1]   = last sample (inclusive).
+     *
+     * Returns a single DataVariant containing vector<double> of the slice.
+     * Returns empty if coordinates are out of range.
+     */
+    [[nodiscard]] std::vector<DataVariant> get_region_data(const Region& region) const override;
+
+    /**
+     * @brief Write a sample range back into a series.
+     *
+     * Same coordinate convention as get_region_data(). The first DataVariant
+     * in data must hold vector<double>. Used by Context drag handlers for
+     * wavetable editing and interactive signal manipulation.
+     */
+    void set_region_data(const Region& region, const std::vector<DataVariant>& data) override;
+
+    [[nodiscard]] std::vector<DataVariant> get_region_group_data(const RegionGroup& group) const override;
+    [[nodiscard]] std::vector<DataVariant> get_segments_data(const std::vector<RegionSegment>& segments) const override;
+
+    [[nodiscard]] std::span<const double> get_frame(uint64_t frame_index) const override;
+    void get_frames(std::span<double> output, uint64_t start_frame, uint64_t num_frames) const override;
+
+    [[nodiscard]] double get_value_at(const std::vector<uint64_t>& coordinates) const override;
+    void set_value_at(const std::vector<uint64_t>& coordinates, double value) override;
+
+    [[nodiscard]] uint64_t coordinates_to_linear_index(const std::vector<uint64_t>& coordinates) const override;
+    [[nodiscard]] std::vector<uint64_t> linear_index_to_coordinates(uint64_t linear_index) const override;
+
+    void clear() override;
+    void lock() override { }
+    void unlock() override { }
+    bool try_lock() override { return true; }
+
+    [[nodiscard]] const void* get_raw_data() const override;
+    [[nodiscard]] bool has_data() const override;
+
+    [[nodiscard]] ContainerDataStructure& get_structure() override { return m_structure; }
+    [[nodiscard]] const ContainerDataStructure& get_structure() const override { return m_structure; }
+    void set_structure(ContainerDataStructure s) override { m_structure = std::move(s); }
+
+    void add_region_group(const RegionGroup& group) override;
+    [[nodiscard]] const RegionGroup& get_region_group(const std::string& name) const override;
+    [[nodiscard]] std::unordered_map<std::string, RegionGroup> get_all_region_groups() const override;
+    void remove_region_group(const std::string& name) override;
+
+    [[nodiscard]] bool is_region_loaded(const Region&) const override { return true; }
+    void load_region(const Region&) override { }
+    void unload_region(const Region&) override { }
+
+    [[nodiscard]] DataAccess channel_data(size_t index) override;
+    [[nodiscard]] std::vector<DataAccess> all_channel_data() override;
+
+    // =========================================================================
+    // SignalSourceContainer
+    // =========================================================================
+
+    [[nodiscard]] ProcessingState get_processing_state() const override;
+    void update_processing_state(ProcessingState state) override;
+
+    void register_state_change_callback(
+        std::function<void(const std::shared_ptr<SignalSourceContainer>&, ProcessingState)> cb) override;
+    void unregister_state_change_callback() override;
+
+    [[nodiscard]] bool is_ready_for_processing() const override;
+    void mark_ready_for_processing(bool ready) override;
+
+    void create_default_processor() override;
+    void process_default() override;
+
+    void set_default_processor(const std::shared_ptr<DataProcessor>& processor) override;
+    [[nodiscard]] std::shared_ptr<DataProcessor> get_default_processor() const override;
+
+    [[nodiscard]] std::shared_ptr<DataProcessingChain> get_processing_chain() override { return m_chain; }
+    void set_processing_chain(const std::shared_ptr<DataProcessingChain>& chain) override { m_chain = chain; }
+
+    [[nodiscard]] std::vector<DataVariant>& get_processed_data() override { return m_processed_data; }
+    [[nodiscard]] const std::vector<DataVariant>& get_processed_data() const override { return m_processed_data; }
+    [[nodiscard]] const std::vector<DataVariant>& get_data() override { return m_data; }
+
+    void mark_buffers_for_processing(bool) override { }
+    void mark_buffers_for_removal() override { }
+
+    // ---- dimension reader stubs (no concurrent consumer tracking needed yet) ----
+    uint32_t register_dimension_reader(uint32_t) override { return 0; }
+    void unregister_dimension_reader(uint32_t) override { }
+    [[nodiscard]] bool has_active_readers() const override { return false; }
+    void mark_dimension_consumed(uint32_t, uint32_t) override { }
+    [[nodiscard]] bool all_dimensions_consumed() const override { return true; }
+
+private:
+    void rebuild_dimensions();
+
+    /**
+     * @brief Return the PlotProcessor, creating and attaching it if absent.
+     *
+     * Called by all bind_* methods. Guarantees the processor exists before
+     * delegating the bind call, without requiring the caller to manage it.
+     */
+    PlotProcessor& ensure_processor();
+
+    std::vector<std::string> m_names;
+    std::vector<DataVariant> m_data;
+    std::vector<DataVariant> m_processed_data;
+    std::vector<DataDimension> m_dimensions;
+
+    ContainerDataStructure m_structure;
+    std::shared_ptr<DataProcessor> m_processor;
+    std::shared_ptr<DataProcessingChain> m_chain;
+
+    std::unordered_map<std::string, RegionGroup> m_region_groups;
+
+    std::atomic<ProcessingState> m_processing_state { ProcessingState::IDLE };
+    std::atomic<bool> m_ready_for_processing { false };
+
+    std::function<void(const std::shared_ptr<SignalSourceContainer>&, ProcessingState)> m_state_cb;
+
+    mutable std::vector<double> m_frame_cache;
+};
+
+} // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Source/PlotContainer.hpp
+++ b/src/MayaFlux/Kakshya/Source/PlotContainer.hpp
@@ -54,11 +54,23 @@ public:
 
     /**
      * @brief Add a named series with a given capacity, zero-initialised.
-     * @param name   Series name. Used as the DataDimension name and for lookup.
-     * @param count  Number of samples. Sets the DataDimension size.
+     *
+     * @param name     Series name. Used as the DataDimension name and for lookup.
+     * @param count    Number of samples. Sets the DataDimension size.
+     * @param role     Semantic role of this series. Used by DomainMapping to
+     *                 locate series by axis intent rather than by index.
+     *                 e.g. SPATIAL_X, SPATIAL_Y, SPATIAL_Z, TIME, FREQUENCY,
+     *                 COLOR, CHANNEL, CUSTOM.
+     * @param modality Data modality of this series. Describes the nature of the
+     *                 scalar sequence: AUDIO_1D for time-domain waveforms,
+     *                 SPECTRAL_2D for frequency bins, SCALAR_F32 for generic
+     *                 scalar data, TENSOR_ND when no closer modality applies.
      * @return Index of the newly added series.
      */
-    uint32_t add_series(std::string name, uint64_t count);
+    uint32_t add_series(std::string name,
+        uint64_t count,
+        DataDimension::Role role = DataDimension::Role::CUSTOM,
+        DataModality modality = DataModality::TENSOR_ND);
 
     // =========================================================================
     // Source binding — delegates to PlotProcessor, creating it if absent.
@@ -172,6 +184,11 @@ public:
      */
     [[nodiscard]] uint64_t series_size(uint32_t index) const;
 
+    /**
+     * @brief Return the role of a series.
+     */
+    [[nodiscard]] DataDimension::Role series_role(uint32_t index) const;
+
     // =========================================================================
     // NDDataContainer
     // =========================================================================
@@ -279,8 +296,6 @@ public:
     [[nodiscard]] bool all_dimensions_consumed() const override { return true; }
 
 private:
-    void rebuild_dimensions();
-
     /**
      * @brief Return the PlotProcessor, creating and attaching it if absent.
      *
@@ -289,10 +304,8 @@ private:
      */
     PlotProcessor& ensure_processor();
 
-    std::vector<std::string> m_names;
     std::vector<DataVariant> m_data;
     std::vector<DataVariant> m_processed_data;
-    std::vector<DataDimension> m_dimensions;
 
     ContainerDataStructure m_structure;
     std::shared_ptr<DataProcessor> m_processor;

--- a/src/MayaFlux/Portal/Forma/Bridge.hpp
+++ b/src/MayaFlux/Portal/Forma/Bridge.hpp
@@ -260,17 +260,27 @@ public:
         std::shared_ptr<Buffers::FormaBuffer> buffer,
         std::function<float(T)> project = {})
     {
-        std::function<float()> reader = project
-            ? std::function<float()>([s = state, p = std::move(project)] {
-                  return p(s->value);
-              })
-            : std::function<float()>([s = state] {
-                  return static_cast<float>(s->value);
-              });
+        std::function<float()> reader;
+        if (project) {
+            reader = [s = state, p = std::move(project)] {
+                return p(s->value);
+            };
+        } else if constexpr (std::is_convertible_v<T, float>) {
+            reader = [s = state] {
+                return static_cast<float>(s->value);
+            };
+        } else {
+            reader = [] { return 0.F; };
+        }
 
-        std::function<void(float)> writer = [s = state](float v) {
-            s->write(static_cast<T>(v));
-        };
+        std::function<void(float)> writer;
+        if constexpr (std::is_convertible_v<float, T>) {
+            writer = [s = state](float v) {
+                s->write(static_cast<T>(v));
+            };
+        } else {
+            writer = [](float) { };
+        }
 
         state->id = id;
         m_records[id] = ElementRecord {

--- a/src/MayaFlux/Portal/Forma/Forma.hpp
+++ b/src/MayaFlux/Portal/Forma/Forma.hpp
@@ -149,6 +149,7 @@ MAYAFLUX_API bool is_initialized();
  * @param initial    Starting value written into MappedState.
  * @param capacity   Initial FormaBuffer capacity in bytes.
  * @param topology   Primitive topology for the FormaBuffer.
+ * @param project    Optional T -> float projection for outbound readers.
  * @return Fully constructed Mapped<T> with element registered in @p layer.
  */
 template <typename T>
@@ -158,12 +159,13 @@ template <typename T>
     GeometryFn<T> geom,
     T initial,
     size_t capacity = 4096,
-    Graphics::PrimitiveTopology topology = Graphics::PrimitiveTopology::TRIANGLE_STRIP)
+    Graphics::PrimitiveTopology topology = Graphics::PrimitiveTopology::TRIANGLE_STRIP,
+    std::function<float(T)> project = {})
 {
     auto buf = create_buffer(std::move(window), capacity, topology);
     auto mapped = make_mapped<T>(initial, std::move(geom), buf);
     mapped.element.id = layer.add(mapped.element);
-    get_bridge().register_element(mapped);
+    get_bridge().register_element(mapped, std::move(project));
     return mapped;
 }
 

--- a/src/MayaFlux/Portal/Forma/Plot/Plot.cpp
+++ b/src/MayaFlux/Portal/Forma/Plot/Plot.cpp
@@ -2,6 +2,7 @@
 
 #include "MayaFlux/Core/Backends/Graphics/Vulkan/VKImage.hpp"
 #include "MayaFlux/Nodes/Graphics/VertexSpec.hpp"
+#include "MayaFlux/Kakshya/Region/RegionGroup.hpp"
 
 namespace MayaFlux::Portal::Forma::Plot {
 

--- a/src/MayaFlux/Portal/Forma/Plot/Plot.cpp
+++ b/src/MayaFlux/Portal/Forma/Plot/Plot.cpp
@@ -1,0 +1,395 @@
+#include "Plot.hpp"
+
+#include "MayaFlux/Core/Backends/Graphics/Vulkan/VKImage.hpp"
+#include "MayaFlux/Nodes/Graphics/VertexSpec.hpp"
+
+namespace MayaFlux::Portal::Forma::Plot {
+
+using Role = Kakshya::DataDimension::Role;
+using Nodes::LineVertex;
+using Nodes::MeshVertex;
+using Nodes::PointVertex;
+using Nodes::TextureQuadVertex;
+
+// =============================================================================
+// series_by_role
+// =============================================================================
+
+std::vector<std::span<const double>> series_by_role(
+    const Kakshya::PlotContainer& container,
+    Role role)
+{
+    const auto& dims = container.get_structure().dimensions;
+    const auto& data = container.get_processed_data();
+
+    std::vector<std::span<const double>> result;
+    for (size_t i = 0; i < dims.size() && i < data.size(); ++i) {
+        if (dims[i].role != role)
+            continue;
+        const auto* vec = std::get_if<std::vector<double>>(&data[i]);
+        if (!vec || vec->empty())
+            continue;
+        result.emplace_back(vec->data(), vec->size());
+    }
+    return result;
+}
+
+// =============================================================================
+// data_range / apply_auto_scale
+// =============================================================================
+
+std::pair<float, float> data_range(std::span<const double> series)
+{
+    if (series.empty())
+        return { 0.F, 1.F };
+
+    double lo = std::numeric_limits<double>::max();
+    double hi = std::numeric_limits<double>::lowest();
+    for (double v : series) {
+        if (v < lo)
+            lo = v;
+        if (v > hi)
+            hi = v;
+    }
+    if (lo == hi)
+        hi = lo + 1.0;
+    return { static_cast<float>(lo), static_cast<float>(hi) };
+}
+
+void apply_auto_scale(AxisRange& range,
+    const std::vector<std::span<const double>>& series)
+{
+    if (!range.auto_scale || series.empty())
+        return;
+
+    float lo = std::numeric_limits<float>::max();
+    float hi = std::numeric_limits<float>::lowest();
+    for (const auto& s : series) {
+        auto [slo, shi] = data_range(s);
+        lo = std::min(lo, slo);
+        hi = std::max(hi, shi);
+    }
+    range.min = lo;
+    range.max = hi;
+}
+
+// =============================================================================
+// palette_color
+// =============================================================================
+
+glm::vec3 palette_color(const std::vector<glm::vec3>& palette,
+    size_t index) noexcept
+{
+    if (palette.empty())
+        return glm::vec3(1.F);
+    return palette[index % palette.size()];
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+namespace {
+
+    template <typename V>
+    void push_vertex(std::vector<uint8_t>& out, const V& v)
+    {
+        const auto* src = reinterpret_cast<const uint8_t*>(&v);
+        out.insert(out.end(), src, src + sizeof(V));
+    }
+
+    std::vector<float> uniform_x(size_t n, const AxisRange& x_range)
+    {
+        std::vector<float> xs(n);
+        if (n == 1) {
+            xs[0] = x_range.to_ndc((x_range.min + x_range.max) * 0.5F);
+            return xs;
+        }
+        for (size_t i = 0; i < n; ++i) {
+            const float t = static_cast<float>(i) / static_cast<float>(n - 1);
+            const float v = x_range.min + t * (x_range.max - x_range.min);
+            xs[i] = x_range.to_ndc(v);
+        }
+        return xs;
+    }
+
+} // namespace
+
+// =============================================================================
+// waveform
+// =============================================================================
+
+GeometryFn<std::shared_ptr<Kakshya::PlotContainer>> waveform(
+    AxisRange x_range,
+    AxisRange y_range,
+    AxisRange z_range,
+    const std::vector<glm::vec3>& palette,
+    float thickness)
+{
+    return [x_range, y_range, z_range, palette, thickness](
+               const std::shared_ptr<Kakshya::PlotContainer>& container,
+               std::vector<uint8_t>& out,
+               Element&) mutable {
+        if (!container)
+            return;
+
+        container->process_default();
+
+        auto y_series = series_by_role(*container, Role::SPATIAL_Y);
+        if (y_series.empty())
+            y_series = series_by_role(*container, Role::TIME);
+        if (y_series.empty())
+            return;
+
+        const auto x_series = series_by_role(*container, Role::SPATIAL_X);
+        const auto z_series = series_by_role(*container, Role::SPATIAL_Z);
+
+        apply_auto_scale(x_range, x_series.empty() ? y_series : x_series);
+        apply_auto_scale(y_range, y_series);
+        apply_auto_scale(z_range, z_series);
+
+        out.clear();
+
+        for (size_t si = 0; si < y_series.size(); ++si) {
+            const auto& ys = y_series[si];
+            const size_t n = ys.size();
+            if (n == 0)
+                continue;
+
+            const glm::vec3 color = palette_color(palette, si);
+
+            const bool has_x = si < x_series.size() && x_series[si].size() == n;
+            const bool has_z = si < z_series.size() && z_series[si].size() == n;
+
+            std::vector<float> xs;
+            if (has_x) {
+                xs.reserve(n);
+                for (double v : x_series[si])
+                    xs.push_back(x_range.to_ndc(static_cast<float>(v)));
+            } else {
+                xs = uniform_x(n, x_range);
+            }
+
+            for (size_t i = 0; i < n; ++i) {
+                LineVertex v;
+                v.position = glm::vec3(
+                    xs[i],
+                    y_range.to_ndc(static_cast<float>(ys[i])),
+                    has_z ? z_range.to_ndc(static_cast<float>(z_series[si][i])) : 0.F);
+                v.color = color;
+                v.thickness = thickness;
+                push_vertex(out, v);
+            }
+
+            // Degenerate separator between runs: repeat last vertex twice
+            // with zero thickness so the LINE_STRIP draws no segment between runs.
+            if (si + 1 < y_series.size()) {
+                const float last_z = has_z
+                    ? z_range.to_ndc(static_cast<float>(z_series[si][n - 1]))
+                    : 0.F;
+                LineVertex sep;
+                sep.position = glm::vec3(
+                    xs[n - 1],
+                    y_range.to_ndc(static_cast<float>(ys[n - 1])),
+                    last_z);
+                sep.color = color;
+                sep.thickness = 0.F;
+                push_vertex(out, sep);
+                push_vertex(out, sep);
+            }
+        }
+    };
+}
+
+// =============================================================================
+// scatter
+// =============================================================================
+
+GeometryFn<std::shared_ptr<Kakshya::PlotContainer>> scatter(
+    AxisRange x_range,
+    AxisRange y_range,
+    AxisRange z_range,
+    const std::vector<glm::vec3>& palette,
+    float point_size)
+{
+    return [x_range, y_range, z_range, palette, point_size](
+               const std::shared_ptr<Kakshya::PlotContainer>& container,
+               std::vector<uint8_t>& out,
+               Element&) mutable {
+        if (!container)
+            return;
+
+        container->process_default();
+
+        const auto x_series = series_by_role(*container, Role::SPATIAL_X);
+        auto y_series = series_by_role(*container, Role::SPATIAL_Y);
+        const auto z_series = series_by_role(*container, Role::SPATIAL_Z);
+        const auto c_series = series_by_role(*container, Role::COLOR);
+
+        if (y_series.empty())
+            return;
+
+        apply_auto_scale(x_range, x_series);
+        apply_auto_scale(y_range, y_series);
+        apply_auto_scale(z_range, z_series);
+
+        out.clear();
+
+        for (size_t si = 0; si < y_series.size(); ++si) {
+            const auto& ys = y_series[si];
+            const size_t n = ys.size();
+            if (n == 0)
+                continue;
+
+            const glm::vec3 base_color = palette_color(palette, si);
+
+            // Reuse last X series if fewer X series than Y series.
+            const bool has_x = !x_series.empty();
+            const auto& xs = has_x
+                ? x_series[std::min(si, x_series.size() - 1)]
+                : std::span<const double> {};
+
+            const bool has_z = si < z_series.size() && z_series[si].size() == n;
+            const bool has_c = si < c_series.size() && c_series[si].size() == n;
+
+            for (size_t i = 0; i < n; ++i) {
+                PointVertex v;
+
+                v.position.x = has_x
+                    ? x_range.to_ndc(static_cast<float>(xs[std::min(i, xs.size() - 1)]))
+                    : x_range.to_ndc(x_range.min
+                          + static_cast<float>(i)
+                              / static_cast<float>(std::max<size_t>(n - 1, 1))
+                              * (x_range.max - x_range.min));
+
+                v.position.y = y_range.to_ndc(static_cast<float>(ys[i]));
+
+                v.position.z = has_z
+                    ? z_range.to_ndc(static_cast<float>(z_series[si][i]))
+                    : 0.F;
+
+                if (has_c) {
+                    const float t = y_range.normalise(
+                        static_cast<float>(c_series[si][i]));
+                    v.color = glm::mix(glm::vec3(1.F), base_color, t);
+                } else {
+                    v.color = base_color;
+                }
+
+                v.size = point_size;
+                push_vertex(out, v);
+            }
+        }
+    };
+}
+
+// =============================================================================
+// bars
+// =============================================================================
+
+GeometryFn<std::shared_ptr<Kakshya::PlotContainer>> bars(
+    AxisRange x_range,
+    AxisRange y_range,
+    const std::vector<glm::vec3>& palette)
+{
+    return [x_range, y_range, palette](
+               const std::shared_ptr<Kakshya::PlotContainer>& container,
+               std::vector<uint8_t>& out,
+               Element&) mutable {
+        if (!container)
+            return;
+
+        container->process_default();
+
+        auto f_series = series_by_role(*container, Role::FREQUENCY);
+        if (f_series.empty())
+            f_series = series_by_role(*container, Role::SPATIAL_Y);
+        if (f_series.empty())
+            return;
+
+        apply_auto_scale(y_range, f_series);
+
+        out.clear();
+
+        for (size_t si = 0; si < f_series.size(); ++si) {
+            const auto& series = f_series[si];
+            const size_t n = series.size();
+            if (n == 0)
+                continue;
+
+            const glm::vec3 color = palette_color(palette, si);
+
+            const float bar_w = (x_range.max - x_range.min)
+                / static_cast<float>(n);
+            const float y_base = y_range.to_ndc(0.F);
+
+            for (size_t i = 0; i < n; ++i) {
+                const float x_left = x_range.to_ndc(
+                    x_range.min + static_cast<float>(i) * bar_w);
+                const float x_right = x_range.to_ndc(
+                    x_range.min + static_cast<float>(i + 1) * bar_w);
+                const float y_top = y_range.to_ndc(
+                    static_cast<float>(series[i]));
+
+                const auto emit = [&](float x, float y) {
+                    MeshVertex v;
+                    v.position = glm::vec3(x, y, 0.F);
+                    v.color = color;
+                    push_vertex(out, v);
+                };
+
+                // Two triangles per bar (TRIANGLE_LIST).
+                emit(x_left, y_base);
+                emit(x_right, y_base);
+                emit(x_left, y_top);
+                emit(x_right, y_base);
+                emit(x_right, y_top);
+                emit(x_left, y_top);
+            }
+        }
+    };
+}
+
+// =============================================================================
+// background
+// =============================================================================
+
+GeometryFn<float> background(
+    Kinesis::AABB2D bounds,
+    glm::vec3 color,
+    const std::shared_ptr<Core::VKImage>& texture)
+{
+    return [bounds, color, texture](
+               float,
+               std::vector<uint8_t>& out,
+               Element& el) {
+        out.clear();
+
+        if (texture) {
+            // Textured quad — four TextureQuadVertex as TRIANGLE_STRIP.
+            // UV origin bottom-left matching Vulkan image layout.
+            const std::array<TextureQuadVertex, 4> verts = { {
+                { .position = { bounds.min.x, bounds.min.y, 0.F }, .texcoord = { 0.F, 1.F } },
+                { .position = { bounds.max.x, bounds.min.y, 0.F }, .texcoord = { 1.F, 1.F } },
+                { .position = { bounds.min.x, bounds.max.y, 0.F }, .texcoord = { 0.F, 0.F } },
+                { .position = { bounds.max.x, bounds.max.y, 0.F }, .texcoord = { 1.F, 0.F } },
+            } };
+            const auto* src = reinterpret_cast<const uint8_t*>(verts.data());
+            out.insert(out.end(), src, src + sizeof(verts));
+        } else {
+            // Solid color quad — four MeshVertex as TRIANGLE_STRIP.
+            const std::array<MeshVertex, 4> verts = { {
+                { .position = { bounds.min.x, bounds.min.y, 0.F }, .color = color },
+                { .position = { bounds.max.x, bounds.min.y, 0.F }, .color = color },
+                { .position = { bounds.min.x, bounds.max.y, 0.F }, .color = color },
+                { .position = { bounds.max.x, bounds.max.y, 0.F }, .color = color },
+            } };
+            const auto* src = reinterpret_cast<const uint8_t*>(verts.data());
+            out.insert(out.end(), src, src + sizeof(verts));
+        }
+
+        el.bounds_hint = bounds;
+    };
+}
+
+} // namespace MayaFlux::Portal::Forma::Plot

--- a/src/MayaFlux/Portal/Forma/Plot/Plot.hpp
+++ b/src/MayaFlux/Portal/Forma/Plot/Plot.hpp
@@ -1,0 +1,199 @@
+#pragma once
+
+#include "MayaFlux/Kakshya/Source/PlotContainer.hpp"
+#include "MayaFlux/Kinesis/Spatial/Bounds.hpp"
+#include "MayaFlux/Portal/Forma/Primitives/Mapped.hpp"
+
+namespace MayaFlux::Portal::Forma::Plot {
+
+// =============================================================================
+// AxisRange
+// =============================================================================
+
+/**
+ * @struct AxisRange
+ * @brief Scalar domain extent for one plot axis.
+ *
+ * Maps raw double values in [min, max] to the normalised render space
+ * expected by the geometry function. When auto_scale is true, min and max
+ * are recomputed from the series data on every process() call and the
+ * stored values are ignored until then.
+ */
+struct AxisRange {
+    float min { -1.F };
+    float max { 1.F };
+    bool auto_scale { false };
+
+    /** @brief Map a value into [0, 1] within this range. */
+    [[nodiscard]] float normalise(float v) const noexcept
+    {
+        if (max == min)
+            return 0.F;
+        return (v - min) / (max - min);
+    }
+
+    /** @brief Map a value into [-1, 1] NDC within this range. */
+    [[nodiscard]] float to_ndc(float v) const noexcept
+    {
+        return normalise(v) * 2.F - 1.F;
+    }
+};
+
+// =============================================================================
+// series_by_role
+// =============================================================================
+
+/**
+ * @brief Collect all series from processed_data whose DataDimension role
+ *        matches @p role.
+ *
+ * Returns spans pointing directly into the DataVariant storage — no copy.
+ * Returns an empty vector if no series carry the role or if any matching
+ * variant does not hold vector<double>.
+ *
+ * @param container  PlotContainer after process_default() has been called.
+ * @param role       DataDimension::Role to match.
+ */
+[[nodiscard]] std::vector<std::span<const double>> series_by_role(
+    const Kakshya::PlotContainer& container,
+    Kakshya::DataDimension::Role role);
+
+/**
+ * @brief Compute [min, max] over a scalar series.
+ *
+ * Returns {0, 1} for an empty span.
+ */
+[[nodiscard]] std::pair<float, float> data_range(std::span<const double> series);
+
+/**
+ * @brief Apply auto-scaling to an AxisRange from a set of series.
+ *
+ * Computes the union [min, max] over all provided series and updates
+ * @p range in place. No-op if series is empty or range.auto_scale is false.
+ */
+void apply_auto_scale(AxisRange& range,
+    const std::vector<std::span<const double>>& series);
+
+// =============================================================================
+// Palette
+// =============================================================================
+
+/**
+ * @brief Resolve a per-series color from a palette.
+ *
+ * Wraps @p palette cyclically: palette[index % palette.size()].
+ * Returns white if @p palette is empty.
+ *
+ * @param palette  Per-series base colors. Size 1 = uniform color.
+ * @param index    Series index.
+ */
+[[nodiscard]] glm::vec3 palette_color(const std::vector<glm::vec3>& palette,
+    size_t index) noexcept;
+
+// =============================================================================
+// Geometry function factories
+// =============================================================================
+
+/**
+ * @brief LINE_STRIP waveform for TIME or SPATIAL_Y series.
+ *
+ * Reads all SPATIAL_X series as explicit X sample positions. If none are
+ * present, generates uniform X positions across [x_range.min, x_range.max]
+ * for each Y series independently.
+ *
+ * SPATIAL_Z series map to the Z position of each vertex if present,
+ * enabling 3D ribbon / parametric curve display. If a SPATIAL_Z series
+ * count does not match the corresponding Y series, Z defaults to 0.
+ *
+ * Each Y series produces one LINE_STRIP run. Runs are separated by a
+ * degenerate vertex so they share one FormaBuffer.
+ *
+ * Per-series color is resolved from @p palette cyclically.
+ *
+ * Calls container->process_default() before reading processed_data.
+ *
+ * @param x_range   Domain for X. auto_scale recomputes from data each frame.
+ * @param y_range   Domain for Y.
+ * @param z_range   Domain for Z. Ignored if no SPATIAL_Z series present.
+ * @param palette   Per-series colors, cycled. {1,1,1} if empty.
+ * @param thickness Line thickness in pixels.
+ */
+[[nodiscard]] GeometryFn<std::shared_ptr<Kakshya::PlotContainer>> waveform(
+    AxisRange x_range = {},
+    AxisRange y_range = {},
+    AxisRange z_range = {},
+    const std::vector<glm::vec3>& palette = {},
+    float thickness = 1.5F);
+
+/**
+ * @brief POINT_LIST scatter plot for paired (X, Y[, Z]) series.
+ *
+ * Pairs the i-th SPATIAL_X series with the i-th SPATIAL_Y series. If there
+ * are more Y series than X series, the last X series is reused. Each pair
+ * produces one run of PointVertex in the output bytes.
+ *
+ * SPATIAL_Z series map to Z position, enabling a true 3D scatter cloud.
+ * A COLOR series modulates per-sample point color: samples are mapped
+ * through y_range.normalise() and blended between white and the series
+ * base color from @p palette.
+ *
+ * Per-series color is resolved from @p palette cyclically.
+ *
+ * @param x_range    Domain for X.
+ * @param y_range    Domain for Y.
+ * @param z_range    Domain for Z.
+ * @param palette    Per-series colors, cycled. {1,1,1} if empty.
+ * @param point_size Point size in pixels.
+ */
+[[nodiscard]] GeometryFn<std::shared_ptr<Kakshya::PlotContainer>> scatter(
+    AxisRange x_range = {},
+    AxisRange y_range = {},
+    AxisRange z_range = {},
+    const std::vector<glm::vec3>& palette = {},
+    float point_size = 4.F);
+
+/**
+ * @brief TRIANGLE_LIST bar chart for FREQUENCY or SPATIAL_Y series.
+ *
+ * Each FREQUENCY series produces one set of bars tiled uniformly across
+ * [x_range.min, x_range.max]. Bar height maps sample value through y_range.
+ *
+ * Multiple FREQUENCY series are currently rendered on top of each other
+ * in the same X range. Side-by-side or stacked layout is not yet
+ * implemented; no three-caller evidence exists for those layouts.
+ *
+ * Per-series color is resolved from @p palette cyclically.
+ *
+ * @param x_range  Domain for X (bar positions).
+ * @param y_range  Domain for Y (bar heights).
+ * @param palette  Per-series colors, cycled. {1,1,1} if empty.
+ */
+[[nodiscard]] GeometryFn<std::shared_ptr<Kakshya::PlotContainer>> bars(
+    AxisRange x_range = {},
+    AxisRange y_range = {},
+    const std::vector<glm::vec3>& palette = {});
+
+/**
+ * @brief TRIANGLE_STRIP background quad for a plot area.
+ *
+ * Produces a solid-color or textured full-screen quad covering @p bounds.
+ * Intended to be added to the same Layer as a plot element via Layer::relate,
+ * rendered before it.
+ *
+ * When @p texture is non-null the quad uses the textured vertex path and
+ * the caller must pass a matching FormaBuffer with a texture binding. When
+ * null the quad is filled with @p color.
+ *
+ * T is float (a dummy tick value — the background is static unless the
+ * caller drives it). Write any float to state->write() to refresh.
+ *
+ * @param bounds   Plot area in NDC.
+ * @param color    Fill color when no texture is provided.
+ * @param texture  Optional GPU image. nullptr = solid color.
+ */
+[[nodiscard]] GeometryFn<float> background(
+    Kinesis::AABB2D bounds,
+    glm::vec3 color = glm::vec3(1.F),
+    const std::shared_ptr<Core::VKImage>& texture = nullptr);
+
+} // namespace MayaFlux::Portal::Forma::Plot

--- a/src/MayaFlux/Vruta/Routine.cpp
+++ b/src/MayaFlux/Vruta/Routine.cpp
@@ -342,8 +342,6 @@ bool GraphicsRoutine::try_resume_with_context(uint64_t current_value, DelayConte
 
 bool GraphicsRoutine::try_resume(uint64_t current_context)
 {
-    // Default to FRAME_BASED context for backwards compatibility
-    // Note: You'll need to add FRAME_BASED to the DelayContext enum
     return try_resume_with_context(current_context, DelayContext::FRAME_BASED);
 }
 


### PR DESCRIPTION
Plotting in MayaFlux is not a UI operation. A plot is a geometry function applied to signal data. The rendered curve is the signal. The same data driving audio output, feeding a node network, or populating a wavetable routes directly into a plot element with no conversion layer, no special display type, and no separation between "data" and "display". Interaction with the rendered curve writes back into the same storage the audio thread reads from.

This is distinct from visualization tools that treat signals as read-only inputs to a display layer. Here the plot element and the signal share the same `DataVariant` storage. A dragged curve segment is a wavetable edit. A selected region is a `Region` extraction. The geometry function is the display path of a signal operation.

---

### What this adds

**`Kakshya::PlotContainer`** is a `SignalSourceContainer` holding N named scalar series as `vector<double>` DataVariants. Each series carries a `DataDimension::Role` encoding its semantic axis: `SPATIAL_X`, `SPATIAL_Y`, `SPATIAL_Z`, `FREQUENCY`, `TIME`, `COLOR`. All series metadata lives in `m_structure.dimensions`. No mutex: all write paths operate on the graphics/scheduler thread with no concurrent hardware producer.

**`Kakshya::PlotProcessor`** acquires data into series from any combination of sources using the same extraction machinery as `NodeSourceProcessor` and `DescriptorBindingsProcessor`. No new acquisition primitives were needed.

Source types per series:

- `NODE`: via `Buffers::extract_multiple_samples`, identical snapshot context handling to `NodeSourceProcessor`. Node lifecycle tracked via `add_buffer_reference` / `remove_buffer_reference`.
- `AUDIO_BUFFER`: copies `get_data()` span each `process()` call.
- `NETWORK`: reads `get_audio_buffer()`, validated for audio output mode at bind time.
- `CALLABLE`: `std::function<void(std::vector<double>&)>` called by reference each `process()`.
- `RAW`: lock-free `atomic_flag` pending swap via `set_raw()`, any-thread safe.

**`Portal::Forma::Plot`** provides geometry function factories that read `processed_data` by role and emit Vulkan vertices directly. All geometry functions call `container->process_default()` internally on each `sync()`.

- `waveform()`: LINE_STRIP per `SPATIAL_Y` or `TIME` series, with optional `SPATIAL_X` and `SPATIAL_Z` for explicit axis positions and 3D ribbon display. Multi-series runs separated by degenerate zero-thickness vertices.
- `scatter()`: POINT_LIST pairing `SPATIAL_X`/`Y`/`Z` series. Last X series reused when fewer X than Y series. `COLOR` series modulates per-sample color against the palette base.
- `bars()`: TRIANGLE_LIST (6 verts per bar) for `FREQUENCY` or `SPATIAL_Y` series.
- `background()`: static TRIANGLE_STRIP quad, solid `MeshVertex` or textured `TextureQuadVertex`, for use behind a plot element via `Layer::relate`.

`AxisRange` maps a scalar domain `[min, max]` to NDC with optional `auto_scale` that recomputes bounds from series data each frame. Per-series color is resolved cyclically from a `std::vector<glm::vec3>` palette.

`Bridge::register_element` gains `if constexpr` guards on the default reader/writer paths so non-scalar `MappedState<T>` types compile and register correctly without a projection function. `create_element` gains an optional `project` parameter forwarded to `register_element`.

---

### Usage

**Frequency-modulated sine as a live waveform:**

```cpp
auto mod  = vega.Random()  | Audio[0];
auto sine = vega.Sine(220) | Audio[0];
sine->set_frequency_modulator(mod);

auto container = std::make_shared<Kakshya::PlotContainer>();
const uint32_t y_idx = container->add_series("fm_sine", 512,
    DataDimension::Role::SPATIAL_Y, DataModality::AUDIO_1D);
container->bind_node(y_idx, sine);
container->mark_ready_for_processing(true);

auto el = Portal::Forma::create_element<std::shared_ptr<Kakshya::PlotContainer>>(
    *layer, window,
    Plot::waveform(
        AxisRange { -1.F, 1.F },
        AxisRange { -1.F, 1.F },
        AxisRange {},
        { glm::vec3(0.2F, 0.9F, 0.6F) },
        1.5F),
    container,
    514 * sizeof(Nodes::LineVertex),
    PrimitiveTopology::LINE_STRIP);

auto state = el.state;
schedule_metro(1.0 / 60.0, [container, state]() {
    container->process_default();
    state->write(container);
});
```

**Live mic input as a bar chart with background:**

```cpp
auto container = std::make_shared<Kakshya::PlotContainer>();
const uint32_t f_idx = container->add_series("spectrum", 64,
    DataDimension::Role::FREQUENCY, DataModality::SPECTRAL_2D);

auto buf = create_input_listener_buffer(0, false);
container->bind_audio_buffer(f_idx, buf);
container->mark_ready_for_processing(true);

constexpr Kinesis::AABB2D bounds { glm::vec2(-0.9F, -0.9F), glm::vec2(0.9F, 0.9F) };

auto bg = Portal::Forma::create_element<float>(
    *layer, window,
    Plot::background(bounds, glm::vec3(0.08F)),
    0.F, 4 * sizeof(Nodes::MeshVertex),
    PrimitiveTopology::TRIANGLE_STRIP);

auto bars_el = Portal::Forma::create_element<std::shared_ptr<Kakshya::PlotContainer>>(
    *layer, window,
    Plot::bars(
        AxisRange { -0.9F, 0.9F },
        AxisRange { 0.F, 1.F },
        { glm::vec3(0.2F, 0.9F, 0.5F) }),
    container,
    64 * 6 * sizeof(Nodes::MeshVertex),
    PrimitiveTopology::TRIANGLE_LIST);

layer->relate(bars_el.element.id, bg.element.id);
layer->send_to_back(bg.element.id);

auto state = bars_el.state;
schedule_metro(1.0 / 60.0, [container, state]() {
    container->process_default();
    state->write(container);
});
```

**Region read-back for wavetable editing (interaction path, not yet wired to Context):**

```cpp
Region r;
r.start_coordinates = { y_idx, 128 };
r.end_coordinates   = { y_idx, 255 };
auto slice = container->get_region_data(r); // vector<double>, no copy of full series

// After drag interaction writes back:
container->set_region_data(r, modified_slice);
```

---

### What this does not do

- No axis labels or tick marks yet. Those are a `TextBuffer` element composed alongside the plot element via `Layer::relate`, not built into the geometry functions.
- No built-in update scheduling. Update cadence is caller-controlled: a `schedule_metro`, an audio callback, a network completion signal, or any other Vruta context. This matches every other container in the project.
- `bars` multi-series overlap is noted but not resolved. Side-by-side layout deferred pending real usage.