### PR TITLE
Coroutine-native event sources and live audio output as addressable data

### DIFF
--- a/src/MayaFlux/Core/Backends/Windowing/Glfw/GlfwWindow.hpp
+++ b/src/MayaFlux/Core/Backends/Windowing/Glfw/GlfwWindow.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "MayaFlux/Core/Backends/Windowing/Window.hpp"
-#include "MayaFlux/Vruta/EventSource.hpp"
+#include "MayaFlux/Vruta/WindowEventSource.hpp"
 
 #include <GLFW/glfw3.h>
 
@@ -76,8 +76,8 @@ public:
 
     void set_color(const std::array<float, 4>& color) override;
 
-    Vruta::EventSource& get_event_source() override { return m_event_source; }
-    [[nodiscard]] const Vruta::EventSource& get_event_source() const override { return m_event_source; }
+    Vruta::WindowEventSource& get_event_source() override { return m_event_source; }
+    [[nodiscard]] const Vruta::WindowEventSource& get_event_source() const override { return m_event_source; }
 
     /**
      * @brief Check if window is registered with graphics subsystem
@@ -143,7 +143,7 @@ private:
 
     std::atomic<bool> m_graphics_registered { false };
 
-    Vruta::EventSource m_event_source;
+    Vruta::WindowEventSource m_event_source;
 
     std::vector<std::weak_ptr<Buffers::VKBuffer>> m_rendering_buffers;
     std::vector<uint64_t> m_frame_commands;

--- a/src/MayaFlux/Core/Backends/Windowing/Window.hpp
+++ b/src/MayaFlux/Core/Backends/Windowing/Window.hpp
@@ -3,7 +3,7 @@
 #include "MayaFlux/Core/GlobalGraphicsInfo.hpp"
 
 namespace MayaFlux::Vruta {
-class EventSource;
+class WindowEventSource;
 }
 
 namespace MayaFlux::Buffers {
@@ -112,8 +112,8 @@ public:
     /**
      * @brief Gets the event source for awaiting events
      */
-    [[nodiscard]] virtual Vruta::EventSource& get_event_source() = 0;
-    [[nodiscard]] virtual const Vruta::EventSource& get_event_source() const = 0;
+    [[nodiscard]] virtual Vruta::WindowEventSource& get_event_source() = 0;
+    [[nodiscard]] virtual const Vruta::WindowEventSource& get_event_source() const = 0;
 
     /**
      * @brief Check if window is registered with graphics subsystem

--- a/src/MayaFlux/Core/Subsystems/AudioSubsystem.cpp
+++ b/src/MayaFlux/Core/Subsystems/AudioSubsystem.cpp
@@ -1,5 +1,8 @@
 #include "AudioSubsystem.hpp"
 
+#include "MayaFlux/Registry/BackendRegistry.hpp"
+#include "MayaFlux/Registry/Service/AudioBackendService.hpp"
+
 #include "MayaFlux/Journal/Archivist.hpp"
 
 namespace MayaFlux::Core {
@@ -26,6 +29,14 @@ void AudioSubsystem::initialize(SubsystemProcessingHandle& handle)
         m_stream_info,
         this);
 
+    register_backend_service();
+    m_notify_running.store(true, std::memory_order_release);
+
+#ifdef MAYAFLUX_PLATFORM_MACOS
+    m_observers_ptr.store(new ObserverMap(), std::memory_order_release);
+#endif
+
+    m_notify_thread = std::thread(&AudioSubsystem::notify_loop, this);
     m_is_ready = true;
 }
 
@@ -143,6 +154,11 @@ int AudioSubsystem::process_output(double* output_buffer, unsigned int num_frame
         m_handle->nodes.cleanup_completed_routing();
         m_handle->buffers.cleanup_completed_routing();
 
+        m_snapshot_size.store(static_cast<uint32_t>(total_samples), std::memory_order_release);
+        m_snapshot_ptr.store(output_buffer, std::memory_order_release);
+        m_snapshot_generation.fetch_add(1, std::memory_order_release);
+        m_snapshot_generation.notify_all();
+
         m_callback_active.fetch_sub(1, std::memory_order_release);
         return has_underrun ? 1 : 0;
 
@@ -201,6 +217,149 @@ int AudioSubsystem::process_audio(double* input_buffer, double* output_buffer, u
     return 0;
 }
 
+void AudioSubsystem::register_backend_service()
+{
+    auto svc = std::make_shared<Registry::Service::AudioBackendService>();
+
+    svc->get_output_snapshot = [this]() -> std::span<const double> {
+        const double* ptr = m_snapshot_ptr.load(std::memory_order_acquire);
+        uint32_t sz = m_snapshot_size.load(std::memory_order_acquire);
+        if (!ptr || sz == 0)
+            return {};
+        return { ptr, sz };
+    };
+
+    svc->register_output_observer = [this](
+                                        std::function<void(const double*, uint32_t)> cb) -> uint32_t {
+        uint32_t id = m_next_observer_id.fetch_add(1, std::memory_order_relaxed);
+#ifdef MAYAFLUX_PLATFORM_MACOS
+        const ObserverMap* current = m_observers_ptr.load(std::memory_order_acquire);
+        const ObserverMap* next;
+        do {
+            auto* copy = new ObserverMap(*current);
+            (*copy)[id] = cb;
+            next = copy;
+        } while (!m_observers_ptr.compare_exchange_weak(
+            current, next,
+            std::memory_order_release, std::memory_order_acquire));
+        retire_observers(current);
+#else
+        auto current = m_observers.load(std::memory_order_acquire);
+        std::shared_ptr<ObserverMap> next;
+        do {
+            next = std::make_shared<ObserverMap>(*current);
+            (*next)[id] = cb;
+        } while (!m_observers.compare_exchange_weak(
+            current, next,
+            std::memory_order_release, std::memory_order_acquire));
+#endif
+        return id;
+    };
+
+    svc->unregister_output_observer = [this](uint32_t id) {
+#ifdef MAYAFLUX_PLATFORM_MACOS
+        const ObserverMap* current = m_observers_ptr.load(std::memory_order_acquire);
+        const ObserverMap* next;
+        do {
+            auto* copy = new ObserverMap(*current);
+            copy->erase(id);
+            next = copy;
+        } while (!m_observers_ptr.compare_exchange_weak(
+            current, next,
+            std::memory_order_release, std::memory_order_acquire));
+        retire_observers(current);
+#else
+        auto current = m_observers.load(std::memory_order_acquire);
+        std::shared_ptr<ObserverMap> next;
+        do {
+            next = std::make_shared<ObserverMap>(*current);
+            next->erase(id);
+        } while (!m_observers.compare_exchange_weak(
+            current, next,
+            std::memory_order_release, std::memory_order_acquire));
+#endif
+    };
+
+    m_audio_backend_service = svc;
+    Registry::BackendRegistry::instance()
+        .register_service<Registry::Service::AudioBackendService>(
+            [svc]() -> void* { return svc.get(); });
+}
+
+void AudioSubsystem::notify_loop()
+{
+    uint64_t last_gen = 0;
+
+    while (m_notify_running.load(std::memory_order_acquire)) {
+        m_snapshot_generation.wait(last_gen, std::memory_order_relaxed);
+
+        if (!m_notify_running.load(std::memory_order_acquire))
+            break;
+
+        last_gen = m_snapshot_generation.load(std::memory_order_acquire);
+
+        const double* ptr = m_snapshot_ptr.load(std::memory_order_acquire);
+        uint32_t sz = m_snapshot_size.load(std::memory_order_acquire);
+
+        if (!ptr || sz == 0)
+            continue;
+
+#ifdef MAYAFLUX_PLATFORM_MACOS
+        auto [obs, slot] = acquire_observers();
+        if (obs) {
+            for (auto& [id, cb] : *obs)
+                cb(ptr, sz);
+        }
+        release_observers(slot);
+#else
+        auto obs = m_observers.load(std::memory_order_acquire);
+        for (auto& [id, cb] : *obs)
+            cb(ptr, sz);
+#endif
+    }
+}
+
+#ifdef MAYAFLUX_PLATFORM_MACOS
+std::pair<const AudioSubsystem::ObserverMap*, size_t>
+AudioSubsystem::acquire_observers() const
+{
+    size_t slot = m_obs_hazard_counter.fetch_add(1, std::memory_order_relaxed)
+        % MAX_OBSERVER_READERS;
+    const ObserverMap* current;
+    do {
+        current = m_observers_ptr.load(std::memory_order_acquire);
+        m_obs_hazard_ptrs[slot].store(current, std::memory_order_release);
+    } while (current != m_observers_ptr.load(std::memory_order_acquire));
+    return { current, slot };
+}
+
+void AudioSubsystem::release_observers(size_t slot) const
+{
+    m_obs_hazard_ptrs[slot].store(nullptr, std::memory_order_release);
+}
+
+void AudioSubsystem::retire_observers(const ObserverMap* old)
+{
+    m_obs_retired.push_back(old);
+    auto it = m_obs_retired.begin();
+    while (it != m_obs_retired.end()) {
+        bool referenced = false;
+        for (size_t i = 0; i < MAX_OBSERVER_READERS; ++i) {
+            if (m_obs_hazard_ptrs[i].load(std::memory_order_acquire) == *it) {
+                referenced = true;
+                break;
+            }
+        }
+        if (!referenced) {
+            delete *it;
+            it = m_obs_retired.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+#endif
+
 void AudioSubsystem::start()
 {
     if (!m_is_ready || !m_audio_stream) {
@@ -232,9 +391,16 @@ void AudioSubsystem::stop()
     }
 
     if (m_callback_active.load() > 0) {
-        MF_INFO(Journal::Component::Core, Journal::Context::AudioSubsystem, "Stopped while {} callback(s) active",
-            m_callback_active.load());
+        MF_INFO(Journal::Component::Core, Journal::Context::AudioSubsystem,
+            "Stopped while {} callback(s) active", m_callback_active.load());
     }
+
+    m_notify_running.store(false, std::memory_order_release);
+    m_snapshot_generation.fetch_add(1, std::memory_order_release);
+    m_snapshot_generation.notify_all();
+
+    if (m_notify_thread.joinable())
+        m_notify_thread.join();
 
     MF_INFO(Journal::Component::Core, Journal::Context::AudioSubsystem,
         "AudioSubsystem stopped");
@@ -265,6 +431,7 @@ void AudioSubsystem::wait_until_running()
 void AudioSubsystem::shutdown()
 {
     stop();
+
     if (m_audio_stream) {
         m_audio_stream->close();
     }
@@ -272,6 +439,16 @@ void AudioSubsystem::shutdown()
     m_audio_device.reset();
     m_audiobackend->cleanup();
     m_audiobackend.reset();
+
+    Registry::BackendRegistry::instance()
+        .unregister_service<Registry::Service::AudioBackendService>();
+
+    m_audio_backend_service.reset();
+
+#ifdef MAYAFLUX_PLATFORM_MACOS
+    delete m_observers_ptr.exchange(nullptr, std::memory_order_acq_rel);
+#endif
+
     m_is_ready = false;
 }
 

--- a/src/MayaFlux/Core/Subsystems/AudioSubsystem.hpp
+++ b/src/MayaFlux/Core/Subsystems/AudioSubsystem.hpp
@@ -4,6 +4,10 @@
 
 #include "MayaFlux/Core/Backends/Audio/AudioBackend.hpp"
 
+namespace MayaFlux::Registry::Service {
+struct AudioBackendService;
+}
+
 namespace MayaFlux::Core {
 
 /**
@@ -115,11 +119,17 @@ public:
     SubsystemProcessingHandle* get_processing_context_handle() override { return m_handle; }
 
 private:
+    using ObserverMap = std::unordered_map<uint32_t, std::function<void(const double*, uint32_t)>>;
+    void register_backend_service();
+    void notify_loop();
+
     GlobalStreamInfo m_stream_info; ///< Audio stream configuration
 
     std::unique_ptr<IAudioBackend> m_audiobackend; ///< Audio backend implementation
     std::unique_ptr<AudioDevice> m_audio_device; ///< Audio device manager
     std::unique_ptr<AudioStream> m_audio_stream; ///< Audio stream manager
+
+    std::shared_ptr<Registry::Service::AudioBackendService> m_audio_backend_service;
 
     SubsystemTokens m_subsystem_tokens; ///< Processing token configuration
     SubsystemProcessingHandle* m_handle; ///< Reference to processing handle
@@ -129,6 +139,33 @@ private:
 
     std::atomic<bool> m_is_running { false }; ///< Subsystem running state
     std::atomic<int> m_callback_active { 0 }; ///< Active callback counter
+
+    std::atomic<uint32_t> m_next_observer_id { 1 };
+    std::atomic<bool> m_notify_running { false };
+
+    alignas(64) std::atomic<const double*> m_snapshot_ptr { nullptr };
+    std::atomic<uint64_t> m_snapshot_generation { 0 };
+    std::atomic<uint32_t> m_snapshot_size { 0 };
+
+    std::thread m_notify_thread;
+
+#ifdef MAYAFLUX_PLATFORM_MACOS
+    // Apple Clang lacks std::atomic<std::shared_ptr<T>> - raw pointer + hazard
+    std::atomic<const ObserverMap*> m_observers_ptr { nullptr };
+
+    static constexpr size_t MAX_OBSERVER_READERS = 8;
+    mutable std::array<std::atomic<const ObserverMap*>, MAX_OBSERVER_READERS> m_obs_hazard_ptrs {};
+    mutable std::atomic<size_t> m_obs_hazard_counter { 0 };
+
+    std::pair<const ObserverMap*, size_t> acquire_observers() const;
+    void release_observers(size_t slot) const;
+    void retire_observers(const ObserverMap* old);
+    std::vector<const ObserverMap*> m_obs_retired;
+#else
+    std::atomic<std::shared_ptr<ObserverMap>> m_observers {
+        std::make_shared<ObserverMap>()
+    };
+#endif
 
     static const SubsystemType m_type = SubsystemType::AUDIO;
 };

--- a/src/MayaFlux/Kakshya/Processors/AudioOutputAccessProcessor.cpp
+++ b/src/MayaFlux/Kakshya/Processors/AudioOutputAccessProcessor.cpp
@@ -1,0 +1,143 @@
+#include "AudioOutputAccessProcessor.hpp"
+
+#include "MayaFlux/Kakshya/Source/AudioOutputContainer.hpp"
+
+#include "MayaFlux/Registry/BackendRegistry.hpp"
+#include "MayaFlux/Registry/Service/AudioBackendService.hpp"
+
+#include "MayaFlux/Journal/Archivist.hpp"
+
+namespace MayaFlux::Kakshya {
+
+AudioOutputAccessProcessor::AudioOutputAccessProcessor(uint32_t buffer_size)
+    : m_buffer_size(buffer_size)
+    , m_backend_service(
+          Registry::BackendRegistry::instance()
+              .get_service<Registry::Service::AudioBackendService>())
+{
+    if (!m_backend_service) {
+        MF_WARN(Journal::Component::Kakshya, Journal::Context::Configuration,
+            "AudioOutputAccessProcessor: AudioBackendService not yet registered"
+            "process() calls will be no-ops until the service is available");
+    }
+}
+
+void AudioOutputAccessProcessor::on_attach(
+    const std::shared_ptr<SignalSourceContainer>& container)
+{
+    auto ac = std::dynamic_pointer_cast<AudioOutputContainer>(container);
+    if (!ac) {
+        error<std::invalid_argument>(
+            Journal::Component::Kakshya,
+            Journal::Context::ContainerProcessing,
+            std::source_location::current(),
+            "AudioOutputAccessProcessor requires an AudioOutputContainer");
+    }
+
+    m_channel_count = ac->get_structure().get_channel_count();
+    m_organization = ac->get_structure().organization;
+
+    ac->mark_ready_for_processing(true);
+
+    MF_INFO(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
+        "AudioOutputAccessProcessor attached: {} channels, {} frames/cycle, {}",
+        m_channel_count, m_buffer_size,
+        m_organization == OrganizationStrategy::PLANAR ? "planar" : "interleaved");
+}
+
+void AudioOutputAccessProcessor::on_detach(
+    const std::shared_ptr<SignalSourceContainer>& /*container*/)
+{
+    m_channel_count = 0;
+    m_buffer_size = 0;
+}
+
+void AudioOutputAccessProcessor::process(
+    const std::shared_ptr<SignalSourceContainer>& container)
+{
+    if (m_is_processing.exchange(true, std::memory_order_acq_rel))
+        return;
+
+    auto ac = std::dynamic_pointer_cast<AudioOutputContainer>(container);
+    if (!ac) {
+        MF_RT_ERROR(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
+            "AudioOutputAccessProcessor requires an AudioOutputContainer");
+        m_is_processing.store(false, std::memory_order_release);
+        return;
+    }
+
+    if (!m_backend_service) {
+        MF_RT_ERROR(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
+            "AudioBackendService unavailable");
+        m_is_processing.store(false, std::memory_order_release);
+        return;
+    }
+
+    const auto snap = m_backend_service->get_output_snapshot();
+    if (snap.empty()) {
+        MF_RT_WARN(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
+            "AudioOutputAccessProcessor: snapshot empty, no cycle completed yet");
+        m_is_processing.store(false, std::memory_order_release);
+        return;
+    }
+
+    ac->update_processing_state(ProcessingState::PROCESSING);
+
+    thread_local std::vector<std::vector<double>> tl_channels;
+
+    tl_channels.resize(m_channel_count);
+    for (auto& ch : tl_channels)
+        ch.resize(m_buffer_size);
+
+    if (m_organization == OrganizationStrategy::PLANAR) {
+        for (uint32_t ch = 0; ch < m_channel_count; ++ch) {
+            for (uint32_t f = 0; f < m_buffer_size; ++f) {
+                tl_channels[ch][f] = snap[f * m_channel_count + ch];
+            }
+        }
+    } else {
+        tl_channels[0].assign(snap.begin(), snap.end());
+    }
+
+    {
+
+        std::unique_lock lock(ac->m_data_mutex);
+        auto& pd = ac->get_processed_data();
+        if (m_organization == OrganizationStrategy::PLANAR) {
+            pd.resize(m_channel_count);
+            for (uint32_t ch = 0; ch < m_channel_count; ++ch)
+                pd[ch] = DataVariant(tl_channels[ch]);
+        } else {
+            pd.resize(1);
+            pd[0] = DataVariant(tl_channels[0]);
+        }
+    }
+
+    const uint64_t write_head = ac->get_num_frames();
+
+    {
+        std::unique_lock lock(ac->m_data_mutex);
+        if (m_organization == OrganizationStrategy::PLANAR) {
+            if (ac->m_data.size() < m_channel_count)
+                ac->m_data.resize(m_channel_count, DataVariant(std::vector<double> {}));
+            for (uint32_t ch = 0; ch < m_channel_count; ++ch) {
+                auto& vec = std::get<std::vector<double>>(ac->m_data[ch]);
+                vec.insert(vec.end(), tl_channels[ch].begin(), tl_channels[ch].end());
+            }
+        } else {
+            if (ac->m_data.empty())
+                ac->m_data.resize(1, DataVariant(std::vector<double> {}));
+            auto& vec = std::get<std::vector<double>>(ac->m_data[0]);
+            vec.insert(vec.end(), tl_channels[0].begin(), tl_channels[0].end());
+        }
+        ac->m_num_frames += m_buffer_size;
+        ac->setup_dimensions();
+        ac->invalidate_span_cache();
+        ac->m_double_extraction_dirty.store(true, std::memory_order_release);
+    }
+
+    ac->update_processing_state(ProcessingState::PROCESSED);
+    m_is_processing.store(false, std::memory_order_release);
+}
+
+} // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Processors/AudioOutputAccessProcessor.hpp
+++ b/src/MayaFlux/Kakshya/Processors/AudioOutputAccessProcessor.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "MayaFlux/Kakshya/DataProcessor.hpp"
+#include "MayaFlux/Kakshya/NDData/NDData.hpp"
+
+namespace MayaFlux::Registry::Service {
+struct AudioBackendService;
+}
+
+namespace MayaFlux::Kakshya {
+
+/**
+ * @class AudioOutputAccessProcessor
+ * @brief Default DataProcessor for AudioOutputContainer.
+ *
+ * Each process() call performs two writes:
+ *
+ *   1. m_processed_data — deinterleaved snapshot for the current cycle only.
+ *      PLANAR:      processed_data[ch] = vector<double>(buffer_size)
+ *      INTERLEAVED: processed_data[0]  = vector<double>(buffer_size * channels)
+ *
+ *   2. m_data (history) — the same deinterleaved per-channel data is appended
+ *      to the container's growing corpus via write_frames(). The write head
+ *      (get_num_frames()) advances by buffer_size each cycle, enabling
+ *      CursorAccessProcessor readers to chase it independently.
+ *
+ * The snapshot pointer from AudioBackendService::get_output_snapshot is
+ * engine-owned and valid only for the duration of process(). Both writes
+ * complete before process() returns.
+ *
+ * on_attach validates that the container is an AudioOutputContainer and
+ * caches channel count, buffer size, and organization strategy.
+ */
+class MAYAFLUX_API AudioOutputAccessProcessor : public DataProcessor {
+public:
+    /**
+     * @brief Construct with the fixed output block size.
+     * @param buffer_size Frames per cycle, must match GlobalStreamInfo::buffer_size.
+     */
+    explicit AudioOutputAccessProcessor(uint32_t buffer_size);
+
+    ~AudioOutputAccessProcessor() override = default;
+
+    /**
+     * @brief Validate container type, cache structure, mark ready for processing.
+     * @throws std::invalid_argument if container is not an AudioOutputContainer.
+     */
+    void on_attach(const std::shared_ptr<SignalSourceContainer>& container) override;
+
+    /**
+     * @brief Clear cached state.
+     */
+    void on_detach(const std::shared_ptr<SignalSourceContainer>& container) override;
+
+    /**
+     * @brief Pull engine snapshot, write m_processed_data, append to m_data.
+     *
+     * No-op if the backend service is unavailable or the snapshot is empty.
+     * Logs a trace-level message in those cases rather than erroring, since
+     * the first few calls during engine startup may arrive before any cycle
+     * has completed.
+     */
+    void process(const std::shared_ptr<SignalSourceContainer>& container) override;
+
+    [[nodiscard]] bool is_processing() const override { return m_is_processing.load(); }
+
+private:
+    uint32_t m_buffer_size { 0 };
+    uint32_t m_channel_count { 0 };
+    OrganizationStrategy m_organization { OrganizationStrategy::PLANAR };
+    std::atomic<bool> m_is_processing { false };
+
+    Registry::Service::AudioBackendService* m_backend_service { nullptr };
+};
+
+} // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Source/AudioOutputContainer.cpp
+++ b/src/MayaFlux/Kakshya/Source/AudioOutputContainer.cpp
@@ -1,0 +1,27 @@
+#include "AudioOutputContainer.hpp"
+
+#include "MayaFlux/Kakshya/Processors/AudioOutputAccessProcessor.hpp"
+
+namespace MayaFlux::Kakshya {
+
+AudioOutputContainer::AudioOutputContainer(Core::GlobalStreamInfo stream_info)
+    : DynamicSoundStream(stream_info.sample_rate, stream_info.output.channels)
+    , m_stream_info(stream_info)
+    , m_buffer_size(stream_info.buffer_size)
+{
+    set_auto_resize(true);
+}
+
+void AudioOutputContainer::create_default_processor()
+{
+    auto proc = std::make_shared<AudioOutputAccessProcessor>(m_buffer_size);
+    set_default_processor(proc);
+}
+
+void AudioOutputContainer::process_default()
+{
+    if (m_default_processor)
+        m_default_processor->process(shared_from_this());
+}
+
+} // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Source/AudioOutputContainer.hpp
+++ b/src/MayaFlux/Kakshya/Source/AudioOutputContainer.hpp
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "DynamicSoundStream.hpp"
+#include "MayaFlux/Core/GlobalStreamInfo.hpp"
+
+namespace MayaFlux::Kakshya {
+
+class AudioOutputAccessProcessor;
+
+/**
+ * @class AudioOutputContainer
+ * @brief DynamicSoundStream subclass wrapping the live engine audio output.
+ *
+ * Exposes each completed output cycle as addressable N-dimensional data,
+ * symmetric with WindowContainer's treatment of window surfaces.
+ *
+ * Data model:
+ *   m_processed_data — current cycle snapshot, written by AudioOutputAccessProcessor
+ *                       each process() call. Hot consumable for real-time nodes,
+ *                       visualizers, and metering.
+ *   m_data           — unbounded accumulating history of all output frames written
+ *                       so far, growing via write_frames() each cycle. The write
+ *                       head is always get_num_frames(). Readers attach independent
+ *                       CursorAccessProcessor instances against this container and
+ *                       chase the write head at their own rate.
+ *
+ * Multi-reader model:
+ *   Inherited from DynamicSoundStream. Each consumer (SoundFileWriter, network
+ *   broadcast, metering) calls allocate_dynamic_slot() and attaches a
+ *   CursorAccessProcessor with set_loop_region(reader_pos, get_num_frames()).
+ *   The container never pushes to readers; readers pull on their own schedule.
+ *
+ * Processing model:
+ *   The default processor (AudioOutputAccessProcessor) pulls the engine snapshot
+ *   once per process() call, writes the deinterleaved result into m_processed_data,
+ *   then appends the same data to m_data via write_frames(). The container never
+ *   calls process() itself; callers drive it via process_default() hooked into
+ *   an AudioBackendService observer or BroadcastSource.
+ *
+ * Position semantics:
+ *   m_read_position is unused as a navigation cursor here. The write head
+ *   (get_num_frames()) is the only meaningful position. StreamContainer
+ *   position purv virtuals are inherited from SoundStreamContainer and operate
+ *   correctly against m_data for any reader that chooses to use them.
+ */
+class MAYAFLUX_API AudioOutputContainer : public DynamicSoundStream {
+public:
+    /**
+     * @brief Construct from stream configuration.
+     * @param stream_info  Provides channel count, buffer size, and sample rate.
+     */
+    explicit AudioOutputContainer(Core::GlobalStreamInfo stream_info);
+
+    ~AudioOutputContainer() override = default;
+
+    AudioOutputContainer(const AudioOutputContainer&) = delete;
+    AudioOutputContainer& operator=(const AudioOutputContainer&) = delete;
+    AudioOutputContainer(AudioOutputContainer&&) = delete;
+    AudioOutputContainer& operator=(AudioOutputContainer&&) = delete;
+
+    [[nodiscard]] uint32_t get_buffer_size() const { return m_buffer_size; }
+
+    /**
+     * @brief Instantiate and attach an AudioOutputAccessProcessor as the default processor.
+     *
+     * Overrides DynamicSoundStream::create_default_processor which would
+     * attach a ContiguousAccessProcessor unsuitable for a live output source.
+     */
+    void create_default_processor() override;
+
+    /**
+     * @brief Drive one cycle: pull snapshot, update m_processed_data, append to m_data.
+     *
+     * Overrides SoundStreamContainer::process_default to skip the
+     * is_ready_for_processing guard — the container is always ready once
+     * the backend has produced at least one cycle.
+     */
+    void process_default() override;
+
+private:
+    Core::GlobalStreamInfo m_stream_info;
+    uint32_t m_buffer_size;
+
+    friend class AudioOutputAccessProcessor;
+};
+
+} // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kriya/Awaiters/BroadcastAwaiter.hpp
+++ b/src/MayaFlux/Kriya/Awaiters/BroadcastAwaiter.hpp
@@ -1,0 +1,136 @@
+#pragma once
+
+#include "EventAwaiter.hpp"
+#include "MayaFlux/Vruta/BroadcastSource.hpp"
+
+namespace MayaFlux::Kriya {
+
+/**
+ * @class BroadcastAwaiter
+ * @brief Awaiter for suspending a coroutine until a BroadcastSource<T> fires.
+ *
+ * Works with any coroutine type: SoundRoutine, GraphicsRoutine, Event,
+ * ComplexRoutine. The awaiter does not own the source; the source must
+ * outlive any suspended awaiter.
+ *
+ * Edge-triggered: await_ready() returns true only when a value arrived
+ * before this co_await expression (pending slot occupied). Otherwise the
+ * coroutine suspends and is resumed by the next signal() call.
+ *
+ * One BroadcastAwaiter may be registered against a BroadcastSource at a
+ * time. For fan-out to multiple consumers, use one BroadcastSource per
+ * consumer.
+ *
+ * The captured shared_ptr to the BroadcastSource must be copied into a
+ * coroutine-local variable before first use, not referenced only through
+ * the lambda closure. The lambda closure lives on the caller's stack;
+ * the coroutine frame is heap-allocated and outlives the caller.
+ *
+ * @code
+ * auto src = make_persistent_shared<Vruta::BroadcastSource<MyType>>();
+ *
+ * auto routine = [src]() -> Vruta::Event {
+ *     auto local_src = src;   // pull into coroutine frame
+ *     while (true) {
+ *         auto val = co_await local_src->next();
+ *     }
+ * };
+ * @endcode
+ *
+ * @tparam T Payload type matching the bound BroadcastSource<T>.
+ * @see BroadcastSource
+ */
+template <typename T>
+class BroadcastAwaiter : public EventAwaiter {
+public:
+    explicit BroadcastAwaiter(Vruta::BroadcastSource<T>& source)
+        : m_source(source)
+    {
+    }
+
+    ~BroadcastAwaiter() override
+    {
+        if (m_is_suspended)
+            m_source.unregister_waiter(this);
+    }
+
+    BroadcastAwaiter(const BroadcastAwaiter&) = delete;
+    BroadcastAwaiter& operator=(const BroadcastAwaiter&) = delete;
+    BroadcastAwaiter(BroadcastAwaiter&&) noexcept = default;
+    BroadcastAwaiter& operator=(BroadcastAwaiter&&) noexcept = delete;
+
+    /**
+     * @brief Returns true if a pending value is already available.
+     *
+     * Consumes the pending value on success. The coroutine does not suspend.
+     */
+    bool await_ready()
+    {
+        auto val = m_source.pop_pending();
+        if (val) {
+            m_result = std::move(*val);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @brief Register with the source and suspend, or consume a pending value
+     *        that arrived in the race window and return false (no suspend).
+     *
+     * @param handle Coroutine handle.
+     * @return true if the coroutine should suspend, false if it should continue.
+     */
+    bool await_suspend(std::coroutine_handle<> handle)
+    {
+        m_handle = handle;
+        m_is_suspended = true;
+        m_source.register_waiter(this);
+
+        if (auto val = m_source.pop_pending()) {
+            m_source.unregister_waiter(this);
+            m_result = std::move(*val);
+            m_is_suspended = false;
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @brief Return the delivered value on resume.
+     */
+    T await_resume()
+    {
+        m_is_suspended = false;
+        return std::move(m_result);
+    }
+
+    /**
+     * @brief Called by BroadcastSource::signal() from any thread.
+     * @param value Value committed by the signaller.
+     */
+    void deliver(const T& value)
+    {
+        m_result = value;
+        m_is_suspended = false;
+        m_handle.resume();
+    }
+
+    /**
+     * @brief Satisfies EventAwaiter interface. BroadcastAwaiter bypasses
+     * the EventSource dispatch() path; deliver() is called directly.
+     */
+    void try_resume(const void*) override { }
+
+    /**
+     * @brief BroadcastAwaiter has no filter semantics. Always returns true.
+     */
+    [[nodiscard]] bool filter_matches(const void*) const override { return true; }
+
+private:
+    Vruta::BroadcastSource<T>& m_source;
+    T m_result {};
+};
+
+} // namespace MayaFlux::Kriya

--- a/src/MayaFlux/Kriya/Awaiters/EventAwaiter.cpp
+++ b/src/MayaFlux/Kriya/Awaiters/EventAwaiter.cpp
@@ -2,60 +2,67 @@
 
 namespace MayaFlux::Kriya {
 
-EventAwaiter::~EventAwaiter()
+WindowEventAwaiter::~WindowEventAwaiter()
 {
-    if (m_is_suspended) {
+    if (m_is_suspended)
         m_source.unregister_waiter(this);
-    }
 }
 
-bool EventAwaiter::await_ready()
+bool WindowEventAwaiter::await_ready()
 {
-    if (auto event = m_source.pop_event(m_filter)) {
-        m_result = *event;
+    if (auto ev = m_source.pop_event(m_filter)) {
+        m_result = *ev;
         return true;
     }
     return false;
 }
 
-void EventAwaiter::await_suspend(std::coroutine_handle<> handle)
+void WindowEventAwaiter::await_suspend(std::coroutine_handle<> handle)
 {
     m_handle = handle;
     m_is_suspended = true;
     m_source.register_waiter(this);
 }
 
-Core::WindowEvent EventAwaiter::await_resume()
+Core::WindowEvent WindowEventAwaiter::await_resume()
 {
     m_is_suspended = false;
     return m_result;
 }
 
-void EventAwaiter::try_resume()
+void WindowEventAwaiter::try_resume(const void* event)
 {
-    if (auto event = m_source.pop_event(m_filter)) {
-        m_result = *event;
+    if (!filter_matches(event))
+        return;
+
+    if (auto ev = m_source.pop_event(m_filter)) {
+        m_result = *ev;
         m_source.unregister_waiter(this);
         m_is_suspended = false;
         m_handle.resume();
     }
 }
 
-bool EventAwaiter::filter_matches(const Core::WindowEvent& event) const
+bool WindowEventAwaiter::filter_matches(const void* event) const
 {
-    if (m_filter.event_type && event.type != *m_filter.event_type)
+    const auto* ev = static_cast<const Core::WindowEvent*>(event);
+
+    if (m_filter.event_type && ev->type != *m_filter.event_type)
         return false;
+
     if (m_filter.key_code) {
-        auto* kd = std::get_if<Core::WindowEvent::KeyData>(&event.data);
+        const auto* kd = std::get_if<Core::WindowEvent::KeyData>(&ev->data);
         if (!kd || kd->key != static_cast<int16_t>(*m_filter.key_code))
             return false;
     }
+
     if (m_filter.button) {
-        auto* bd = std::get_if<Core::WindowEvent::MouseButtonData>(&event.data);
+        const auto* bd = std::get_if<Core::WindowEvent::MouseButtonData>(&ev->data);
         if (!bd || bd->button != static_cast<int>(*m_filter.button))
             return false;
     }
+
     return true;
 }
 
-}
+} // namespace MayaFlux::Kriya

--- a/src/MayaFlux/Kriya/Awaiters/EventAwaiter.hpp
+++ b/src/MayaFlux/Kriya/Awaiters/EventAwaiter.hpp
@@ -1,90 +1,131 @@
 #pragma once
 
 #include "MayaFlux/Core/GlobalGraphicsInfo.hpp"
-#include "MayaFlux/Vruta/EventSource.hpp"
+#include "MayaFlux/Vruta/WindowEventSource.hpp"
 
-#include "coroutine"
+#include <coroutine>
+#include <utility>
 
 namespace MayaFlux::Kriya {
 
+// =============================================================================
+// EventAwaiter - base
+// =============================================================================
+
 /**
  * @class EventAwaiter
- * @brief Awaiter for suspending on window events with optional filtering
+ * @brief Abstract base for all event-driven awaiters.
  *
- * Allows coroutines to suspend until specific window events arrive.
- * Events are filtered by type and/or input key/button, with support for
- * both awaiting any event or specific event types.
+ * Provides the interface EventSource uses to manage its waiter list
+ * without knowing the payload type or filter semantics of concrete awaiters.
  *
- * @note EventAwaiter takes EventFilter by value, so temporary filters
- * created in next_event() and await_event() are safe.
- *
- * Usage Examples:
- * @code
- * // Wait for any event
- * auto event = co_await event_source.next_event();
- *
- * // Wait for specific event type
- * auto event = co_await event_source.await_event(WindowEventType::KEY_PRESSED);
- *
- * // Wait for specific key press (via EventFilter)
- * Vruta::EventFilter filter(IO::Keys::Escape);
- * auto event = co_await EventAwaiter(source, filter);
- *
- * // Manual filter construction for complex queries
- * Vruta::EventFilter filter;
- * filter.event_type = WindowEventType::KEY_PRESSED;
- * filter.key_code = IO::Keys::Space;
- * auto event = co_await EventAwaiter(source, filter);
- * @endcode
- *
- * @see EventSource for creating awaiters
- * @see EventFilter for filter construction
- * @see IO::Keys for key enumeration
+ * @see WindowEventAwaiter
+ * @see SignalAwaiter
  */
 class MAYAFLUX_API EventAwaiter {
 public:
-    EventAwaiter(Vruta::EventSource& source, Vruta::EventFilter filter = {})
-        : m_source(source)
-        , m_filter(filter)
-    {
-    }
+    virtual ~EventAwaiter() = default;
 
-    ~EventAwaiter();
-
+    EventAwaiter() = default;
     EventAwaiter(const EventAwaiter&) = delete;
     EventAwaiter& operator=(const EventAwaiter&) = delete;
     EventAwaiter(EventAwaiter&&) noexcept = default;
-    EventAwaiter& operator=(EventAwaiter&&) noexcept = delete;
+    EventAwaiter& operator=(EventAwaiter&&) noexcept = default;
 
     /**
-     * @brief Check if event already available
+     * @brief Called by the source to attempt resumption of the suspended coroutine.
+     *
+     * @param event Type-erased pointer to the candidate signal value.
+     */
+    virtual void try_resume(const void* event) = 0;
+
+    /**
+     * @brief Returns true if the candidate signal passes this awaiter's filter.
+     *
+     * @param event Type-erased pointer to the candidate signal value.
+     */
+    [[nodiscard]] virtual bool filter_matches(const void* event) const = 0;
+
+protected:
+    std::coroutine_handle<> m_handle;
+    bool m_is_suspended {};
+};
+
+// =============================================================================
+// WindowEventAwaiter
+// =============================================================================
+
+/**
+ * @class WindowEventAwaiter
+ * @brief Awaiter for suspending on GLFW window input events with optional filtering.
+ *
+ * Payload type is Core::WindowEvent. Filter criteria are WindowEventType,
+ * IO::Keys, and IO::MouseButtons via EventFilter. Works with any coroutine
+ * type: SoundRoutine, GraphicsRoutine, Event, ComplexRoutine.
+ *
+ * Multiple awaiters may register against the same WindowEventSource simultaneously.
+ * The source must outlive any suspended awaiter.
+ *
+ * @code
+ * auto ev = co_await source.next_event();
+ * auto ev = co_await source.await_event(WindowEventType::KEY_PRESSED);
+ *
+ * Vruta::EventFilter f(IO::Keys::Escape);
+ * auto ev = co_await WindowEventAwaiter(source, f);
+ * @endcode
+ *
+ * @see WindowEventSource
+ * @see EventFilter
+ */
+class MAYAFLUX_API WindowEventAwaiter : public EventAwaiter {
+public:
+    explicit WindowEventAwaiter(Vruta::WindowEventSource& source, Vruta::WindowEventFilter filter = {})
+        : m_source(source)
+        , m_filter(std::move(filter))
+    {
+    }
+
+    ~WindowEventAwaiter() override;
+
+    WindowEventAwaiter(const WindowEventAwaiter&) = delete;
+    WindowEventAwaiter& operator=(const WindowEventAwaiter&) = delete;
+    WindowEventAwaiter(WindowEventAwaiter&&) noexcept = default;
+    WindowEventAwaiter& operator=(WindowEventAwaiter&&) noexcept = delete;
+
+    /**
+     * @brief Returns true if a matching event is already queued; stores it if so.
      */
     bool await_ready();
 
     /**
-     * @brief Suspend coroutine, register for event notification
+     * @brief Registers with the source and suspends the coroutine.
+     * @param handle Type-erased coroutine handle.
      */
     void await_suspend(std::coroutine_handle<> handle);
 
     /**
-     * @brief Resume with event data
+     * @brief Returns the event that caused resumption.
      */
     Core::WindowEvent await_resume();
 
     /**
-     * @brief Called by EventSource when event arrives
+     * @brief Casts event to Core::WindowEvent, checks filter, resumes if matched.
+     * @param event Type-erased pointer to Core::WindowEvent.
      */
-    void try_resume();
+    void try_resume(const void* event) override;
+
+    /**
+     * @brief Casts event to Core::WindowEvent and checks against stored filter.
+     * @param event Type-erased pointer to Core::WindowEvent.
+     */
+    [[nodiscard]] bool filter_matches(const void* event) const override;
 
 private:
-    Vruta::EventSource& m_source;
-    Vruta::EventFilter m_filter;
+    Vruta::WindowEventSource& m_source;
+    Vruta::WindowEventFilter m_filter;
     Core::WindowEvent m_result;
-    std::coroutine_handle<> m_handle;
-    bool m_is_suspended = false;
 
-    [[nodiscard]] bool filter_matches(const Core::WindowEvent& event) const;
-
-    friend class Vruta::EventSource;
+    friend class Vruta::WindowEventSource;
 };
-}
+
+} // namespace MayaFlux::Kriya

--- a/src/MayaFlux/Kriya/Awaiters/EventAwaiter.hpp
+++ b/src/MayaFlux/Kriya/Awaiters/EventAwaiter.hpp
@@ -4,7 +4,6 @@
 #include "MayaFlux/Vruta/WindowEventSource.hpp"
 
 #include <coroutine>
-#include <utility>
 
 namespace MayaFlux::Kriya {
 

--- a/src/MayaFlux/Kriya/Awaiters/NetworkAwaiter.hpp
+++ b/src/MayaFlux/Kriya/Awaiters/NetworkAwaiter.hpp
@@ -2,7 +2,7 @@
 
 #include "MayaFlux/Vruta/NetworkSource.hpp"
 
-#include <coroutine>
+#include "MayaFlux/Kriya/Awaiters/EventAwaiter.hpp"
 
 namespace MayaFlux::Kriya {
 
@@ -35,14 +35,14 @@ namespace MayaFlux::Kriya {
  * };
  * @endcode
  */
-class MAYAFLUX_API NetworkAwaiter {
+class MAYAFLUX_API NetworkAwaiter : public EventAwaiter {
 public:
     explicit NetworkAwaiter(Vruta::NetworkSource& source)
         : m_source(source)
     {
     }
 
-    ~NetworkAwaiter();
+    ~NetworkAwaiter() override;
 
     NetworkAwaiter(const NetworkAwaiter&) = delete;
     NetworkAwaiter& operator=(const NetworkAwaiter&) = delete;
@@ -76,11 +76,20 @@ public:
      */
     void deliver(const Core::NetworkMessage& message);
 
+    /**
+     * @brief NetworkAwaiter is driven by deliver(), not dispatch().
+     * Satisfies the EventAwaiter interface; never called by NetworkSource.
+     */
+    void try_resume(const void*) override { }
+
+    /**
+     * @brief NetworkAwaiter has no filter semantics. Always returns true.
+     */
+    [[nodiscard]] bool filter_matches(const void*) const override { return true; }
+
 private:
     Vruta::NetworkSource& m_source;
     Core::NetworkMessage m_result;
-    std::coroutine_handle<> m_handle;
-    bool m_is_suspended {};
 
     /**
      * @brief Intrusive list link for lock-free waiter broadcast.

--- a/src/MayaFlux/Kriya/BroadcastEvents.cpp
+++ b/src/MayaFlux/Kriya/BroadcastEvents.cpp
@@ -1,0 +1,37 @@
+#include "BroadcastEvents.hpp"
+
+#include "MayaFlux/Registry/BackendRegistry.hpp"
+#include "MayaFlux/Registry/Service/AudioBackendService.hpp"
+
+namespace MayaFlux::Kriya {
+
+std::shared_ptr<Vruta::BroadcastSource<bool>> audio_output_tick()
+{
+    auto* svc = Registry::BackendRegistry::instance()
+                    .get_service<Registry::Service::AudioBackendService>();
+
+    if (!svc)
+        return nullptr;
+
+    struct State {
+        Vruta::BroadcastSource<bool> source;
+        Registry::Service::AudioBackendService* svc { nullptr };
+        uint32_t observer_id { 0 };
+        ~State()
+        {
+            if (svc)
+                svc->unregister_output_observer(observer_id);
+        }
+    };
+
+    auto state = std::make_shared<State>();
+    state->svc = svc;
+    state->observer_id = svc->register_output_observer(
+        [s = state.get()](const double*, uint32_t) {
+            s->source.signal(true);
+        });
+
+    return { state, &state->source };
+}
+
+} // namespace MayaFlux::Kriya

--- a/src/MayaFlux/Kriya/BroadcastEvents.hpp
+++ b/src/MayaFlux/Kriya/BroadcastEvents.hpp
@@ -51,6 +51,24 @@ Vruta::Event on_signal_matching(
     Predicate predicate,
     Callback callback);
 
+/**
+ * @brief Create a BroadcastSource<bool> ticking once per audio output cycle.
+ *
+ * Registers an observer with AudioBackendService and returns the source.
+ * The returned observer id is stored inside the source's shared state via
+ * a custom deleter on the shared_ptr - unregistration is automatic when
+ * the last owner drops the source.
+ *
+ * @code
+ * auto src = Kriya::audio_output_tick();
+ * get_event_manager()->add_event(std::make_shared<Vruta::Event>(
+ *     Kriya::on_signal(src, [ct](bool) {
+ *         ct->process_default();
+ *     })));
+ * @endcode
+ */
+[[nodiscard]] std::shared_ptr<Vruta::BroadcastSource<bool>> audio_output_tick();
+
 } // namespace MayaFlux::Kriya
 
 #include "BroadcastEvents.inl"

--- a/src/MayaFlux/Kriya/BroadcastEvents.hpp
+++ b/src/MayaFlux/Kriya/BroadcastEvents.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "Awaiters/BroadcastAwaiter.hpp"
+#include "MayaFlux/Vruta/BroadcastSource.hpp"
+
+namespace MayaFlux::Vruta {
+class Event;
+}
+
+namespace MayaFlux::Kriya {
+
+/**
+ * @brief Creates an Event coroutine that fires on every signal from a BroadcastSource.
+ *
+ * @param source   Shared ownership of the BroadcastSource; lifetime is tied to the coroutine frame.
+ * @param callback Invoked with each delivered value.
+ * @return Event coroutine suitable for EventManager::add_event().
+ *
+ * @code
+ * auto src = make_persistent_shared<Vruta::BroadcastSource<float>>();
+ *
+ * get_event_manager()->add_event(std::make_shared<Vruta::Event>(
+ *     Kriya::on_signal(src, [](const float& val) {
+ *         // handle val
+ *     })));
+ * @endcode
+ */
+template <typename T, typename Callback>
+Vruta::Event on_signal(
+    std::shared_ptr<Vruta::BroadcastSource<T>> source,
+    Callback callback);
+
+/**
+ * @brief Creates an Event coroutine that fires only when a predicate matches.
+ *
+ * @param source    Shared ownership of the BroadcastSource.
+ * @param predicate Returns true for values that should trigger the callback.
+ * @param callback  Invoked with each matching value.
+ * @return Event coroutine suitable for EventManager::add_event().
+ *
+ * @code
+ * get_event_manager()->add_event(std::make_shared<Vruta::Event>(
+ *     Kriya::on_signal_matching(src,
+ *         [](const float& v) { return v > 0.5f; },
+ *         [](const float& v) { })));
+ * @endcode
+ */
+template <typename T, typename Predicate, typename Callback>
+Vruta::Event on_signal_matching(
+    std::shared_ptr<Vruta::BroadcastSource<T>> source,
+    Predicate predicate,
+    Callback callback);
+
+} // namespace MayaFlux::Kriya
+
+#include "BroadcastEvents.inl"

--- a/src/MayaFlux/Kriya/BroadcastEvents.inl
+++ b/src/MayaFlux/Kriya/BroadcastEvents.inl
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "Awaiters/GetPromise.hpp"
+#include "MayaFlux/Vruta/BroadcastSource.hpp"
+#include "MayaFlux/Vruta/Event.hpp"
+
+namespace MayaFlux::Kriya {
+
+template <typename T, typename Callback>
+Vruta::Event on_signal(
+    std::shared_ptr<Vruta::BroadcastSource<T>> source,
+    Callback callback)
+{
+    auto& promise = co_await GetEventPromise {};
+
+    while (true) {
+        if (promise.should_terminate)
+            break;
+
+        auto val = co_await source->next();
+        callback(val);
+    }
+}
+
+template <typename T, typename Predicate, typename Callback>
+Vruta::Event on_signal_matching(
+    std::shared_ptr<Vruta::BroadcastSource<T>> source,
+    Predicate predicate,
+    Callback callback)
+{
+    auto& promise = co_await GetEventPromise {};
+
+    while (true) {
+        if (promise.should_terminate)
+            break;
+
+        auto val = co_await source->next();
+        if (predicate(val))
+            callback(val);
+    }
+}
+
+} // namespace MayaFlux::Kriya

--- a/src/MayaFlux/Kriya/InputEvents.cpp
+++ b/src/MayaFlux/Kriya/InputEvents.cpp
@@ -15,7 +15,7 @@ Vruta::Event key_pressed(
     auto& promise = co_await GetEventPromise {};
     auto& source = window->get_event_source();
 
-    Vruta::EventFilter filter;
+    Vruta::WindowEventFilter filter;
     filter.event_type = Core::WindowEventType::KEY_PRESSED;
     filter.key_code = key;
 
@@ -24,7 +24,7 @@ Vruta::Event key_pressed(
             break;
         }
 
-        co_await EventAwaiter(source, filter);
+        co_await WindowEventAwaiter(source, filter);
         callback();
     }
 }
@@ -37,7 +37,7 @@ Vruta::Event key_released(
     auto& promise = co_await GetEventPromise {};
     auto& source = window->get_event_source();
 
-    Vruta::EventFilter filter;
+    Vruta::WindowEventFilter filter;
     filter.event_type = Core::WindowEventType::KEY_RELEASED;
     filter.key_code = key;
 
@@ -46,7 +46,7 @@ Vruta::Event key_released(
             break;
         }
 
-        co_await EventAwaiter(source, filter);
+        co_await WindowEventAwaiter(source, filter);
         callback();
     }
 }
@@ -58,7 +58,7 @@ Vruta::Event any_key(
     auto& promise = co_await GetEventPromise {};
     auto& source = window->get_event_source();
 
-    Vruta::EventFilter filter;
+    Vruta::WindowEventFilter filter;
     filter.event_type = Core::WindowEventType::KEY_PRESSED;
 
     while (true) {
@@ -66,7 +66,7 @@ Vruta::Event any_key(
             break;
         }
 
-        auto event = co_await EventAwaiter(source, filter);
+        auto event = co_await WindowEventAwaiter(source, filter);
 
         if (auto* key_data = std::get_if<Core::WindowEvent::KeyData>(&event.data)) {
             callback(static_cast<IO::Keys>(key_data->key));
@@ -82,7 +82,7 @@ Vruta::Event mouse_pressed(
     auto& promise = co_await GetEventPromise {};
     auto& source = window->get_event_source();
 
-    Vruta::EventFilter filter;
+    Vruta::WindowEventFilter filter;
     filter.event_type = Core::WindowEventType::MOUSE_BUTTON_PRESSED;
     filter.button = button;
 
@@ -91,7 +91,7 @@ Vruta::Event mouse_pressed(
             break;
         }
 
-        co_await EventAwaiter(source, filter);
+        co_await WindowEventAwaiter(source, filter);
 
         auto [x, y] = source.get_mouse_position();
         callback(x, y);
@@ -106,7 +106,7 @@ Vruta::Event mouse_released(
     auto& promise = co_await GetEventPromise {};
     auto& source = window->get_event_source();
 
-    Vruta::EventFilter filter;
+    Vruta::WindowEventFilter filter;
     filter.event_type = Core::WindowEventType::MOUSE_BUTTON_RELEASED;
     filter.button = button;
 
@@ -115,7 +115,7 @@ Vruta::Event mouse_released(
             break;
         }
 
-        co_await EventAwaiter(source, filter);
+        co_await WindowEventAwaiter(source, filter);
 
         auto [x, y] = source.get_mouse_position();
         callback(x, y);
@@ -129,7 +129,7 @@ Vruta::Event mouse_moved(
     auto& promise = co_await GetEventPromise {};
     auto& source = window->get_event_source();
 
-    Vruta::EventFilter filter;
+    Vruta::WindowEventFilter filter;
     filter.event_type = Core::WindowEventType::MOUSE_MOTION;
 
     while (true) {
@@ -137,7 +137,7 @@ Vruta::Event mouse_moved(
             break;
         }
 
-        auto event = co_await EventAwaiter(source, filter);
+        auto event = co_await WindowEventAwaiter(source, filter);
 
         if (auto* pos_data = std::get_if<Core::WindowEvent::MousePosData>(&event.data)) {
             callback(pos_data->x, pos_data->y);
@@ -152,7 +152,7 @@ Vruta::Event mouse_scrolled(
     auto& promise = co_await GetEventPromise {};
     auto& source = window->get_event_source();
 
-    Vruta::EventFilter filter;
+    Vruta::WindowEventFilter filter;
     filter.event_type = Core::WindowEventType::MOUSE_SCROLLED;
 
     while (true) {
@@ -160,7 +160,7 @@ Vruta::Event mouse_scrolled(
             break;
         }
 
-        auto event = co_await EventAwaiter(source, filter);
+        auto event = co_await WindowEventAwaiter(source, filter);
 
         if (auto* scroll_data = std::get_if<Core::WindowEvent::ScrollData>(&event.data)) {
             callback(scroll_data->x_offset, scroll_data->y_offset);

--- a/src/MayaFlux/Kriya/InputEvents.hpp
+++ b/src/MayaFlux/Kriya/InputEvents.hpp
@@ -10,7 +10,7 @@ namespace Core {
 namespace Vruta {
     class TaskScheduler;
     class Event;
-    class EventSource;
+    class WindowEventSource;
 }
 namespace Kriya {
 

--- a/src/MayaFlux/MayaFlux.hpp
+++ b/src/MayaFlux/MayaFlux.hpp
@@ -104,6 +104,7 @@
 #include "Kriya/Awaiters/DelayAwaiters.hpp"
 #include "Kriya/Awaiters/EventAwaiter.hpp"
 #include "Kriya/Awaiters/NetworkAwaiter.hpp"
+#include "Kriya/BroadcastEvents.hpp"
 #include "Kriya/BufferPipeline.hpp"
 #include "Kriya/Chain.hpp"
 #include "Kriya/CycleCoordinator.hpp"

--- a/src/MayaFlux/Nexus/Wiring.cpp
+++ b/src/MayaFlux/Nexus/Wiring.cpp
@@ -51,7 +51,7 @@ Wiring& Wiring::on(Vruta::NetworkSource& source)
     return *this;
 }
 
-Wiring& Wiring::on(Vruta::EventSource& source, Vruta::EventFilter filter)
+Wiring& Wiring::on(Vruta::WindowEventSource& source, Vruta::WindowEventFilter filter)
 {
     m_trigger = EventTrigger { .source = &source, .filter = filter };
     return *this;
@@ -371,13 +371,13 @@ void Wiring::finalise()
                         network_loop(*trig.source, m_fabric, id)),
                     name, false);
 
-            } else if constexpr (std::is_same_v<T, EventTrigger>) {
+            } else if constexpr (std::is_same_v<T, WindowEventTrigger>) {
                 auto name = make_name("nexus_event");
                 reg.event_name = name;
                 Fabric& fab = m_fabric;
                 ev_manager.add_event(
                     std::make_shared<Vruta::Event>(
-                        event_source_loop(*trig.source, trig.filter, fab, id)),
+                        window_event_source_loop(*trig.source, trig.filter, fab, id)),
                     name);
             }
         },
@@ -451,9 +451,9 @@ void Wiring::cancel()
 // Internal
 // =============================================================================
 
-Vruta::Event Wiring::event_source_loop(
-    Vruta::EventSource& source,
-    Vruta::EventFilter filter,
+Vruta::Event Wiring::window_event_source_loop(
+    Vruta::WindowEventSource& source,
+    Vruta::WindowEventFilter filter,
     Fabric& fabric,
     uint32_t id)
 {
@@ -461,7 +461,7 @@ Vruta::Event Wiring::event_source_loop(
     while (true) {
         if (promise.should_terminate)
             break;
-        auto event = co_await Kriya::EventAwaiter(source, filter);
+        auto event = co_await Kriya::WindowEventAwaiter(source, filter);
         if (auto* pos = std::get_if<Core::WindowEvent::MousePosData>(&event.data))
             fabric.m_registrations[id].pending_cursor = glm::vec2(pos->x, pos->y);
         fabric.fire(id);

--- a/src/MayaFlux/Nexus/Wiring.hpp
+++ b/src/MayaFlux/Nexus/Wiring.hpp
@@ -3,8 +3,8 @@
 #include "Agent.hpp"
 
 #include "MayaFlux/IO/Keys.hpp"
-#include "MayaFlux/Vruta/EventSource.hpp"
 #include "MayaFlux/Vruta/NetworkSource.hpp"
+#include "MayaFlux/Vruta/WindowEventSource.hpp"
 
 namespace MayaFlux::Core {
 class Window;
@@ -85,7 +85,7 @@ public:
      * @param source Event stream.
      * @param filter Optional filter criteria.
      */
-    Wiring& on(Vruta::EventSource& source, Vruta::EventFilter filter = {});
+    Wiring& on(Vruta::WindowEventSource& source, Vruta::WindowEventFilter filter = {});
 
     /**
      * @brief Choreograph a position move as an EventChain step.
@@ -219,6 +219,11 @@ private:
         Vruta::EventFilter filter;
     };
 
+    struct WindowEventTrigger {
+        Vruta::WindowEventSource* source {};
+        Vruta::WindowEventFilter filter;
+    };
+
     using Trigger = std::variant<std::monostate, KeyTrigger, MouseTrigger, NetworkTrigger, EventTrigger>;
     using Factory = std::variant<std::monostate, SoundFactory, GraphicsFactory, ComplexFactory>;
     using EFactory = std::optional<EventFactory>;
@@ -245,7 +250,7 @@ private:
     std::string m_bind_attach_name;
     std::string m_bind_detach_name;
 
-    Vruta::Event event_source_loop(Vruta::EventSource& source, Vruta::EventFilter filter, Fabric& fabric, uint32_t id);
+    Vruta::Event window_event_source_loop(Vruta::WindowEventSource& source, Vruta::WindowEventFilter filter, Fabric& fabric, uint32_t id);
 
 public:
     // =====================================================================

--- a/src/MayaFlux/Portal/Forma/Context.cpp
+++ b/src/MayaFlux/Portal/Forma/Context.cpp
@@ -3,7 +3,7 @@
 #include "MayaFlux/Core/Backends/Windowing/Window.hpp"
 #include "MayaFlux/Kriya/InputEvents.hpp"
 #include "MayaFlux/Vruta/EventManager.hpp"
-#include "MayaFlux/Vruta/EventSource.hpp"
+#include "MayaFlux/Vruta/WindowEventSource.hpp"
 
 namespace MayaFlux::Portal::Forma {
 
@@ -63,7 +63,7 @@ void Context::unbind(uint32_t id)
     m_callbacks.erase(id);
 }
 
-const Vruta::EventSource& Context::event_source() const
+const Vruta::WindowEventSource& Context::event_source() const
 {
     return m_window->get_event_source();
 }

--- a/src/MayaFlux/Portal/Forma/Context.hpp
+++ b/src/MayaFlux/Portal/Forma/Context.hpp
@@ -10,7 +10,7 @@ class Window;
 
 namespace MayaFlux::Vruta {
 class EventManager;
-class EventSource;
+class WindowEventSource;
 }
 
 namespace MayaFlux::Portal::Forma {
@@ -113,7 +113,7 @@ public:
 
     [[nodiscard]] std::optional<uint32_t> hovered() const { return m_hovered; }
 
-    [[nodiscard]] const Vruta::EventSource& event_source() const;
+    [[nodiscard]] const Vruta::WindowEventSource& event_source() const;
 
 private:
     struct ElementCallbacks {

--- a/src/MayaFlux/Registry/Service/AudioBackendService.hpp
+++ b/src/MayaFlux/Registry/Service/AudioBackendService.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+namespace MayaFlux::Registry::Service {
+
+/**
+ * @brief Backend audio subsystem service interface.
+ *
+ * Registered into BackendRegistry by AudioSubsystem during initialize().
+ * Follows the same pattern as NetworkService, BufferService, DisplayService,
+ * and InputService: plain struct of std::function members, natural C++ types
+ * only, no engine-internal pointers.
+ *
+ * Two consumption models:
+ *
+ * Polling: call get_output_snapshot() from any non-RT thread to read the
+ * last committed interleaved output buffer.
+ *
+ * Per-cycle notification: call register_output_observer() with a callback.
+ * The callback fires on a dedicated notification thread (not the RT audio
+ * thread) once per output cycle. Any number of observers may be registered
+ * at any time. Each receives a unique id for later unregistration.
+ * The callback must not block; post to a lock-free queue if further work
+ * is needed.
+ *
+ * @code
+ * auto* svc = BackendRegistry::instance().get_service<AudioBackendService>();
+ * if (!svc) return;
+ *
+ * // Polling:
+ * auto snap = svc->get_output_snapshot();
+ *
+ * // Per-cycle observer:
+ * auto id = svc->register_output_observer([](const double* data, uint32_t total_samples) {
+ *     // runs on notification thread, not RT thread
+ * });
+ *
+ * // Later:
+ * svc->unregister_output_observer(id);
+ * @endcode
+ */
+struct MAYAFLUX_API AudioBackendService {
+
+    /**
+     * @brief Returns a span over the last committed interleaved output buffer.
+     *
+     * Lock-free. Safe from any non-RT thread. The underlying pointer is
+     * engine-owned and valid between the last output cycle and the next.
+     * Copy the data if it is needed beyond the current cycle.
+     *
+     * Returns an empty span if no output cycle has completed yet.
+     */
+    std::function<std::span<const double>()> get_output_snapshot;
+
+    /**
+     * @brief Register a per-cycle output observer.
+     *
+     * The observer fires on the dedicated notification thread once per
+     * output cycle. May be called from any thread at any time.
+     *
+     * @param observer Callable receiving (interleaved data ptr, total samples).
+     * @return Opaque id for use with unregister_output_observer.
+     */
+    std::function<uint32_t(std::function<void(const double*, uint32_t)>)> register_output_observer;
+
+    /**
+     * @brief Unregister a previously registered observer.
+     *
+     * Safe to call from any thread at any time, including from within
+     * the observer callback itself.
+     *
+     * @param id Id returned by register_output_observer.
+     */
+    std::function<void(uint32_t)> unregister_output_observer;
+};
+
+} // namespace MayaFlux::Registry::Service

--- a/src/MayaFlux/Vruta/BroadcastSource.hpp
+++ b/src/MayaFlux/Vruta/BroadcastSource.hpp
@@ -1,0 +1,138 @@
+#pragma once
+
+#include "MayaFlux/Vruta/EventSource.hpp"
+
+namespace MayaFlux::Kriya {
+template <typename T>
+class BroadcastAwaiter;
+}
+
+namespace MayaFlux::Vruta {
+
+/**
+ * @class BroadcastSource
+ * @brief Awaitable single-value broadcast channel for cross-thread signal delivery.
+ *
+ * Bridges a callback-based producer (e.g. audio output observer) to a coroutine
+ * consumer via co_await. Each signal() call delivers to the suspended awaiter,
+ * or stores the value for the next await_ready() poll if no awaiter is registered.
+ *
+ * Thread safety contract:
+ * - signal() may be called from any thread at any time.
+ * - register_waiter() / unregister_waiter() / pop_pending() are called only
+ *   from the coroutine's execution context (single-threaded per coroutine).
+ *
+ * Race window between await_ready() returning false and await_suspend()
+ * completing registration is closed by signal() itself: it uses a generation
+ * counter so a missed signal leaves the pending slot non-null, which
+ * await_suspend() checks after registration via a second pop_pending() call.
+ * The self-resume in await_suspend is intentionally absent; instead the CAS
+ * leaves the awaiter registered and the value in m_result, and returns to the
+ * coroutine machinery which will call await_resume() when the handle is resumed
+ * by the scheduler or by a subsequent signal() deliver() call.
+ *
+ * One coroutine per BroadcastSource instance. For fan-out, use one
+ * BroadcastSource per consumer.
+ *
+ * @tparam T Payload type. Must be copyable.
+ *
+ * @see BroadcastAwaiter
+ */
+template <typename T>
+class BroadcastSource : public EventSource {
+public:
+    BroadcastSource() = default;
+    ~BroadcastSource() override = default;
+
+    BroadcastSource(const BroadcastSource&) = delete;
+    BroadcastSource& operator=(const BroadcastSource&) = delete;
+    BroadcastSource(BroadcastSource&&) = delete;
+    BroadcastSource& operator=(BroadcastSource&&) = delete;
+
+    /**
+     * @brief Deliver a value to the waiting coroutine, or store it as pending.
+     *
+     * Atomically takes the waiter slot. If a waiter is present, delivers
+     * directly and resumes. Otherwise stores the value for the next
+     * await_ready() or post-registration check.
+     *
+     * Safe to call from any thread.
+     *
+     * @param value Value to deliver.
+     */
+    void signal(const T& value)
+    {
+        auto* w = m_waiter.exchange(nullptr, std::memory_order_acq_rel);
+        if (w) {
+            w->deliver(value);
+        } else {
+            m_pending_value = value;
+            m_pending_flag.store(true, std::memory_order_release);
+        }
+    }
+
+    /**
+     * @brief Create an awaiter for the next signal.
+     */
+    Kriya::BroadcastAwaiter<T> next()
+    {
+        return Kriya::BroadcastAwaiter<T> { *this };
+    }
+
+    /**
+     * @brief Returns true if a value arrived before any awaiter registered.
+     */
+    [[nodiscard]] bool has_pending() const override
+    {
+        return m_pending_flag.load(std::memory_order_acquire);
+    }
+
+    /**
+     * @brief Discard any stored pending value.
+     */
+    void clear() override
+    {
+        m_pending_flag.store(false, std::memory_order_release);
+    }
+
+private:
+    std::atomic<Kriya::BroadcastAwaiter<T>*> m_waiter { nullptr };
+
+    /// @brief Pending value written by signal() when no waiter is registered.
+    /// Written only by the signal() caller; read only by the coroutine thread.
+    T m_pending_value {};
+    std::atomic<bool> m_pending_flag { false };
+
+    /**
+     * @brief Consume and return the pending value if one is available.
+     *
+     * Called only from the coroutine's execution context.
+     *
+     * @return The pending value, or std::nullopt.
+     */
+    std::optional<T> pop_pending()
+    {
+        if (!m_pending_flag.load(std::memory_order_acquire))
+            return std::nullopt;
+        T val = m_pending_value;
+        m_pending_flag.store(false, std::memory_order_release);
+        return val;
+    }
+
+    void register_waiter(Kriya::BroadcastAwaiter<T>* awaiter)
+    {
+        m_waiter.store(awaiter, std::memory_order_release);
+    }
+
+    void unregister_waiter(Kriya::BroadcastAwaiter<T>* awaiter)
+    {
+        Kriya::BroadcastAwaiter<T>* expected = awaiter;
+        m_waiter.compare_exchange_strong(
+            expected, nullptr,
+            std::memory_order_acq_rel, std::memory_order_relaxed);
+    }
+
+    friend class Kriya::BroadcastAwaiter<T>;
+};
+
+} // namespace MayaFlux::Vruta

--- a/src/MayaFlux/Vruta/EventSource.cpp
+++ b/src/MayaFlux/Vruta/EventSource.cpp
@@ -4,114 +4,14 @@
 
 namespace MayaFlux::Vruta {
 
-void EventSource::signal(Core::WindowEvent event)
+void EventSource::dispatch(const void* event)
 {
-    if (auto* key_data = std::get_if<Core::WindowEvent::KeyData>(&event.data)) {
-        if (event.type == Core::WindowEventType::KEY_PRESSED) {
-            m_key_states[key_data->key] = true;
-        } else if (event.type == Core::WindowEventType::KEY_RELEASED) {
-            m_key_states[key_data->key] = false;
-        }
-    }
-
-    if (auto* button_data = std::get_if<Core::WindowEvent::MouseButtonData>(&event.data)) {
-        if (event.type == Core::WindowEventType::MOUSE_BUTTON_PRESSED) {
-            m_button_states[button_data->button] = true;
-        } else if (event.type == Core::WindowEventType::MOUSE_BUTTON_RELEASED) {
-            m_button_states[button_data->button] = false;
-        }
-    }
-
-    if (auto* pos_data = std::get_if<Core::WindowEvent::MousePosData>(&event.data)) {
-        m_mouse_x = pos_data->x;
-        m_mouse_y = pos_data->y;
-    }
-
-    if (m_waiters.empty()) {
+    if (m_waiters.empty())
         return;
-    }
-
-    bool any_waiter_matches = std::ranges::any_of(m_waiters, [&](const Kriya::EventAwaiter* w) {
-        return w->filter_matches(event);
-    });
-
-    if (!any_waiter_matches)
-        return;
-
-    m_pending_events.push(event);
 
     auto waiters = m_waiters;
-    for (auto* awaiter : waiters) {
-        awaiter->try_resume();
-    }
-}
-
-Kriya::EventAwaiter EventSource::next_event()
-{
-    return Kriya::EventAwaiter { *this, {} };
-}
-
-Kriya::EventAwaiter EventSource::await_event(Core::WindowEventType type)
-{
-    return Kriya::EventAwaiter { *this, type };
-}
-
-std::optional<Core::WindowEvent> EventSource::pop_event(const EventFilter& filter)
-{
-    if (m_pending_events.empty()) {
-        return std::nullopt;
-    }
-
-    if (!filter.event_type && !filter.key_code && !filter.button) {
-        auto event = m_pending_events.front();
-        m_pending_events.pop();
-        return event;
-    }
-
-    std::queue<Core::WindowEvent> temp_queue;
-    std::optional<Core::WindowEvent> result;
-
-    while (!m_pending_events.empty()) {
-        auto event = m_pending_events.front();
-        m_pending_events.pop();
-
-        bool matches = true;
-
-        if (filter.event_type && event.type != *filter.event_type) {
-            matches = false;
-        }
-
-        if (matches && filter.key_code) {
-            auto key_code = static_cast<int16_t>(*filter.key_code);
-            if (auto key_data = std::get_if<Core::WindowEvent::KeyData>(&event.data)) {
-                if (key_data->key != key_code) {
-                    matches = false;
-                }
-            } else {
-                matches = false;
-            }
-        }
-
-        if (matches && filter.button) {
-            auto button_code = static_cast<int>(*filter.button);
-            if (auto* button_data = std::get_if<Core::WindowEvent::MouseButtonData>(&event.data)) {
-                if (button_data->button != button_code) {
-                    matches = false;
-                }
-            } else {
-                matches = false;
-            }
-        }
-
-        if (matches && !result) {
-            result = event;
-        } else {
-            temp_queue.push(event);
-        }
-    }
-
-    m_pending_events = std::move(temp_queue);
-    return result;
+    for (auto* w : waiters)
+        w->try_resume(event);
 }
 
 void EventSource::register_waiter(Kriya::EventAwaiter* awaiter)
@@ -122,27 +22,8 @@ void EventSource::register_waiter(Kriya::EventAwaiter* awaiter)
 void EventSource::unregister_waiter(Kriya::EventAwaiter* awaiter)
 {
     auto it = std::ranges::find(m_waiters, awaiter);
-    if (it != m_waiters.end()) {
+    if (it != m_waiters.end())
         m_waiters.erase(it);
-    }
-}
-
-bool EventSource::is_key_pressed(IO::Keys key) const
-{
-    auto key_int = static_cast<int16_t>(key);
-    auto it = m_key_states.find(key_int);
-    return it != m_key_states.end() && it->second;
-}
-
-bool EventSource::is_mouse_pressed(int button) const
-{
-    auto it = m_button_states.find(button);
-    return it != m_button_states.end() && it->second;
-}
-
-std::pair<double, double> EventSource::get_mouse_position() const
-{
-    return { m_mouse_x, m_mouse_y };
 }
 
 } // namespace MayaFlux::Vruta

--- a/src/MayaFlux/Vruta/EventSource.hpp
+++ b/src/MayaFlux/Vruta/EventSource.hpp
@@ -1,62 +1,34 @@
 #pragma once
 
-#include "MayaFlux/Core/GlobalGraphicsInfo.hpp"
-
-#include "MayaFlux/IO/Keys.hpp"
-
-#include <queue>
-
 namespace MayaFlux::Kriya {
 class EventAwaiter;
 }
 
 namespace MayaFlux::Vruta {
 
-/**
- * @struct EventFilter
- * @brief Filter criteria for window events
- *
- * Used to filter events in the pending queue. Multiple criteria can be
- * combined to create specific filters (e.g., a specific key press).
- */
-struct MAYAFLUX_API EventFilter {
-    std::optional<Core::WindowEventType> event_type;
-    std::optional<IO::Keys> key_code; // For KEY_PRESSED/RELEASED filtering
-    std::optional<IO::MouseButtons> button; // For MOUSE_BUTTON_* filtering
-
-    EventFilter() = default;
-
-    /**
-     * @brief Constructs filter for specific event type
-     * @param type The window event type to filter
-     */
-    EventFilter(Core::WindowEventType type)
-        : event_type(type)
-    {
-    }
-
-    /**
-     * @brief Constructs filter for specific key event
-     * @param key The key to filter for
-     */
-    EventFilter(IO::Keys key)
-        : key_code(key)
-    {
-    }
-};
+// =============================================================================
+// EventSource - base
+// =============================================================================
 
 /**
  * @class EventSource
- * @brief Awaitable event stream for window events
+ * @brief Abstract base for all awaitable signal sources.
  *
- * Unlike clocks (SampleClock, FrameClock) which tick periodically,
- * EventSource is signaled when discrete window events occur.
- * Coroutines can suspend until events arrive.
+ * Manages the waiter list and dispatches to registered awaiters via the
+ * type-erased EventAwaiter interface. Has no knowledge of payload type,
+ * filter semantics, or threading model.
+ *
+ * Derived classes call dispatch() with a type-erased pointer to the current
+ * signal value. Each registered awaiter receives the pointer and decides
+ * independently whether to resume.
+ *
+ * @see WindowEventSource
+ * @see SignalSource
  */
 class MAYAFLUX_API EventSource {
 public:
     EventSource() = default;
-    ~EventSource() = default;
+    virtual ~EventSource() = default;
 
     EventSource(const EventSource&) = delete;
     EventSource& operator=(const EventSource&) = delete;
@@ -64,82 +36,48 @@ public:
     EventSource& operator=(EventSource&&) noexcept = default;
 
     /**
-     * @brief Signals that an event occurred
-     * @param event The event data
+     * @brief Returns true if any signals are buffered and not yet consumed.
+     */
+    [[nodiscard]] virtual bool has_pending() const = 0;
+
+    /**
+     * @brief Discards all buffered signals.
+     */
+    virtual void clear() = 0;
+
+protected:
+    /**
+     * @brief Iterates the waiter list, passing the type-erased signal to each.
      *
-     * Called by GLFW callbacks. Queues event and resumes waiting coroutines.
-     */
-    void signal(Core::WindowEvent event);
-
-    /**
-     * @brief Creates awaiter for next event (any type)
-     */
-    Kriya::EventAwaiter next_event();
-
-    /**
-     * @brief Creates awaiter for specific event type
-     */
-    Kriya::EventAwaiter await_event(Core::WindowEventType type);
-
-    /**
-     * @brief Checks if events are pending
-     */
-    [[nodiscard]] bool has_pending() const { return !m_pending_events.empty(); }
-
-    /**
-     * @brief Gets number of pending events
-     */
-    [[nodiscard]] size_t pending_count() const { return m_pending_events.size(); }
-
-    /**
-     * @brief Clears all pending events
-     */
-    void clear() { m_pending_events = {}; }
-
-    /**
-     * @brief Query if a specific key is currently pressed
-     * @param key The key to check
-     * @return True if key is currently pressed
-     */
-    [[nodiscard]] bool is_key_pressed(IO::Keys key) const;
-
-    /**
-     * @brief Query if a specific mouse button is currently pressed
-     * @param button Mouse button to check
-     * @return True if button is currently pressed
-     */
-    [[nodiscard]] bool is_mouse_pressed(int button) const;
-
-    /**
-     * @brief Get current mouse position
-     * @return Pair of (x, y) coordinates
-     */
-    [[nodiscard]] std::pair<double, double> get_mouse_position() const;
-
-private:
-    std::queue<Core::WindowEvent> m_pending_events;
-    std::vector<Kriya::EventAwaiter*> m_waiters;
-
-    std::unordered_map<int16_t, bool> m_key_states;
-    std::unordered_map<int, bool> m_button_states;
-    double m_mouse_x {};
-    double m_mouse_y {};
-
-    /**
-     * @brief Pop event matching filter from queue
-     * @param filter Filter criteria
-     * @return Event if found, nullopt otherwise
+     * Called by derived classes after committing a new signal value.
+     * Awaiters that match resume and unregister themselves.
      *
-     * Searches the queue for an event matching all filter criteria.
-     * Removes and returns the first matching event, preserving order
-     * of non-matching events.
+     * @param event Type-erased pointer to the current signal value.
      */
-    std::optional<Core::WindowEvent> pop_event(const EventFilter& filter);
+    void dispatch(const void* event);
 
     void register_waiter(Kriya::EventAwaiter* awaiter);
     void unregister_waiter(Kriya::EventAwaiter* awaiter);
 
+private:
+    std::vector<Kriya::EventAwaiter*> m_waiters;
+
     friend class Kriya::EventAwaiter;
 };
 
-}
+/**
+ * @class EventFilter
+ * @brief Base for event filters used by EventSources to match signals to awaiters.
+ *
+ * Concrete filter types (e.g. WindowEventFilter) derive from this and add
+ * specific criteria. EventSources use the base pointer to check if a filter is
+ * present and to pass it to awaiters, which then downcast as needed.
+ *
+ * @see WindowEventFilter
+ */
+class MAYAFLUX_API EventFilter {
+public:
+    virtual ~EventFilter() = default;
+};
+
+} // namespace MayaFlux::Vruta

--- a/src/MayaFlux/Vruta/NetworkSource.hpp
+++ b/src/MayaFlux/Vruta/NetworkSource.hpp
@@ -3,6 +3,8 @@
 #include "MayaFlux/Core/GlobalNetworkConfig.hpp"
 #include "MayaFlux/Transitive/Memory/RingBuffer.hpp"
 
+#include "MayaFlux/Vruta/EventSource.hpp"
+
 namespace MayaFlux::Kriya {
 class NetworkAwaiter;
 }
@@ -38,7 +40,7 @@ namespace MayaFlux::Vruta {
  * };
  * @endcode
  */
-class MAYAFLUX_API NetworkSource {
+class MAYAFLUX_API NetworkSource : public EventSource {
 public:
     /**
      * @brief Open a network endpoint and begin receiving
@@ -79,7 +81,7 @@ public:
     /**
      * @brief Check if messages are pending
      */
-    [[nodiscard]] bool has_pending() const;
+    [[nodiscard]] bool has_pending() const override;
 
     /**
      * @brief Get number of pending messages
@@ -89,7 +91,7 @@ public:
     /**
      * @brief Clear all pending messages
      */
-    void clear();
+    void clear() override;
 
 private:
     static constexpr size_t QUEUE_CAPACITY = 256;

--- a/src/MayaFlux/Vruta/WindowEventSource.cpp
+++ b/src/MayaFlux/Vruta/WindowEventSource.cpp
@@ -1,0 +1,111 @@
+#include "WindowEventSource.hpp"
+
+#include "MayaFlux/Kriya/Awaiters/EventAwaiter.hpp"
+
+namespace MayaFlux::Vruta {
+
+void WindowEventSource::signal(Core::WindowEvent event)
+{
+    if (auto* kd = std::get_if<Core::WindowEvent::KeyData>(&event.data)) {
+        if (event.type == Core::WindowEventType::KEY_PRESSED) {
+            m_key_states[kd->key] = true;
+        } else if (event.type == Core::WindowEventType::KEY_RELEASED) {
+            m_key_states[kd->key] = false;
+        }
+    }
+
+    if (auto* bd = std::get_if<Core::WindowEvent::MouseButtonData>(&event.data)) {
+        if (event.type == Core::WindowEventType::MOUSE_BUTTON_PRESSED) {
+            m_button_states[bd->button] = true;
+        } else if (event.type == Core::WindowEventType::MOUSE_BUTTON_RELEASED) {
+            m_button_states[bd->button] = false;
+        }
+    }
+
+    if (auto* pd = std::get_if<Core::WindowEvent::MousePosData>(&event.data)) {
+        m_mouse_x = pd->x;
+        m_mouse_y = pd->y;
+    }
+
+    m_pending_events.push(event);
+    dispatch(&event);
+}
+
+Kriya::WindowEventAwaiter WindowEventSource::next_event()
+{
+    return Kriya::WindowEventAwaiter { *this, {} };
+}
+
+Kriya::WindowEventAwaiter WindowEventSource::await_event(Core::WindowEventType type)
+{
+    return Kriya::WindowEventAwaiter { *this, type };
+}
+
+std::optional<Core::WindowEvent> WindowEventSource::pop_event(const WindowEventFilter& filter)
+{
+    if (m_pending_events.empty())
+        return std::nullopt;
+
+    if (!filter.event_type && !filter.key_code && !filter.button) {
+        auto ev = m_pending_events.front();
+        m_pending_events.pop();
+        return ev;
+    }
+
+    std::queue<Core::WindowEvent> tmp;
+    std::optional<Core::WindowEvent> result;
+
+    while (!m_pending_events.empty()) {
+        auto ev = m_pending_events.front();
+        m_pending_events.pop();
+
+        bool matches = true;
+
+        if (filter.event_type && ev.type != *filter.event_type)
+            matches = false;
+
+        if (matches && filter.key_code) {
+            if (auto* kd = std::get_if<Core::WindowEvent::KeyData>(&ev.data)) {
+                matches = kd->key == static_cast<int16_t>(*filter.key_code);
+            } else {
+                matches = false;
+            }
+        }
+
+        if (matches && filter.button) {
+            if (auto* bd = std::get_if<Core::WindowEvent::MouseButtonData>(&ev.data)) {
+                matches = bd->button == static_cast<int>(*filter.button);
+            } else {
+                matches = false;
+            }
+        }
+
+        if (matches && !result) {
+            result = ev;
+        } else {
+            tmp.push(ev);
+        }
+    }
+
+    m_pending_events = std::move(tmp);
+    return result;
+}
+
+bool WindowEventSource::is_key_pressed(IO::Keys key) const
+{
+    auto it = m_key_states.find(static_cast<int16_t>(key));
+    return it != m_key_states.end() && it->second;
+}
+
+bool WindowEventSource::is_mouse_pressed(int button) const
+{
+    auto it = m_button_states.find(button);
+    return it != m_button_states.end() && it->second;
+}
+
+std::pair<double, double> WindowEventSource::get_mouse_position() const
+{
+    return { m_mouse_x, m_mouse_y };
+}
+
+} // namespace MayaFlux::Vruta

--- a/src/MayaFlux/Vruta/WindowEventSource.hpp
+++ b/src/MayaFlux/Vruta/WindowEventSource.hpp
@@ -1,0 +1,135 @@
+#pragma once
+
+#include "EventSource.hpp"
+
+#include "MayaFlux/Core/GlobalGraphicsInfo.hpp"
+#include "MayaFlux/IO/Keys.hpp"
+
+#include <queue>
+
+namespace MayaFlux::Kriya {
+class WindowEventAwaiter;
+}
+
+namespace MayaFlux::Vruta {
+
+// =============================================================================
+// EventFilter
+// =============================================================================
+
+/**
+ * @struct WindowEventFilter
+ * @brief Filter criteria for GLFW window input events.
+ *
+ * Multiple criteria are ANDed. An empty filter matches any event.
+ */
+struct MAYAFLUX_API WindowEventFilter : public EventFilter {
+    std::optional<Core::WindowEventType> event_type;
+    std::optional<IO::Keys> key_code;
+    std::optional<IO::MouseButtons> button;
+
+    WindowEventFilter() = default;
+
+    /**
+     * @brief Constructs a filter matching a specific event type.
+     * @param type Event type to match.
+     */
+    WindowEventFilter(Core::WindowEventType type)
+        : event_type(type)
+    {
+    }
+
+    /**
+     * @brief Constructs a filter matching a specific key.
+     * @param key Key to match.
+     */
+    WindowEventFilter(IO::Keys key)
+        : key_code(key)
+    {
+    }
+};
+
+// =============================================================================
+// WindowEventSource
+// =============================================================================
+
+/**
+ * @class WindowEventSource
+ * @brief Awaitable stream of GLFW window input events.
+ *
+ * Signals are produced by GLFW callbacks on the main thread. Coroutines
+ * suspend via WindowEventAwaiter and are resumed synchronously from signal().
+ * Tracks input state for immediate polling via is_key_pressed(),
+ * is_mouse_pressed(), and get_mouse_position().
+ *
+ * @see EventSource
+ * @see WindowEventAwaiter
+ * @see EventFilter
+ */
+class MAYAFLUX_API WindowEventSource : public EventSource {
+public:
+    WindowEventSource() = default;
+    ~WindowEventSource() override = default;
+
+    WindowEventSource(const WindowEventSource&) = delete;
+    WindowEventSource& operator=(const WindowEventSource&) = delete;
+    WindowEventSource(WindowEventSource&&) noexcept = default;
+    WindowEventSource& operator=(WindowEventSource&&) noexcept = default;
+
+    /**
+     * @brief Enqueue a window event and resume matching waiters.
+     * @param event Event produced by the GLFW backend.
+     *
+     * Updates input state caches before dispatching.
+     */
+    void signal(Core::WindowEvent event);
+
+    /**
+     * @brief Creates an awaiter that resumes on the next event of any type.
+     */
+    Kriya::WindowEventAwaiter next_event();
+
+    /**
+     * @brief Creates an awaiter that resumes on the next event matching a type.
+     * @param type Event type to wait for.
+     */
+    Kriya::WindowEventAwaiter await_event(Core::WindowEventType type);
+
+    [[nodiscard]] bool has_pending() const override { return !m_pending_events.empty(); }
+    [[nodiscard]] size_t pending_count() const { return m_pending_events.size(); }
+    void clear() override { m_pending_events = {}; }
+
+    /**
+     * @brief Returns true if the given key is currently held.
+     * @param key Key to query.
+     */
+    [[nodiscard]] bool is_key_pressed(IO::Keys key) const;
+
+    /**
+     * @brief Returns true if the given mouse button is currently held.
+     * @param button Button index.
+     */
+    [[nodiscard]] bool is_mouse_pressed(int button) const;
+
+    /**
+     * @brief Returns the last known cursor position in screen coordinates.
+     */
+    [[nodiscard]] std::pair<double, double> get_mouse_position() const;
+
+private:
+    std::queue<Core::WindowEvent> m_pending_events;
+    std::unordered_map<int16_t, bool> m_key_states;
+    std::unordered_map<int, bool> m_button_states;
+    double m_mouse_x {};
+    double m_mouse_y {};
+
+    /**
+     * @brief Removes and returns the first pending event matching the filter.
+     * @param filter Filter criteria.
+     */
+    std::optional<Core::WindowEvent> pop_event(const WindowEventFilter& filter);
+
+    friend class Kriya::WindowEventAwaiter;
+};
+
+} // namespace MayaFlux::Vruta


### PR DESCRIPTION
Two problems motivated this work.

First, the coroutine scheduler had no general mechanism for bridging
callback-based producers into `co_await`-able consumers. Window events had
their own bespoke path. Network had its own. Any new source required
duplicating suspension/resumption mechanics from scratch.

Second, the engine's own audio output was opaque to everything above the
backend callback. There was no way to observe, inspect, record, or route
the mixed output without re-entering the RT thread or bypassing the
container system entirely.

Both problems share the same shape: a producer fires on some thread, a
coroutine needs to wake and consume. The solution builds the general
mechanism first, then uses it to expose audio output as a first-class
data source.

## Changes

### Event source abstraction (`Vruta`, `Kriya`, `Nexus`)

`EventSource`, `EventAwaiter`, and `EventFilter` become proper abstract
bases with type-erased payload dispatch via `void*`. Window events move
into concrete `WindowEventSource`, `WindowEventFilter`, and
`WindowEventAwaiter` classes that carry all GLFW payload types and filter
semantics. `NetworkSource` and `NetworkAwaiter` derive from the same bases
with no-op overrides for the dispatch path they don't use.

This gives every future event source a defined integration point: derive,
implement `dispatch()` or manage your own waiter list, and the coroutine
suspension machinery works without touching the scheduler.

**Breaking change**: anything using `EventFilter`, `EventSource`, or
`EventAwaiter` directly for window events must migrate to the
`WindowEventSource`/`Filter`/`Awaiter` classes.

### `BroadcastSource<T>` and `BroadcastAwaiter<T>` (`Vruta`)

A lock-free single-consumer awaitable channel. `signal()` delivers to a
suspended coroutine via `deliver()`, or stores a pending value for the
next `await_ready()` poll if no coroutine is waiting. The race window
between `await_ready()` returning false and `await_suspend()` completing
registration is closed by a generation counter - a signal that arrives in
that window leaves the pending slot non-null, which `await_suspend()`
checks after registration.

Callers must copy the `shared_ptr` into a coroutine-local variable before
`co_await` - the lambda closure lives on the caller's stack while the
coroutine frame is heap-allocated and outlives it. This is a known GCC 16
frame layout constraint documented in the class.

### `AudioBackendService` (`Registry`)

A plain `std::function` struct registered into `BackendRegistry` by
`AudioSubsystem` during `initialize()`. Exposes two consumption models:
snapshot polling (`get_output_snapshot`) for non-RT threads that want the
last committed buffer on demand, and per-cycle observer callbacks
(`register_output_observer` / `unregister_output_observer`) for consumers
that need to wake on every cycle. Follows the same pattern as
`NetworkService` and `InputService`.

### Notify thread and snapshot atomics (`AudioSubsystem`)

The RT audio callback now does three atomic stores and a `notify_all` -
nothing else. A dedicated notification thread wakes on
`m_snapshot_generation` (C++20 atomic wait) and fans out to registered
observers. Observer map is copy-on-write via `atomic<shared_ptr>` on
Linux/Windows; raw pointer with hazard pointers on macOS where Apple
Clang lacks `atomic<shared_ptr<T>>`.

`stop()` joins the notify thread cleanly by setting `m_notify_running`
false then doing a dummy `fetch_add` + `notify_all` on
`m_snapshot_generation` to guarantee the thread wakes and exits.

### `BroadcastEvents` (`Kriya`)

`on_signal` and `on_signal_matching` are coroutine factory functions that
loop on `co_await source->next()` and invoke a callback on each delivery.
They follow the `NetworkEvents` pattern: the source `shared_ptr` is a
function parameter, not a lambda capture, so it lives in the coroutine
frame and survives suspension. Promoted to the global API surface.

### `AudioOutputContainer` and `AudioOutputAccessProcessor` (`Kakshya`)

`AudioOutputContainer` is a `DynamicSoundStream` subclass. Every completed
output cycle is now a readable Kakshya container with the same region,
cursor, and consumer machinery used by file-backed and camera-backed
sources.

The data model inverts the usual stream container convention:

- `m_processed_data` holds the current cycle's snapshot, deinterleaved
  per-channel. One cycle, hot, available immediately after
  `process_default()` returns.
- `m_data` is the unbounded accumulating history. Grows by direct
  protected-member append each cycle. The write head is always
  `get_num_frames()`. Independent readers attach `CursorAccessProcessor`
  instances via `allocate_dynamic_slot()` and chase the write head at
  their own rate - the multi-reader machinery in `DynamicSoundStream`
  works without modification.

The backend snapshot is always interleaved regardless of backend.
Deinterleaving into `m_processed_data` is unconditional; the container's
organisation setting governs `m_data` layout for downstream readers.

`AudioOutputAccessProcessor` owns the `AudioBackendService` pointer - the
container has no registry coupling. It is registered as `friend` on
`AudioOutputContainer` for direct access to the protected members it
needs: `m_data_mutex`, `m_processed_data`, `m_data`, `m_num_frames`,
`setup_dimensions()`, `invalidate_span_cache()`.

`m_data` grows without bound. For sessions longer than a few minutes,
callers should use the inherited `enable_circular_buffer(capacity)` unless
full session capture is the intent.

### `audio_output_tick()` (`Kriya`)

A free function returning a `shared_ptr<BroadcastSource<bool>>` that
ticks once per output cycle. Observer registration and unregistration are
automatic - unregistration fires when the last owner drops the source via
aliased shared ownership of a private `State` struct. Registry and service
headers are confined to `BroadcastEvents.cpp` and do not appear in the
public header.

The full wiring from node graph to observable output data:

```cpp
auto ct = std::make_shared<Kakshya::AudioOutputContainer>(
    Config::get_global_stream_info());
ct->create_default_processor();

auto src = Kriya::audio_output_tick();
get_event_manager()->add_event(std::make_shared<Vruta::Event>(
    Kriya::on_signal(src, [ct](bool) {
        ct->process_default();
        auto vt = ct->get_processed_data();
        // per-channel vectors available here, one per output channel
    })));
```

## Out of scope

`SoundFileWriter` - FFmpeg encode, mux, SPSC drain queue, and worker
thread - is a distinct feature and will follow on a separate branch once
`AudioOutputContainer` has been exercised in production.