### PR TITLE
Audio file write infrastructure

### DIFF
--- a/src/MayaFlux/Core/Engine.cpp
+++ b/src/MayaFlux/Core/Engine.cpp
@@ -123,7 +123,7 @@ void Engine::Init(const GlobalStreamInfo& streamInfo, const GlobalGraphicsConfig
     m_node_graph_manager->set_node_config(m_node_config);
 
     m_io_manager = std::make_shared<IO::IOManager>(
-        m_stream_info.sample_rate, m_stream_info.buffer_size, m_graphics_config.target_frame_rate, m_buffer_manager);
+        m_stream_info, m_graphics_config.target_frame_rate, m_buffer_manager);
 
     if (m_graphics_config.windowing_backend != GlobalGraphicsConfig::WindowingBackend::NONE) {
         m_window_manager = std::make_shared<WindowManager>(m_graphics_config);

--- a/src/MayaFlux/IO/AudioEncodeContext.cpp
+++ b/src/MayaFlux/IO/AudioEncodeContext.cpp
@@ -1,0 +1,424 @@
+#include "AudioEncodeContext.hpp"
+#include "FFmpegDemuxContext.hpp"
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/audio_fifo.h>
+#include <libavutil/channel_layout.h>
+#include <libavutil/error.h>
+#include <libavutil/opt.h>
+#include <libavutil/samplefmt.h>
+#include <libswresample/swresample.h>
+}
+
+namespace MayaFlux::IO {
+
+// =========================================================================
+// Destructor
+// =========================================================================
+
+AudioEncodeContext::~AudioEncodeContext()
+{
+    close();
+}
+
+void AudioEncodeContext::close()
+{
+    if (fifo) {
+        av_audio_fifo_free(fifo);
+        fifo = nullptr;
+    }
+    if (swr_context) {
+        swr_free(&swr_context);
+        swr_context = nullptr;
+    }
+    if (codec_context) {
+        avcodec_free_context(&codec_context);
+        codec_context = nullptr;
+    }
+    stream = nullptr;
+    stream_index = -1;
+    sample_rate = 0;
+    channels = 0;
+    m_pts = 0;
+    m_last_error.clear();
+}
+
+// =========================================================================
+// Open
+// =========================================================================
+
+bool AudioEncodeContext::open(FFmpegMuxContext& mux,
+    uint32_t sample_rate,
+    uint32_t channels,
+    AVCodecID codec_id)
+{
+    close();
+    FFmpegDemuxContext::init_ffmpeg();
+
+    if (!mux.is_open()) {
+        m_last_error = "AudioEncodeContext::open called on unopened mux";
+        return false;
+    }
+
+    if (codec_id == AV_CODEC_ID_NONE)
+        codec_id = mux.format_context->oformat->audio_codec;
+
+    if (codec_id == AV_CODEC_ID_NONE) {
+        m_last_error = "container has no default audio codec";
+        return false;
+    }
+
+    const AVCodec* codec = avcodec_find_encoder(codec_id);
+    if (!codec) {
+        m_last_error = std::string("avcodec_find_encoder failed for codec ")
+            + avcodec_get_name(codec_id);
+        return false;
+    }
+
+    codec_context = avcodec_alloc_context3(codec);
+    if (!codec_context) {
+        m_last_error = "avcodec_alloc_context3 failed";
+        return false;
+    }
+
+    AVSampleFormat enc_fmt = AV_SAMPLE_FMT_FLTP;
+    {
+        const AVSampleFormat* fmts = nullptr;
+        int n_fmts = 0;
+        if (avcodec_get_supported_config(nullptr, codec, AV_CODEC_CONFIG_SAMPLE_FORMAT,
+                0, reinterpret_cast<const void**>(&fmts), &n_fmts)
+                >= 0
+            && fmts && n_fmts > 0) {
+            enc_fmt = fmts[0];
+            for (int i = 0; i < n_fmts; ++i) {
+                if (fmts[i] == AV_SAMPLE_FMT_S16) {
+                    enc_fmt = AV_SAMPLE_FMT_S16;
+                    break;
+                }
+                if (fmts[i] == AV_SAMPLE_FMT_FLTP) {
+                    enc_fmt = AV_SAMPLE_FMT_FLTP;
+                    break;
+                }
+            }
+        }
+    }
+
+    uint32_t enc_rate = sample_rate;
+    {
+        const int* rates = nullptr;
+        int n_rates = 0;
+        if (avcodec_get_supported_config(nullptr, codec, AV_CODEC_CONFIG_SAMPLE_RATE,
+                0, reinterpret_cast<const void**>(&rates), &n_rates)
+                >= 0
+            && rates && n_rates > 0) {
+            bool found = false;
+            for (int i = 0; i < n_rates; ++i) {
+                if (static_cast<uint32_t>(rates[i]) == sample_rate) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found)
+                enc_rate = static_cast<uint32_t>(rates[0]);
+        }
+    }
+
+    av_channel_layout_default(&codec_context->ch_layout,
+        static_cast<int>(channels));
+    codec_context->sample_rate = static_cast<int>(enc_rate);
+    codec_context->sample_fmt = enc_fmt;
+    codec_context->time_base = { .num = 1, .den = static_cast<int>(enc_rate) };
+
+    if (mux.format_context->oformat->flags & AVFMT_GLOBALHEADER)
+        codec_context->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+
+    if (avcodec_open2(codec_context, codec, nullptr) < 0) {
+        m_last_error = "avcodec_open2 failed";
+        close();
+        return false;
+    }
+
+    stream = mux.add_stream();
+    if (!stream) {
+        m_last_error = mux.last_error();
+        close();
+        return false;
+    }
+
+    if (avcodec_parameters_from_context(stream->codecpar, codec_context) < 0) {
+        m_last_error = "avcodec_parameters_from_context failed";
+        close();
+        return false;
+    }
+
+    stream->time_base = codec_context->time_base;
+    stream_index = stream->index;
+    sample_rate = enc_rate;
+    channels = channels;
+
+    if (!setup_resampler() || !setup_fifo()) {
+        close();
+        return false;
+    }
+
+    return true;
+}
+
+// =========================================================================
+// Resampler: AV_SAMPLE_FMT_DBL (interleaved) → encoder native format
+// =========================================================================
+
+bool AudioEncodeContext::setup_resampler()
+{
+    AVChannelLayout layout {};
+    av_channel_layout_default(&layout, static_cast<int>(channels));
+
+    int ret = swr_alloc_set_opts2(
+        &swr_context,
+        &layout, codec_context->sample_fmt, codec_context->sample_rate,
+        &layout, AV_SAMPLE_FMT_DBL, static_cast<int>(sample_rate),
+        0, nullptr);
+
+    av_channel_layout_uninit(&layout);
+
+    if (ret < 0 || !swr_context) {
+        m_last_error = "swr_alloc_set_opts2 failed";
+        return false;
+    }
+
+    if (swr_init(swr_context) < 0) {
+        m_last_error = "swr_init failed";
+        swr_free(&swr_context);
+        swr_context = nullptr;
+        return false;
+    }
+
+    return true;
+}
+
+// =========================================================================
+// FIFO: sized to two encoder frames so one encode_frames() call never stalls
+// =========================================================================
+
+bool AudioEncodeContext::setup_fifo()
+{
+    int frame_size = codec_context->frame_size > 0
+        ? codec_context->frame_size
+        : 4096;
+
+    fifo = av_audio_fifo_alloc(
+        codec_context->sample_fmt,
+        static_cast<int>(channels),
+        frame_size * 2);
+
+    if (!fifo) {
+        m_last_error = "av_audio_fifo_alloc failed";
+        return false;
+    }
+
+    return true;
+}
+
+// =========================================================================
+// Encoding
+// =========================================================================
+
+bool AudioEncodeContext::encode_frames(std::span<const double> interleaved,
+    uint32_t num_frames,
+    FFmpegMuxContext& mux)
+{
+    if (!is_valid())
+        return false;
+
+    uint8_t** conv = nullptr;
+    int linesize = 0;
+    int alloc = av_samples_alloc_array_and_samples(
+        &conv, &linesize,
+        static_cast<int>(channels),
+        static_cast<int>(num_frames),
+        codec_context->sample_fmt, 0);
+
+    if (alloc < 0 || !conv) {
+        m_last_error = "av_samples_alloc_array_and_samples failed during encode";
+        return false;
+    }
+
+    const auto* src = reinterpret_cast<const uint8_t*>(interleaved.data());
+    int converted = swr_convert(
+        swr_context,
+        conv, static_cast<int>(num_frames),
+        &src, static_cast<int>(num_frames));
+
+    if (converted < 0) {
+        av_freep(static_cast<void*>(&conv[0]));
+        av_freep(static_cast<void*>(&conv));
+        m_last_error = "swr_convert failed";
+        return false;
+    }
+
+    int written = av_audio_fifo_write(fifo,
+        reinterpret_cast<void**>(conv), converted);
+
+    av_freep(static_cast<void*>(&conv[0]));
+    av_freep(static_cast<void*>(&conv));
+
+    if (written < converted) {
+        m_last_error = "av_audio_fifo_write wrote fewer samples than expected";
+        return false;
+    }
+
+    int frame_size = codec_context->frame_size > 0
+        ? codec_context->frame_size
+        : av_audio_fifo_size(fifo);
+
+    while (av_audio_fifo_size(fifo) >= frame_size) {
+        if (!send_fifo_frame(mux, false))
+            return false;
+    }
+
+    return true;
+}
+
+// =========================================================================
+// Drain
+// =========================================================================
+
+bool AudioEncodeContext::drain(FFmpegMuxContext& mux)
+{
+    if (!is_valid())
+        return false;
+
+    while (av_audio_fifo_size(fifo) > 0) {
+        if (!send_fifo_frame(mux, true))
+            return false;
+    }
+
+    if (avcodec_send_frame(codec_context, nullptr) < 0) {
+        m_last_error = "avcodec_send_frame(null) failed during drain";
+        return false;
+    }
+
+    return drain_packets(mux);
+}
+
+// =========================================================================
+// Private helpers
+// =========================================================================
+
+bool AudioEncodeContext::send_fifo_frame(FFmpegMuxContext& mux, bool pad_to_frame_size)
+{
+    int frame_size = codec_context->frame_size > 0
+        ? codec_context->frame_size
+        : av_audio_fifo_size(fifo);
+
+    AVFrame* frame = av_frame_alloc();
+    if (!frame) {
+        m_last_error = "av_frame_alloc failed";
+        return false;
+    }
+
+    frame->nb_samples = frame_size;
+    frame->format = codec_context->sample_fmt;
+    frame->sample_rate = codec_context->sample_rate;
+    av_channel_layout_copy(&frame->ch_layout, &codec_context->ch_layout);
+
+    if (av_frame_get_buffer(frame, 0) < 0) {
+        m_last_error = "av_frame_get_buffer failed";
+        av_frame_free(&frame);
+        return false;
+    }
+
+    if (av_frame_make_writable(frame) < 0) {
+        m_last_error = "av_frame_make_writable failed";
+        av_frame_free(&frame);
+        return false;
+    }
+
+    int available = av_audio_fifo_size(fifo);
+    int to_read = std::min(available, frame_size);
+
+    int read = av_audio_fifo_read(fifo,
+        reinterpret_cast<void**>(frame->data), to_read);
+
+    if (read < to_read) {
+        m_last_error = "av_audio_fifo_read returned fewer samples than expected";
+        av_frame_free(&frame);
+        return false;
+    }
+
+    if (pad_to_frame_size && read < frame_size) {
+        int pad_samples = frame_size - read;
+        int bytes_per_sample = av_get_bytes_per_sample(codec_context->sample_fmt);
+        bool is_planar = av_sample_fmt_is_planar(codec_context->sample_fmt);
+        int planes = is_planar ? static_cast<int>(channels) : 1;
+        int samples_per_plane = is_planar ? pad_samples : pad_samples * static_cast<int>(channels);
+
+        for (int p = 0; p < planes; ++p) {
+            std::memset(
+                frame->data[p] + static_cast<ptrdiff_t>(read) * bytes_per_sample * (is_planar ? 1 : static_cast<int>(channels)),
+                0,
+                static_cast<size_t>(samples_per_plane) * static_cast<size_t>(bytes_per_sample));
+        }
+        frame->nb_samples = frame_size;
+    } else {
+        frame->nb_samples = read;
+    }
+
+    frame->pts = m_pts;
+    m_pts += frame->nb_samples;
+
+    int ret = avcodec_send_frame(codec_context, frame);
+    av_frame_free(&frame);
+
+    if (ret < 0) {
+        char errbuf[AV_ERROR_MAX_STRING_SIZE];
+        av_strerror(ret, errbuf, sizeof(errbuf));
+        m_last_error = std::string("avcodec_send_frame failed: ") + errbuf;
+        return false;
+    }
+
+    return drain_packets(mux);
+}
+
+bool AudioEncodeContext::drain_packets(FFmpegMuxContext& mux)
+{
+    AVPacket* pkt = av_packet_alloc();
+    if (!pkt) {
+        m_last_error = "av_packet_alloc failed";
+        return false;
+    }
+
+    bool ok = true;
+    while (true) {
+        int ret = avcodec_receive_packet(codec_context, pkt);
+        if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF)
+            break;
+        if (ret < 0) {
+            char errbuf[AV_ERROR_MAX_STRING_SIZE];
+            av_strerror(ret, errbuf, sizeof(errbuf));
+            m_last_error = std::string("avcodec_receive_packet failed: ") + errbuf;
+            ok = false;
+            break;
+        }
+
+        pkt->stream_index = stream_index;
+        av_packet_rescale_ts(pkt,
+            codec_context->time_base,
+            stream->time_base);
+
+        if (!mux.write_packet(pkt)) {
+            m_last_error = mux.last_error();
+            ok = false;
+            break;
+        }
+
+        av_packet_unref(pkt);
+    }
+
+    av_packet_free(&pkt);
+    return ok;
+}
+
+} // namespace MayaFlux::IO

--- a/src/MayaFlux/IO/AudioEncodeContext.cpp
+++ b/src/MayaFlux/IO/AudioEncodeContext.cpp
@@ -38,9 +38,9 @@ void AudioEncodeContext::close()
         codec_context = nullptr;
     }
     stream = nullptr;
-    stream_index = -1;
-    sample_rate = 0;
-    channels = 0;
+    m_stream_index = -1;
+    m_sample_rate = 0;
+    m_channels = 0;
     m_pts = 0;
     m_last_error.clear();
 }
@@ -154,9 +154,9 @@ bool AudioEncodeContext::open(FFmpegMuxContext& mux,
     }
 
     stream->time_base = codec_context->time_base;
-    stream_index = stream->index;
-    sample_rate = enc_rate;
-    channels = channels;
+    m_stream_index = stream->index;
+    m_sample_rate = enc_rate;
+    m_channels = channels;
 
     if (!setup_resampler() || !setup_fifo()) {
         close();
@@ -173,12 +173,12 @@ bool AudioEncodeContext::open(FFmpegMuxContext& mux,
 bool AudioEncodeContext::setup_resampler()
 {
     AVChannelLayout layout {};
-    av_channel_layout_default(&layout, static_cast<int>(channels));
+    av_channel_layout_default(&layout, static_cast<int>(m_channels));
 
     int ret = swr_alloc_set_opts2(
         &swr_context,
         &layout, codec_context->sample_fmt, codec_context->sample_rate,
-        &layout, AV_SAMPLE_FMT_DBL, static_cast<int>(sample_rate),
+        &layout, AV_SAMPLE_FMT_DBL, static_cast<int>(m_sample_rate),
         0, nullptr);
 
     av_channel_layout_uninit(&layout);
@@ -210,7 +210,7 @@ bool AudioEncodeContext::setup_fifo()
 
     fifo = av_audio_fifo_alloc(
         codec_context->sample_fmt,
-        static_cast<int>(channels),
+        static_cast<int>(m_channels),
         frame_size * 2);
 
     if (!fifo) {
@@ -236,7 +236,7 @@ bool AudioEncodeContext::encode_frames(std::span<const double> interleaved,
     int linesize = 0;
     int alloc = av_samples_alloc_array_and_samples(
         &conv, &linesize,
-        static_cast<int>(channels),
+        static_cast<int>(m_channels),
         static_cast<int>(num_frames),
         codec_context->sample_fmt, 0);
 
@@ -352,12 +352,12 @@ bool AudioEncodeContext::send_fifo_frame(FFmpegMuxContext& mux, bool pad_to_fram
         int pad_samples = frame_size - read;
         int bytes_per_sample = av_get_bytes_per_sample(codec_context->sample_fmt);
         bool is_planar = av_sample_fmt_is_planar(codec_context->sample_fmt);
-        int planes = is_planar ? static_cast<int>(channels) : 1;
-        int samples_per_plane = is_planar ? pad_samples : pad_samples * static_cast<int>(channels);
+        int planes = is_planar ? static_cast<int>(m_channels) : 1;
+        int samples_per_plane = is_planar ? pad_samples : pad_samples * static_cast<int>(m_channels);
 
         for (int p = 0; p < planes; ++p) {
             std::memset(
-                frame->data[p] + static_cast<ptrdiff_t>(read) * bytes_per_sample * (is_planar ? 1 : static_cast<int>(channels)),
+                frame->data[p] + static_cast<ptrdiff_t>(read) * bytes_per_sample * (is_planar ? 1 : static_cast<int>(m_channels)),
                 0,
                 static_cast<size_t>(samples_per_plane) * static_cast<size_t>(bytes_per_sample));
         }
@@ -403,7 +403,7 @@ bool AudioEncodeContext::drain_packets(FFmpegMuxContext& mux)
             break;
         }
 
-        pkt->stream_index = stream_index;
+        pkt->stream_index = m_stream_index;
         av_packet_rescale_ts(pkt,
             codec_context->time_base,
             stream->time_base);

--- a/src/MayaFlux/IO/AudioEncodeContext.hpp
+++ b/src/MayaFlux/IO/AudioEncodeContext.hpp
@@ -86,7 +86,7 @@ public:
      */
     [[nodiscard]] bool is_valid() const
     {
-        return codec_context && swr_context && fifo && stream_index >= 0;
+        return codec_context && swr_context && fifo && m_stream_index >= 0;
     }
 
     // =========================================================================
@@ -135,14 +135,14 @@ public:
     // Owned handles
     // =========================================================================
 
-    AVCodecContext* codec_context = nullptr; ///< Owned; freed in destructor.
-    SwrContext* swr_context = nullptr; ///< Owned; freed in destructor.
-    AVAudioFifo* fifo = nullptr; ///< Owned; freed in destructor.
-    AVStream* stream = nullptr; ///< Owned by mux; pointer cached here.
+    AVCodecContext* codec_context {}; ///< Owned; freed in destructor.
+    SwrContext* swr_context {}; ///< Owned; freed in destructor.
+    AVAudioFifo* fifo {}; ///< Owned; freed in destructor.
+    AVStream* stream {}; ///< Owned by mux; pointer cached here.
 
-    int stream_index = -1;
-    uint32_t sample_rate = 0;
-    uint32_t channels = 0;
+    int m_stream_index { -1 };
+    uint32_t m_sample_rate {};
+    uint32_t m_channels {};
 
 private:
     int64_t m_pts = 0;

--- a/src/MayaFlux/IO/AudioEncodeContext.hpp
+++ b/src/MayaFlux/IO/AudioEncodeContext.hpp
@@ -1,0 +1,167 @@
+#pragma once
+
+#include "FFmpegMuxContext.hpp"
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+struct AVAudioFifo;
+struct AVStream;
+struct SwrContext;
+}
+
+namespace MayaFlux::IO {
+
+/**
+ * @class AudioEncodeContext
+ * @brief RAII owner of one audio stream's encoder, resampler, and sample FIFO.
+ *
+ * Encapsulates all audio-stream-specific FFmpeg objects on the write path:
+ * - AVCodecContext for the selected or inferred encoder
+ * - SwrContext converting AV_SAMPLE_FMT_DBL (engine canonical) to the encoder's
+ *   native sample format
+ * - AVAudioFifo absorbing arbitrary-size input chunks and emitting fixed-size
+ *   frames required by block-aligned encoders (AAC: 1024, Vorbis: variable)
+ * - AVStream registered inside the supplied FFmpegMuxContext
+ *
+ * Does NOT own AVFormatContext — that belongs to FFmpegMuxContext.
+ *
+ * Destruction order (enforced in destructor):
+ *   fifo → swr_context → codec_context
+ * The associated FFmpegMuxContext must outlive this object.
+ *
+ * Open sequence:
+ *   1. FFmpegMuxContext::open()
+ *   2. AudioEncodeContext::open()      ← adds stream, configures codec+swr+fifo
+ *   3. FFmpegMuxContext::write_header()
+ *   4. encode_frames() loop
+ *   5. drain()                         ← flushes fifo remainder + encoder delay
+ *   6. FFmpegMuxContext::close()       ← writes trailer
+ */
+class MAYAFLUX_API AudioEncodeContext {
+public:
+    AudioEncodeContext() = default;
+    ~AudioEncodeContext();
+
+    AudioEncodeContext(const AudioEncodeContext&) = delete;
+    AudioEncodeContext& operator=(const AudioEncodeContext&) = delete;
+    AudioEncodeContext(AudioEncodeContext&&) = delete;
+    AudioEncodeContext& operator=(AudioEncodeContext&&) = delete;
+
+    // =========================================================================
+    // Lifecycle
+    // =========================================================================
+
+    /**
+     * @brief Open the encoder and register an audio stream in the mux context.
+     *
+     * Selects the encoder: if codec_id is AV_CODEC_ID_NONE the container's
+     * default audio codec is used (WAV → PCM_S16LE, MP4/MKV → AAC,
+     * OGG → Vorbis, FLAC → FLAC). Allocates and opens AVCodecContext,
+     * copies parameters to the new AVStream, initialises SwrContext
+     * (AV_SAMPLE_FMT_DBL → encoder native format), and allocates AVAudioFifo
+     * sized to two encoder frames.
+     *
+     * Must be called after FFmpegMuxContext::open() and before
+     * FFmpegMuxContext::write_header().
+     *
+     * @param mux         Open mux context that will own the output stream.
+     * @param sample_rate PCM sample rate in Hz.
+     * @param channels    Number of interleaved channels.
+     * @param codec_id    Encoder override; AV_CODEC_ID_NONE = container default.
+     * @return True on success; false sets the internal error string.
+     */
+    bool open(FFmpegMuxContext& mux,
+        uint32_t sample_rate,
+        uint32_t channels,
+        AVCodecID codec_id);
+
+    /**
+     * @brief Release all owned resources.
+     *        Safe to call multiple times or on a context that never opened.
+     */
+    void close();
+
+    /**
+     * @brief True if codec, resampler, and FIFO are all ready.
+     */
+    [[nodiscard]] bool is_valid() const
+    {
+        return codec_context && swr_context && fifo && stream_index >= 0;
+    }
+
+    // =========================================================================
+    // Encoding
+    // =========================================================================
+
+    /**
+     * @brief Encode a block of interleaved double-precision PCM frames.
+     *
+     * Converts input via SwrContext, writes converted samples into the FIFO,
+     * then drains the FIFO in encoder-frame-sized chunks. For encoders with
+     * frame_size == 0 (PCM, some raw formats) the entire FIFO content is
+     * submitted as one frame per call.
+     *
+     * Non-blocking: returns false only on a hard encode error, not on FIFO
+     * underrun. Safe to call with any number of frames per call.
+     *
+     * @param interleaved Interleaved samples in double precision.
+     * @param num_frames  Number of PCM frames (samples / channels).
+     * @param mux         Mux context to receive encoded packets.
+     * @return True on success.
+     */
+    bool encode_frames(std::span<const double> interleaved,
+        uint32_t num_frames,
+        FFmpegMuxContext& mux);
+
+    /**
+     * @brief Flush the FIFO remainder and encoder internal delay to the mux.
+     *
+     * Pads the final partial FIFO frame with silence if needed, sends it,
+     * then sends a null frame to signal EOS to the encoder and drains all
+     * buffered output packets. Call once before FFmpegMuxContext::close().
+     *
+     * @param mux Mux context to receive remaining packets.
+     * @return True if all remaining packets were written successfully.
+     */
+    bool drain(FFmpegMuxContext& mux);
+
+    // =========================================================================
+    // Error
+    // =========================================================================
+
+    [[nodiscard]] const std::string& last_error() const { return m_last_error; }
+
+    // =========================================================================
+    // Owned handles
+    // =========================================================================
+
+    AVCodecContext* codec_context = nullptr; ///< Owned; freed in destructor.
+    SwrContext* swr_context = nullptr; ///< Owned; freed in destructor.
+    AVAudioFifo* fifo = nullptr; ///< Owned; freed in destructor.
+    AVStream* stream = nullptr; ///< Owned by mux; pointer cached here.
+
+    int stream_index = -1;
+    uint32_t sample_rate = 0;
+    uint32_t channels = 0;
+
+private:
+    int64_t m_pts = 0;
+    std::string m_last_error;
+
+    bool setup_resampler();
+    bool setup_fifo();
+
+    /**
+     * @brief Pull one frame from the FIFO and send it to the encoder.
+     *        If the FIFO has fewer samples than frame_size, pads with silence.
+     *        Drains all output packets into the mux after sending.
+     */
+    bool send_fifo_frame(FFmpegMuxContext& mux, bool pad_to_frame_size);
+
+    /**
+     * @brief Drain all packets currently available from the encoder into mux.
+     */
+    bool drain_packets(FFmpegMuxContext& mux);
+};
+
+} // namespace MayaFlux::IO

--- a/src/MayaFlux/IO/EXRWriter.cpp
+++ b/src/MayaFlux/IO/EXRWriter.cpp
@@ -1,5 +1,7 @@
 #include "EXRWriter.hpp"
 
+#include "FileWriter.hpp"
+
 #include "MayaFlux/Journal/Archivist.hpp"
 
 #include <tinyexr.h>
@@ -23,7 +25,8 @@ namespace {
 
     bool flush_to_disk(const std::string& filepath, const unsigned char* bytes, size_t size)
     {
-        std::ofstream out(filepath, std::ios::binary | std::ios::trunc);
+        const auto resolved = resolve_write_path(filepath);
+        std::ofstream out(resolved, std::ios::binary | std::ios::trunc);
         if (!out.is_open()) {
             return false;
         }

--- a/src/MayaFlux/IO/FFmpegMuxContext.cpp
+++ b/src/MayaFlux/IO/FFmpegMuxContext.cpp
@@ -1,0 +1,138 @@
+#include "FFmpegMuxContext.hpp"
+#include "FFmpegDemuxContext.hpp"
+
+extern "C" {
+#include <libavformat/avformat.h>
+#include <libavutil/error.h>
+}
+
+namespace MayaFlux::IO {
+
+// =========================================================================
+// Destructor
+// =========================================================================
+
+FFmpegMuxContext::~FFmpegMuxContext()
+{
+    close();
+}
+
+// =========================================================================
+// Lifecycle
+// =========================================================================
+
+bool FFmpegMuxContext::open(const std::string& filepath,
+    const std::string& explicit_format)
+{
+    close();
+    FFmpegDemuxContext::init_ffmpeg();
+
+    const char* fmt = explicit_format.empty() ? nullptr : explicit_format.c_str();
+
+    int ret = avformat_alloc_output_context2(
+        &format_context, nullptr, fmt, filepath.c_str());
+
+    if (ret < 0 || !format_context) {
+        char errbuf[AV_ERROR_MAX_STRING_SIZE];
+        av_strerror(ret, errbuf, sizeof(errbuf));
+        m_last_error = "avformat_alloc_output_context2 failed for \""
+            + filepath + "\": " + errbuf;
+        return false;
+    }
+
+    if (!(format_context->oformat->flags & AVFMT_NOFILE)) {
+        ret = avio_open(&format_context->pb, filepath.c_str(), AVIO_FLAG_WRITE);
+        if (ret < 0) {
+            char errbuf[AV_ERROR_MAX_STRING_SIZE];
+            av_strerror(ret, errbuf, sizeof(errbuf));
+            m_last_error = "avio_open failed for \""
+                + filepath + "\": " + errbuf;
+            avformat_free_context(format_context);
+            format_context = nullptr;
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void FFmpegMuxContext::close()
+{
+    if (!format_context)
+        return;
+
+    if (m_header_written) {
+        av_write_trailer(format_context);
+        m_header_written = false;
+    }
+
+    if (format_context->pb && !(format_context->oformat->flags & AVFMT_NOFILE))
+        avio_closep(&format_context->pb);
+
+    avformat_free_context(format_context);
+    format_context = nullptr;
+    m_last_error.clear();
+}
+
+// =========================================================================
+// Stream registration
+// =========================================================================
+
+AVStream* FFmpegMuxContext::add_stream()
+{
+    if (!format_context) {
+        m_last_error = "add_stream called on unopened context";
+        return nullptr;
+    }
+    AVStream* st = avformat_new_stream(format_context, nullptr);
+    if (!st)
+        m_last_error = "avformat_new_stream failed";
+    return st;
+}
+
+// =========================================================================
+// Header / packet writing
+// =========================================================================
+
+bool FFmpegMuxContext::write_header()
+{
+    if (!format_context) {
+        m_last_error = "write_header called on unopened context";
+        return false;
+    }
+    if (m_header_written) {
+        m_last_error = "write_header called more than once";
+        return false;
+    }
+
+    int ret = avformat_write_header(format_context, nullptr);
+    if (ret < 0) {
+        char errbuf[AV_ERROR_MAX_STRING_SIZE];
+        av_strerror(ret, errbuf, sizeof(errbuf));
+        m_last_error = std::string("avformat_write_header failed: ") + errbuf;
+        return false;
+    }
+
+    m_header_written = true;
+    return true;
+}
+
+bool FFmpegMuxContext::write_packet(AVPacket* pkt)
+{
+    if (!format_context || !m_header_written) {
+        m_last_error = "write_packet called before header was written";
+        return false;
+    }
+
+    int ret = av_interleaved_write_frame(format_context, pkt);
+    if (ret < 0) {
+        char errbuf[AV_ERROR_MAX_STRING_SIZE];
+        av_strerror(ret, errbuf, sizeof(errbuf));
+        m_last_error = std::string("av_interleaved_write_frame failed: ") + errbuf;
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace MayaFlux::IO

--- a/src/MayaFlux/IO/FFmpegMuxContext.cpp
+++ b/src/MayaFlux/IO/FFmpegMuxContext.cpp
@@ -1,6 +1,8 @@
 #include "FFmpegMuxContext.hpp"
 #include "FFmpegDemuxContext.hpp"
 
+#include "FileWriter.hpp"
+
 extern "C" {
 #include <libavformat/avformat.h>
 #include <libavutil/error.h>
@@ -29,24 +31,26 @@ bool FFmpegMuxContext::open(const std::string& filepath,
 
     const char* fmt = explicit_format.empty() ? nullptr : explicit_format.c_str();
 
+    const auto resolved = resolve_write_path(filepath);
+
     int ret = avformat_alloc_output_context2(
-        &format_context, nullptr, fmt, filepath.c_str());
+        &format_context, nullptr, fmt, resolved.c_str());
 
     if (ret < 0 || !format_context) {
         char errbuf[AV_ERROR_MAX_STRING_SIZE];
         av_strerror(ret, errbuf, sizeof(errbuf));
         m_last_error = "avformat_alloc_output_context2 failed for \""
-            + filepath + "\": " + errbuf;
+            + resolved + "\": " + errbuf;
         return false;
     }
 
     if (!(format_context->oformat->flags & AVFMT_NOFILE)) {
-        ret = avio_open(&format_context->pb, filepath.c_str(), AVIO_FLAG_WRITE);
+        ret = avio_open(&format_context->pb, resolved.c_str(), AVIO_FLAG_WRITE);
         if (ret < 0) {
             char errbuf[AV_ERROR_MAX_STRING_SIZE];
             av_strerror(ret, errbuf, sizeof(errbuf));
             m_last_error = "avio_open failed for \""
-                + filepath + "\": " + errbuf;
+                + resolved + "\": " + errbuf;
             avformat_free_context(format_context);
             format_context = nullptr;
             return false;

--- a/src/MayaFlux/IO/FFmpegMuxContext.hpp
+++ b/src/MayaFlux/IO/FFmpegMuxContext.hpp
@@ -1,0 +1,151 @@
+#pragma once
+
+extern "C" {
+struct AVFormatContext;
+struct AVStream;
+struct AVPacket;
+}
+
+namespace MayaFlux::IO {
+
+/**
+ * @class FFmpegMuxContext
+ * @brief RAII owner of a single AVFormatContext on the write path.
+ *
+ * Encapsulates all format-level (container) FFmpeg mux operations:
+ * - Allocating an output context and opening the I/O layer (avio)
+ * - Writing the container header after all streams have been added
+ * - Writing interleaved encoded packets
+ * - Writing the container trailer and releasing all resources
+ *
+ * Does NOT own any codec context, resampler, scaler, or stream — those are
+ * domain-specific and belong to AudioEncodeContext / VideoEncodeContext, which
+ * each call avformat_new_stream() on this context during their own open().
+ *
+ * Stream contexts must be opened and fully configured before write_header()
+ * is called. Packets submitted via write_packet() must have stream_index and
+ * PTS/DTS set by the originating encode context.
+ *
+ * Not copyable or movable; always stack- or member-allocated inside the owner
+ * (SoundFileWriter worker thread, future VideoFileWriter worker thread).
+ *
+ * FFmpeg global initialisation is shared with FFmpegDemuxContext via the
+ * static FFmpegDemuxContext::init_ffmpeg() call.
+ */
+class MAYAFLUX_API FFmpegMuxContext {
+public:
+    FFmpegMuxContext() = default;
+    ~FFmpegMuxContext();
+
+    FFmpegMuxContext(const FFmpegMuxContext&) = delete;
+    FFmpegMuxContext& operator=(const FFmpegMuxContext&) = delete;
+    FFmpegMuxContext(FFmpegMuxContext&&) = delete;
+    FFmpegMuxContext& operator=(FFmpegMuxContext&&) = delete;
+
+    // =========================================================================
+    // Lifecycle
+    // =========================================================================
+
+    /**
+     * @brief Allocate an output context and open the avio layer for writing.
+     *
+     * Format is inferred from the filepath extension via
+     * avformat_alloc_output_context2. Pass explicit_format to override
+     * (e.g. "matroska" to force MKV regardless of extension).
+     *
+     * Does NOT write any data to disk. Call write_header() after all stream
+     * contexts have been opened on this mux context.
+     *
+     * @param filepath        Output file path. Extension determines container.
+     * @param explicit_format FFmpeg short format name override; empty = infer.
+     * @return True on success; false sets the internal error string.
+     */
+    bool open(const std::string& filepath,
+        const std::string& explicit_format = {});
+
+    /**
+     * @brief Write the container trailer, flush avio, and release all resources.
+     *
+     * av_write_trailer is called only if write_header() previously succeeded.
+     * Safe to call multiple times or on a context that was never successfully
+     * opened.
+     */
+    void close();
+
+    /**
+     * @brief True if the context is open and ready to accept streams / packets.
+     */
+    [[nodiscard]] bool is_open() const { return format_context != nullptr; }
+
+    /**
+     * @brief True if write_header() completed successfully.
+     *
+     * Encode contexts may use this to assert sequencing: packets must not be
+     * submitted before the header is written.
+     */
+    [[nodiscard]] bool is_header_written() const { return m_header_written; }
+
+    // =========================================================================
+    // Stream registration
+    // =========================================================================
+
+    /**
+     * @brief Allocate a new AVStream inside this context.
+     *
+     * Called by AudioEncodeContext::open() and VideoEncodeContext::open()
+     * to add their respective streams before write_header().
+     *
+     * @return Pointer to the new AVStream, or nullptr on failure.
+     */
+    [[nodiscard]] AVStream* add_stream();
+
+    // =========================================================================
+    // Header / packet writing
+    // =========================================================================
+
+    /**
+     * @brief Write the container header to the output file.
+     *
+     * Must be called after all stream contexts (audio, video, subtitle, etc.)
+     * have been opened and have set their codec parameters on their AVStream.
+     * Exactly one call is valid per open(); calling twice is an error.
+     *
+     * @return True on success.
+     */
+    bool write_header();
+
+    /**
+     * @brief Submit one encoded packet for interleaved writing.
+     *
+     * Uses av_interleaved_write_frame, which buffers packets internally to
+     * preserve correct interleaving order for containers that require it
+     * (MP4, MKV). For single-stream audio-only containers (WAV, FLAC) this
+     * is equivalent to av_write_frame.
+     *
+     * The packet's stream_index, PTS, DTS, and duration must be set by the
+     * calling encode context before this call. Ownership of the packet data
+     * is transferred to FFmpeg; the caller must not reference pkt after return.
+     *
+     * @param pkt Encoded packet with all fields populated.
+     * @return True on success.
+     */
+    bool write_packet(AVPacket* pkt);
+
+    // =========================================================================
+    // Error
+    // =========================================================================
+
+    [[nodiscard]] const std::string& last_error() const { return m_last_error; }
+
+    // =========================================================================
+    // Raw handle — accessible to encode contexts for stream setup
+    // =========================================================================
+
+    AVFormatContext* format_context = nullptr; ///< Owned; freed in close().
+
+private:
+    bool m_header_written {};
+    std::string m_last_error;
+};
+
+} // namespace MayaFlux::IO

--- a/src/MayaFlux/IO/FileWriter.hpp
+++ b/src/MayaFlux/IO/FileWriter.hpp
@@ -23,6 +23,28 @@ inline FileWriteOptions operator&(FileWriteOptions a, FileWriteOptions b)
 }
 
 /**
+ * @brief Anchor a relative output path to Config::SOURCE_DIR.
+ *
+ * Absolute paths are returned unchanged. Relative paths are prefixed
+ * with Config::SOURCE_DIR so output files land in the project source
+ * tree rather than the binary CWD (which varies by platform and IDE).
+ *
+ * @param filepath Path as supplied by the caller.
+ * @return Resolved path string.
+ */
+[[nodiscard]] inline std::string resolve_write_path(const std::string& filepath)
+{
+    namespace fs = std::filesystem;
+    auto normalized = std::string(filepath);
+    std::ranges::replace(normalized, '\\', '/');
+
+    if (fs::path(normalized).is_absolute())
+        return normalized;
+
+    return (fs::path(Config::SOURCE_DIR) / normalized).string();
+}
+
+/**
  * @class FileWriter
  * @brief Abstract base class for file writing operations
  *

--- a/src/MayaFlux/IO/IOManager.cpp
+++ b/src/MayaFlux/IO/IOManager.cpp
@@ -47,9 +47,8 @@ namespace {
 
 }
 
-IOManager::IOManager(uint64_t sample_rate, uint32_t buffer_size, uint32_t frame_rate, const std::shared_ptr<Buffers::BufferManager>& buffer_manager)
-    : m_sample_rate(sample_rate)
-    , m_buffer_size(buffer_size)
+IOManager::IOManager(Core::GlobalStreamInfo& stream_info, uint32_t frame_rate, const std::shared_ptr<Buffers::BufferManager>& buffer_manager)
+    : m_stream_info(stream_info)
     , m_frame_rate(frame_rate)
     , m_buffer_manager(buffer_manager)
 {
@@ -121,7 +120,7 @@ IOManager::load_video(const std::string& filepath, LoadConfig config)
     reader->set_target_dimensions(config.target_width, config.target_height);
 
     if ((config.video_options & VideoReadOptions::EXTRACT_AUDIO) == VideoReadOptions::EXTRACT_AUDIO) {
-        reader->set_target_sample_rate(m_sample_rate);
+        reader->set_target_sample_rate(m_stream_info.sample_rate);
     }
 
     if (!reader->open(filepath, config.file_options)) {
@@ -248,7 +247,7 @@ std::shared_ptr<Kakshya::SoundFileContainer> IOManager::load_audio(const std::st
         return nullptr;
     }
 
-    reader->set_target_sample_rate(m_sample_rate);
+    reader->set_target_sample_rate(m_stream_info.sample_rate);
     reader->set_audio_options(config.audio_options);
 
     if (!reader->open(filepath, config.file_options)) {
@@ -288,7 +287,7 @@ std::shared_ptr<Kakshya::DynamicSoundStream> IOManager::load_audio_bounded(
         return nullptr;
     }
 
-    reader->set_target_sample_rate(m_sample_rate);
+    reader->set_target_sample_rate(m_stream_info.sample_rate);
 
     auto stream = reader->load_bounded(filepath, max_frames, truncate);
     if (!stream) {
@@ -480,7 +479,7 @@ void IOManager::configure_audio_processor(
     container->set_memory_layout(Kakshya::MemoryLayout::ROW_MAJOR);
 
     const std::vector<uint64_t> output_shape = {
-        m_buffer_size,
+        m_stream_info.buffer_size,
         container->get_num_channels()
     };
 

--- a/src/MayaFlux/IO/IOManager.cpp
+++ b/src/MayaFlux/IO/IOManager.cpp
@@ -7,6 +7,7 @@
 
 #include "MayaFlux/Kakshya/Processors/ContiguousAccessProcessor.hpp"
 #include "MayaFlux/Kakshya/Processors/FrameAccessProcessor.hpp"
+#include "MayaFlux/Kakshya/Source/AudioOutputContainer.hpp"
 #include "MayaFlux/Kakshya/Source/CameraContainer.hpp"
 #include "MayaFlux/Kakshya/Source/SoundFileContainer.hpp"
 #include "MayaFlux/Kakshya/Source/VideoFileContainer.hpp"
@@ -19,6 +20,7 @@
 #include "MayaFlux/Buffers/Textures/TextBuffer.hpp"
 
 #include "MayaFlux/Registry/BackendRegistry.hpp"
+#include "MayaFlux/Registry/Service/AudioBackendService.hpp"
 #include "MayaFlux/Registry/Service/IOService.hpp"
 
 #include "EXRWriter.hpp"
@@ -74,6 +76,25 @@ IOManager::IOManager(Core::GlobalStreamInfo& stream_info, uint32_t frame_rate, c
 
 IOManager::~IOManager()
 {
+    {
+        std::vector<uint32_t> ids;
+        {
+            std::lock_guard lock(m_captures_mutex);
+            ids.reserve(m_captures.size());
+            for (const auto& [id, _] : m_captures)
+                ids.push_back(id);
+        }
+        for (auto id : ids)
+            stop_capture(id);
+    }
+
+    for (auto& w : m_writers) {
+        if (w->is_open()) {
+            auto fut = w->close();
+            fut.wait();
+        }
+    }
+
     Registry::BackendRegistry::instance()
         .unregister_service<Registry::Service::IOService>();
 
@@ -301,6 +322,141 @@ std::shared_ptr<Kakshya::DynamicSoundStream> IOManager::load_audio_bounded(
     m_audio_readers.push_back(std::move(reader));
 
     return stream;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+
+std::shared_ptr<SoundFileWriter>
+IOManager::create_writer(const std::string& filepath,
+    uint32_t channels,
+    uint32_t sample_rate,
+    AVCodecID codec_id)
+{
+    auto writer = std::make_shared<SoundFileWriter>();
+    if (!writer->open(filepath, channels, sample_rate, codec_id)) {
+        MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+            "create_writer: open failed for '{}': {}", filepath, writer->last_error());
+        return nullptr;
+    }
+
+    {
+        std::lock_guard lock(m_save_tasks_mutex);
+        m_writers.push_back(writer);
+    }
+    return writer;
+}
+
+void IOManager::write(const std::shared_ptr<Kakshya::SoundStreamContainer>& container,
+    const std::string& filepath,
+    AVCodecID codec_id)
+{
+    if (!container) {
+        MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+            "write: null container");
+        return;
+    }
+
+    auto writer = std::make_shared<SoundFileWriter>();
+    if (!writer->open(filepath,
+            container->get_num_channels(),
+            container->get_sample_rate(),
+            codec_id)) {
+        MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+            "write: open failed for '{}': {}", filepath, writer->last_error());
+        return;
+    }
+
+    writer->write(container->get_data());
+    auto fut = writer->close();
+
+    std::lock_guard lock(m_save_tasks_mutex);
+    m_save_tasks.push_back(std::move(fut));
+    std::erase_if(m_save_tasks, [](std::future<bool>& f) {
+        return f.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
+    });
+}
+
+uint32_t IOManager::capture_output(const std::string& filepath, AVCodecID codec_id)
+{
+
+    if (!m_audio_backend_service) {
+        m_audio_backend_service = Registry::BackendRegistry::instance()
+                                      .get_service<Registry::Service::AudioBackendService>();
+    }
+
+    if (!m_audio_backend_service) {
+        error<std::runtime_error>(Journal::Component::IO, Journal::Context::FileIO, std::source_location::current(),
+            "capture_output: AudioBackendService unavailable");
+    }
+
+    auto ct = std::make_shared<Kakshya::AudioOutputContainer>(m_stream_info);
+    ct->create_default_processor();
+
+    auto writer = std::make_shared<SoundFileWriter>();
+    if (!writer->open(filepath,
+            m_stream_info.output.channels,
+            m_stream_info.sample_rate,
+            codec_id)) {
+        MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+            "capture_output: writer open failed for '{}': {}", filepath, writer->last_error());
+        return 0;
+    }
+
+    uint32_t obs_id = m_audio_backend_service->register_output_observer(
+        [ct, writer](const double*, uint32_t) {
+            ct->process_default();
+            const auto& vt = ct->get_processed_data();
+            if (!vt.empty())
+                writer->write(vt);
+        });
+
+    {
+        std::lock_guard lock(m_save_tasks_mutex);
+        m_writers.push_back(writer);
+    }
+
+    std::lock_guard lock(m_captures_mutex);
+    m_captures.emplace(obs_id, CaptureState { .container = ct, .writer = writer, .observer_id = obs_id });
+    return obs_id;
+}
+
+void IOManager::stop_capture(uint32_t capture_id)
+{
+    CaptureState state;
+    {
+        std::lock_guard lock(m_captures_mutex);
+        auto it = m_captures.find(capture_id);
+        if (it == m_captures.end()) {
+            MF_WARN(Journal::Component::IO, Journal::Context::FileIO,
+                "stop_capture: unknown capture_id={}", capture_id);
+            return;
+        }
+        state = std::move(it->second);
+        m_captures.erase(it);
+    }
+
+    auto* svc = Registry::BackendRegistry::instance()
+                    .get_service<Registry::Service::AudioBackendService>();
+    if (svc)
+        svc->unregister_output_observer(state.observer_id);
+
+    auto fut = state.writer->close();
+
+    std::lock_guard lock(m_save_tasks_mutex);
+    m_save_tasks.push_back(std::move(fut));
+    std::erase_if(m_save_tasks, [](std::future<bool>& f) {
+        return f.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
+    });
+}
+
+std::vector<uint32_t> IOManager::get_capture_ids() const
+{
+    std::lock_guard lock(m_captures_mutex);
+    std::vector<uint32_t> ids;
+    ids.reserve(m_captures.size());
+    for (const auto& [id, _] : m_captures)
+        ids.push_back(id);
+    return ids;
 }
 
 std::shared_ptr<Kakshya::CameraContainer>

--- a/src/MayaFlux/IO/IOManager.hpp
+++ b/src/MayaFlux/IO/IOManager.hpp
@@ -8,6 +8,7 @@
 
 namespace MayaFlux::Core {
 class VKImage;
+struct GlobalStreamInfo;
 }
 
 namespace MayaFlux::Nodes::Network {
@@ -96,7 +97,7 @@ public:
      * Must be constructed before any VideoFileReader::load_into_container() call
      * that should participate in managed dispatch.
      */
-    IOManager(uint64_t sample_rate, uint32_t buffer_size, uint32_t frame_rate, const std::shared_ptr<Buffers::BufferManager>& buffer_manager);
+    IOManager(Core::GlobalStreamInfo& stream_info, uint32_t frame_rate, const std::shared_ptr<Buffers::BufferManager>& buffer_manager);
 
     /**
      * @brief Unregisters IOService, releases all owned readers, clears stored buffers.
@@ -484,10 +485,7 @@ public:
     [[nodiscard]] std::vector<std::shared_ptr<ModelReader>> get_model_readers() const { return m_model_readers; };
 
 private:
-    uint64_t m_sample_rate;
-
-    uint32_t m_buffer_size;
-
+    Core::GlobalStreamInfo& m_stream_info;
     uint32_t m_frame_rate;
 
     /**

--- a/src/MayaFlux/IO/IOManager.hpp
+++ b/src/MayaFlux/IO/IOManager.hpp
@@ -2,6 +2,7 @@
 
 #include "CameraReader.hpp"
 #include "ImageWriter.hpp"
+#include "SoundFileWriter.hpp"
 #include "VideoFileReader.hpp"
 
 #include <future>
@@ -20,6 +21,7 @@ class SignalSourceContainer;
 class VideoFileContainer;
 class SoundFileContainer;
 class CameraContainer;
+class AudioOutputContainer;
 }
 
 namespace MayaFlux::Buffers {
@@ -33,6 +35,7 @@ class BufferManager;
 
 namespace MayaFlux::Registry::Service {
 class IOService;
+class AudioBackendService;
 }
 
 namespace MayaFlux::IO {
@@ -212,6 +215,71 @@ public:
         const std::string& filepath,
         uint64_t max_frames = 0,
         bool truncate = false);
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Audio — write
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * @brief Construct an open SoundFileWriter the caller drives manually.
+     *
+     * Allocates, opens, and returns a writer ready to accept write() calls.
+     * IOManager does not track this writer; the caller is responsible for
+     * calling close() when done.
+     *
+     * @param filepath    Output file path. Extension determines container format.
+     * @param channels    Number of channels in all submitted data.
+     * @param sample_rate PCM sample rate in Hz.
+     * @param codec_id    Encoder override; AV_CODEC_ID_NONE = container default.
+     * @return Open SoundFileWriter, or nullptr if open() failed.
+     */
+    [[nodiscard]] std::shared_ptr<SoundFileWriter>
+    create_writer(const std::string& filepath,
+        uint32_t channels,
+        uint32_t sample_rate = 48000,
+        AVCodecID codec_id = AV_CODEC_ID_NONE);
+
+    /**
+     * @brief Write a SoundStreamContainer to file in one shot.
+     *
+     * Opens a writer, posts the container's full data, closes, and stores
+     * the encode future in m_save_tasks. Non-blocking; returns immediately.
+     * Container metadata (sample_rate, channels) drives the encoder parameters.
+     *
+     * @param container Source container; any SoundStreamContainer child.
+     * @param filepath  Output file path.
+     * @param codec_id  Encoder override; AV_CODEC_ID_NONE = container default.
+     */
+    void write(const std::shared_ptr<Kakshya::SoundStreamContainer>& container,
+        const std::string& filepath,
+        AVCodecID codec_id = AV_CODEC_ID_NONE);
+
+    /**
+     * @brief Begin continuous capture of live audio output to a file.
+     *
+     * Registers an observer with AudioBackendService. Each output cycle the
+     * observer drives an AudioOutputContainer and posts its processed_data
+     * to a SoundFileWriter. Returns an opaque capture id for use with
+     * stop_capture().
+     *
+     * Returns 0 and logs an error if AudioBackendService is unavailable.
+     *
+     * @param filepath    Output file path.
+     * @param codec_id    Encoder override; AV_CODEC_ID_NONE = container default.
+     * @return Capture handle; pass to stop_capture() to finalise.
+     */
+    [[nodiscard]] uint32_t capture_output(const std::string& filepath,
+        AVCodecID codec_id = AV_CODEC_ID_NONE);
+
+    /**
+     * @brief Stop a running capture and finalise the file.
+     *
+     * Unregisters the AudioBackendService observer, calls writer->close(),
+     * and stores the encode future in m_save_tasks. Non-blocking.
+     *
+     * @param capture_id Handle returned by capture_output().
+     */
+    void stop_capture(uint32_t capture_id);
 
     // ─────────────────────────────────────────────────────────────────────────
     // Audio — hook
@@ -484,6 +552,16 @@ public:
      */
     [[nodiscard]] std::vector<std::shared_ptr<ModelReader>> get_model_readers() const { return m_model_readers; };
 
+    /**
+     * @brief Returns all active capture IDs.
+     */
+    [[nodiscard]] std::vector<uint32_t> get_capture_ids() const;
+
+    /**
+     * @brief Returns all registered SoundFileWriters created via create_writer() or write().
+     */
+    [[nodiscard]] std::vector<std::shared_ptr<SoundFileWriter>> get_sound_writers() const { return m_writers; };
+
 private:
     Core::GlobalStreamInfo& m_stream_info;
     uint32_t m_frame_rate;
@@ -506,6 +584,17 @@ private:
     void configure_audio_processor(
         const std::shared_ptr<Kakshya::SoundFileContainer>& container);
 
+    // ── Audio capture ──────────────────────────────────────────────────────
+
+    struct CaptureState {
+        std::shared_ptr<Kakshya::AudioOutputContainer> container;
+        std::shared_ptr<SoundFileWriter> writer;
+        uint32_t observer_id {};
+    };
+
+    mutable std::mutex m_captures_mutex;
+    std::unordered_map<uint32_t, CaptureState> m_captures;
+
     // ── readers ──────────────────────────────────────────────────────
 
     std::atomic<uint64_t> m_next_reader_id { 1 };
@@ -519,6 +608,8 @@ private:
     std::vector<std::shared_ptr<ImageReader>> m_image_readers;
 
     std::vector<std::shared_ptr<ModelReader>> m_model_readers;
+
+    std::vector<std::shared_ptr<SoundFileWriter>> m_writers;
 
     // ── Stored buffers ─────────────────────────────────────────────────────
 
@@ -551,6 +642,7 @@ private:
     // ── IOService ──────────────────────────────────────────────────────────
 
     std::shared_ptr<Registry::Service::IOService> m_io_service;
+    Registry::Service::AudioBackendService* m_audio_backend_service {};
 };
 
 } // namespace MayaFlux::IO

--- a/src/MayaFlux/IO/STBImageWriter.cpp
+++ b/src/MayaFlux/IO/STBImageWriter.cpp
@@ -1,5 +1,7 @@
 #include "STBImageWriter.hpp"
 
+#include "FileWriter.hpp"
+
 #include "MayaFlux/Journal/Archivist.hpp"
 
 #define STB_IMAGE_WRITE_IMPLEMENTATION
@@ -45,7 +47,8 @@ namespace {
      */
     bool flush_to_disk(const std::string& filepath, const std::vector<uint8_t>& buffer)
     {
-        std::ofstream out(filepath, std::ios::binary | std::ios::trunc);
+        const auto resolved = resolve_write_path(filepath);
+        std::ofstream out(resolved, std::ios::binary | std::ios::trunc);
         if (!out.is_open()) {
             return false;
         }

--- a/src/MayaFlux/IO/SoundFileWriter.cpp
+++ b/src/MayaFlux/IO/SoundFileWriter.cpp
@@ -1,0 +1,247 @@
+#include "SoundFileWriter.hpp"
+
+#include "AudioEncodeContext.hpp"
+#include "FFmpegMuxContext.hpp"
+
+#include "MayaFlux/Buffers/AudioBuffer.hpp"
+#include "MayaFlux/Journal/Archivist.hpp"
+#include "MayaFlux/Kakshya/Source/SoundStreamContainer.hpp"
+extern "C" {
+#include <libavcodec/avcodec.h>
+}
+
+#include <chrono>
+#include <cstddef>
+
+namespace MayaFlux::IO {
+
+// =========================================================================
+// Constructor / destructor
+// =========================================================================
+
+SoundFileWriter::SoundFileWriter()
+    : m_queue(std::make_unique<Memory::LockFreeQueue<WorkItem, k_queue_capacity>>())
+{
+}
+
+SoundFileWriter::~SoundFileWriter()
+{
+    if (m_open.load(std::memory_order_acquire) && !m_closing.exchange(true)) {
+        auto fut = close();
+        if (fut.wait_for(std::chrono::seconds(5)) == std::future_status::timeout) {
+            MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+                "SoundFileWriter destructor timed out; worker detached, file may be incomplete");
+            m_worker.detach();
+            return;
+        }
+    }
+    if (m_worker.joinable())
+        m_worker.join();
+}
+
+// =========================================================================
+// Lifecycle
+// =========================================================================
+
+bool SoundFileWriter::open(const std::string& filepath,
+    uint32_t channels,
+    uint32_t sample_rate,
+    AVCodecID explicit_codec)
+{
+    if (m_open.load(std::memory_order_acquire)) {
+        set_error("open() called while already open");
+        return false;
+    }
+
+    m_channels = channels;
+    m_close_promise = std::promise<bool> {};
+    m_closing.store(false, std::memory_order_release);
+
+    m_worker = std::thread(&SoundFileWriter::worker_loop, this,
+        filepath, channels, sample_rate, explicit_codec);
+
+    constexpr int k_spin_ms = 500;
+    constexpr int k_sleep_us = 500;
+    for (int i = 0; i < (k_spin_ms * 1000 / k_sleep_us); ++i) {
+        if (m_open.load(std::memory_order_acquire))
+            return true;
+        std::this_thread::sleep_for(std::chrono::microseconds(k_sleep_us));
+    }
+
+    if (m_worker.joinable())
+        m_worker.join();
+    return false;
+}
+
+std::future<bool> SoundFileWriter::close()
+{
+    if (!m_closing.exchange(true)) {
+        post(CloseCmd {});
+    }
+    return m_close_promise.get_future();
+}
+
+// =========================================================================
+// Write — interleaved doubles
+// =========================================================================
+
+void SoundFileWriter::write(std::span<const double> interleaved, uint32_t num_frames)
+{
+    if (!m_open.load(std::memory_order_acquire) || interleaved.empty())
+        return;
+
+    uint32_t frames = num_frames > 0
+        ? num_frames
+        : static_cast<uint32_t>(interleaved.size() / (m_channels > 0 ? m_channels : 1));
+
+    post(FrameChunk {
+        .samples = std::vector<double>(interleaved.begin(), interleaved.end()),
+        .num_frames = frames });
+}
+
+void SoundFileWriter::write(const std::vector<Kakshya::DataVariant>& planar)
+{
+    if (!m_open.load(std::memory_order_acquire) || planar.empty())
+        return;
+
+    const auto& ch0 = std::get<std::vector<double>>(planar[0]);
+    auto frames = static_cast<uint32_t>(ch0.size());
+    if (frames == 0)
+        return;
+
+    PlanarChunk chunk;
+    chunk.num_frames = frames;
+    chunk.channels.reserve(planar.size());
+    for (const auto& v : planar)
+        chunk.channels.push_back(std::get<std::vector<double>>(v));
+
+    post(std::move(chunk));
+}
+
+void SoundFileWriter::write(const std::shared_ptr<Buffers::AudioBuffer>& buffer)
+{
+    if (!m_open.load(std::memory_order_acquire) || !buffer)
+        return;
+
+    const auto& data = buffer->get_data();
+    if (data.empty())
+        return;
+
+    post(FrameChunk { .samples = data, .num_frames = static_cast<uint32_t>(data.size()) });
+}
+
+void SoundFileWriter::write(const std::shared_ptr<Kakshya::SoundStreamContainer>& container)
+{
+    if (!m_open.load(std::memory_order_acquire) || !container)
+        return;
+
+    const auto& data = container->get_data();
+    if (data.empty())
+        return;
+
+    write(data);
+}
+
+// =========================================================================
+// Error
+// =========================================================================
+
+std::string SoundFileWriter::last_error() const
+{
+    std::lock_guard lock(m_error_mutex);
+    return m_last_error;
+}
+
+void SoundFileWriter::set_error(std::string msg)
+{
+    std::lock_guard lock(m_error_mutex);
+    m_last_error = std::move(msg);
+}
+
+// =========================================================================
+// Internal helpers
+// =========================================================================
+
+bool SoundFileWriter::post(const WorkItem& item)
+{
+    return m_queue->push(item);
+}
+
+// =========================================================================
+// Worker loop
+// =========================================================================
+
+void SoundFileWriter::worker_loop(const std::string& filepath,
+    uint32_t channels,
+    uint32_t sample_rate,
+    AVCodecID codec_id)
+{
+    FFmpegMuxContext mux;
+    AudioEncodeContext enc;
+
+    auto fail = [&](std::string msg) {
+        set_error(std::move(msg));
+        m_open.store(false, std::memory_order_release);
+        m_close_promise.set_value(false);
+    };
+
+    if (!mux.open(filepath)) {
+        fail(mux.last_error());
+        return;
+    }
+
+    if (!enc.open(mux, sample_rate, channels, codec_id)) {
+        fail(enc.last_error());
+        return;
+    }
+
+    if (!mux.write_header()) {
+        fail(mux.last_error());
+        return;
+    }
+
+    m_open.store(true, std::memory_order_release);
+
+    bool ok = true;
+
+    while (true) {
+        auto item = m_queue->pop();
+        if (!item) {
+            std::this_thread::yield();
+            continue;
+        }
+
+        if (std::holds_alternative<FrameChunk>(*item)) {
+            auto& fc = std::get<FrameChunk>(*item);
+            if (!enc.encode_frames(std::span<const double>(fc.samples), fc.num_frames, mux)) {
+                set_error(enc.last_error());
+                ok = false;
+            }
+        } else if (std::holds_alternative<PlanarChunk>(*item)) {
+            auto& pc = std::get<PlanarChunk>(*item);
+            const auto ch = static_cast<uint32_t>(pc.channels.size());
+            std::vector<double> interleaved(static_cast<size_t>(pc.num_frames) * ch);
+
+            for (uint32_t f = 0; f < pc.num_frames; ++f) {
+                for (uint32_t c = 0; c < ch; ++c)
+                    interleaved[(size_t)f * ch + c] = pc.channels[c][f];
+            }
+
+            if (!enc.encode_frames(interleaved, pc.num_frames, mux)) {
+                set_error(enc.last_error());
+                ok = false;
+            }
+        } else {
+            if (ok && !enc.drain(mux)) {
+                set_error(enc.last_error());
+                ok = false;
+            }
+            mux.close();
+            m_open.store(false, std::memory_order_release);
+            m_close_promise.set_value(ok);
+            return;
+        }
+    }
+}
+
+} // namespace MayaFlux::IO

--- a/src/MayaFlux/IO/SoundFileWriter.hpp
+++ b/src/MayaFlux/IO/SoundFileWriter.hpp
@@ -1,0 +1,189 @@
+#pragma once
+
+#include "MayaFlux/Kakshya/NDData/NDData.hpp"
+#include "MayaFlux/Transitive/Memory/RingBuffer.hpp"
+
+#include <future>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+}
+
+namespace MayaFlux::Buffers {
+class AudioBuffer;
+}
+
+namespace MayaFlux::Kakshya {
+class SoundStreamContainer;
+}
+
+namespace MayaFlux::IO {
+
+/**
+ * @class SoundFileWriter
+ * @brief Asynchronous audio file encoder with a lock-free work queue.
+ *
+ * Accepts audio from multiple source types and encodes it to a file on a
+ * dedicated worker thread. The public API is fully non-blocking: every write
+ * call posts a work item to an SPSC queue and returns immediately. The worker
+ * thread owns all FFmpeg state and is the only thread that touches it.
+ *
+ * Supported input paths:
+ * - Raw interleaved double frames (span or vector, for RT/coroutine callers)
+ * - AudioBuffer          — drains get_data() as interleaved doubles
+ * - SoundStreamContainer — drains get_data_as_double() (interleaved span)
+ *
+ * Threading model:
+ *   Caller thread  →  push work items to m_queue (lock-free)
+ *   Worker thread  →  drain queue, encode via AudioEncodeContext + FFmpegMuxContext
+ *
+ * Lifetime:
+ *   open() spawns the worker. close() posts a CloseCmd and returns a
+ *   future<bool> the caller may wait on. The destructor issues close() if
+ *   still open and joins with a 5-second timeout; on timeout it detaches and
+ *   logs CRITICAL.
+ *
+ * Error handling:
+ *   Encode errors set last_error() and cause the worker to post false to the
+ *   close promise. Subsequent write calls after an encode error are silently
+ *   dropped (is_open() returns false).
+ */
+class MAYAFLUX_API SoundFileWriter {
+public:
+    SoundFileWriter();
+    ~SoundFileWriter();
+
+    SoundFileWriter(const SoundFileWriter&) = delete;
+    SoundFileWriter& operator=(const SoundFileWriter&) = delete;
+    SoundFileWriter(SoundFileWriter&&) = delete;
+    SoundFileWriter& operator=(SoundFileWriter&&) = delete;
+
+    // =========================================================================
+    // Lifecycle
+    // =========================================================================
+
+    /**
+     * @brief Open the output file and spawn the worker thread.
+     *
+     * Format is inferred from the filepath extension (wav, flac, ogg, mp4, mkv…).
+     * Pass explicit_codec to override the container's default audio codec.
+     *
+     * @param filepath       Destination file path. Extension determines container.
+     * @param channels       Number of interleaved channels in all submitted data.
+     * @param sample_rate    PCM sample rate in Hz.
+     * @param explicit_codec Encoder override; AV_CODEC_ID_NONE = container default.
+     * @return True if the worker started successfully.
+     */
+    bool open(const std::string& filepath,
+        uint32_t channels,
+        uint32_t sample_rate,
+        AVCodecID explicit_codec);
+
+    /**
+     * @brief Post a close command to the worker.
+     *
+     * The worker drains the FIFO, flushes the encoder, writes the container
+     * trailer, and fulfils the returned future. The caller may co_await or
+     * .get() the future, or discard it if completion is not needed.
+     *
+     * Safe to call multiple times; subsequent calls return a future that is
+     * immediately ready with false.
+     *
+     * @return future<bool>: true = file complete; false = encode error.
+     */
+    std::future<bool> close();
+
+    /**
+     * @brief True if the worker is running and the encoder is healthy.
+     */
+    [[nodiscard]] bool is_open() const { return m_open.load(std::memory_order_acquire); }
+
+    // =========================================================================
+    // Write
+    // =========================================================================
+
+    /**
+     * @brief Post interleaved double-precision frames to the work queue.
+     *
+     * @param interleaved Interleaved PCM frames in double precision.
+     * @param num_frames  Frame count (samples / channels). If 0, inferred as
+     *                    interleaved.size() / channels.
+     */
+    void write(std::span<const double> interleaved, uint32_t num_frames = 0);
+
+    /**
+     * @brief Post planar per-channel data to the work queue.
+     *
+     * Accepts the DataVariant vector directly from AudioOutputContainer::get_processed_data().
+     * Interleaving is deferred to the worker thread.
+     *
+     * @param planar Per-channel vectors; each element must be vector<double>.
+     */
+    void write(const std::vector<Kakshya::DataVariant>& planar);
+
+    /**
+     * @brief Post one AudioBuffer's mono sample data to the work queue.
+     */
+    void write(const std::shared_ptr<Buffers::AudioBuffer>& buffer);
+
+    /**
+     * @brief Post a SoundStreamContainer's planar channel data to the work queue.
+     *
+     * Reads get_data() on the caller thread, copies, and posts as PlanarChunk.
+     */
+    void write(const std::shared_ptr<Kakshya::SoundStreamContainer>& container);
+
+    // =========================================================================
+    // Error
+    // =========================================================================
+
+    [[nodiscard]] std::string last_error() const;
+
+private:
+    // -------------------------------------------------------------------------
+    // Work item types
+    // -------------------------------------------------------------------------
+
+    struct FrameChunk {
+        std::vector<double> samples;
+        uint32_t num_frames;
+    };
+
+    struct PlanarChunk {
+        std::vector<std::vector<double>> channels;
+        uint32_t num_frames;
+    };
+
+    struct CloseCmd { };
+
+    using WorkItem = std::variant<FrameChunk, PlanarChunk, CloseCmd>;
+
+    // -------------------------------------------------------------------------
+    // Queue
+    // -------------------------------------------------------------------------
+
+    static constexpr size_t k_queue_capacity = 4096;
+    std::unique_ptr<Memory::LockFreeQueue<WorkItem, k_queue_capacity>> m_queue;
+
+    // -------------------------------------------------------------------------
+    // Worker
+    // -------------------------------------------------------------------------
+
+    std::thread m_worker;
+    std::atomic<bool> m_open { false };
+    std::atomic<bool> m_closing { false };
+    std::promise<bool> m_close_promise;
+
+    mutable std::mutex m_error_mutex;
+    std::string m_last_error;
+
+    uint32_t m_channels {};
+
+    void worker_loop(const std::string& filepath, uint32_t channels, uint32_t sample_rate,
+        AVCodecID codec_id);
+
+    void set_error(std::string msg);
+    bool post(const WorkItem& item);
+};
+
+} // namespace MayaFlux::IO


### PR DESCRIPTION
MayaFlux's signal graph including node networks, granular pipelines, buffer captures, and live output can now write its results directly to disk without routing through external tools or screen capture.

The write infrastructure mirrors the read side structurally. `FFmpegMuxContext` owns the output `AVFormatContext` the same way `FFmpegDemuxContext` owns the input one. `AudioEncodeContext` owns `AVCodecContext`, `SwrContext`, and `AVAudioFifo` on the encode path, mirroring `AudioStreamContext` on the decode path. The conversion direction is reversed: the engine's canonical `AV_SAMPLE_FMT_DBL` goes in, the encoder's native format comes out. An `AVAudioFifo` absorbs arbitrary buffer sizes and feeds block-aligned encoders like AAC (1024 samples per frame) without the caller needing to know or care.

`SoundFileWriter` sits on top of these two contexts and exposes a fully non-blocking API. All write calls copy their input and post a work item to a lock-free SPSC queue. A dedicated worker thread owns the FFmpeg contexts and is the only thread that touches them. Four write overloads cover every data shape the framework uses:

```cpp
// From a coroutine, RT-safe
writer->write(std::span<const double> interleaved);

// Directly from AudioOutputContainer::get_processed_data()
writer->write(const std::vector<Kakshya::DataVariant>& planar);

// From a BufferPipeline capture result or any AudioBuffer
writer->write(const std::shared_ptr<Buffers::AudioBuffer>& buffer);

// From any SoundStreamContainer child: SoundFileContainer,
// DynamicSoundStream, AudioOutputContainer
writer->write(const std::shared_ptr<Kakshya::SoundStreamContainer>& container);
```

Planar data is interleaved on the worker thread, not the caller thread. `close()` returns a `std::future<bool>` the caller may wait on or discard.

---

### IOManager integration

Three write operations are added to `IOManager`, following the existing load/hook/retrieve pattern.

**`capture_output`** records the live engine output continuously. It registers an `AudioBackendService` observer, drives an `AudioOutputContainer` each cycle, and posts the processed planar data to a `SoundFileWriter`. This is one line at the call site:

```cpp
auto id = get_io_manager()->capture_output("session.flac");

// ... later
get_io_manager()->stop_capture(id);
```

The capture id is stored in `m_captures` alongside the container and writer. `stop_capture` unregisters the observer and finalises the file. The destructor stops all active captures and joins all open writers before unregistering the IOService, so there are no dangling FFmpeg contexts on shutdown.

**`write`** is the one-shot path for any `SoundStreamContainer`. Sample rate and channel count are read from the container itself. The encode future is stored in `m_save_tasks` alongside image write futures, so `wait_for_pending_saves` covers everything:

```cpp
// After a granular reconstruction
auto result = Yantra::Granular::process_to_container(source, AnalysisType::FEATURE, config);
get_io_manager()->write(result, "reconstructed.wav");

// After a BufferPipeline accumulation session
get_io_manager()->write(my_dynamic_stream, "session_take.flac");
```

**`create_writer`** returns a writer the caller owns and drives manually. This is the right path when the write boundary is not known at open time, for example inside a `BufferPipeline` branch or a coroutine that conditionally captures:

```cpp
auto writer = get_io_manager()->create_writer("take.flac",
    Config::get_num_out_channels(),
    Config::get_sample_rate());

// In a coroutine or pipeline branch
writer->write(some_container);
writer->write(some_other_container);
auto done = writer->close();
```

All writers created via `create_writer` are stored in `m_writers`. `get_sound_writers()` returns the full list including writers created by `capture_output`.

---

### Format

Format is entirely determined by the filepath extension. No code changes are needed to switch formats:

```cpp
capture_output("out.flac");   // FLAC
capture_output("out.wav");    // WAV, PCM S16LE
capture_output("out.ogg");    // OGG Vorbis
capture_output("out.mp4");    // MP4, AAC
```

The codec can be overridden explicitly via `AVCodecID` on any of the three IOManager methods and on `SoundFileWriter::open` directly.

---

### Path resolution

Relative paths are now anchored to `Config::SOURCE_DIR` rather than the binary CWD, which varies by platform and IDE on Windows. `resolve_write_path` is a free function in `FileWriter.hpp`, mirroring `FileReader::resolve_path` on the read side. It is applied in `FFmpegMuxContext::open`, `STBImageWriter::flush_to_disk`, and `EXRWriter::flush_to_disk`, fixing the same latent bug for image writes as well.

---

### Video write path

`FFmpegMuxContext::write_packet` is stream-index agnostic. `add_stream` can be called any number of times before `write_header`. A future `VideoEncodeContext` owning `AVCodecContext` and `SwsContext` on the encode path (RGBA to YUV420P via `sws_scale`) plugs into the same mux layer without any changes to it. A `VideoFileWriter` following the same worker thread pattern as `SoundFileWriter` then becomes the natural next step.

---

### Concrete workflows now possible

**Record a live performance to disk:**
```cpp
auto id = get_io_manager()->capture_output("performance.flac");
// ... engine runs
get_io_manager()->stop_capture(id);
```

**Granular resynthesis to file:**
```cpp
auto source = get_io_manager()->load_audio("input.wav");
auto result = Yantra::Granular::process_to_container(
    source, AnalysisType::SPECTRAL, { .grain_size = 2048 });
get_io_manager()->write(result, "resynthesised.flac");
```

**BufferPipeline capture to file:**
```cpp
auto writer = get_io_manager()->create_writer("capture.wav", 2, 48000);
pipeline >> BufferOperation::capture_input(mgr, 0)
         >> BufferOperation::transform(my_transform);
pipeline.on_complete([writer] {
    writer->write(accumulated_stream);
    writer->close();
});
```

**Async granular with immediate disk write on completion:**
```cpp
Yantra::Granular::process_to_container_async(matrix, source,
    AnalysisType::FEATURE, [](auto container) {
        get_io_manager()->write(container, "grain_result.flac");
    }, config);
```
