### PR TITLE
Kriya: graphics thread routing for temporal primitives

### DIFF
--- a/src/MayaFlux/API/Chronie.cpp
+++ b/src/MayaFlux/API/Chronie.cpp
@@ -46,14 +46,16 @@ void schedule_metro(double interval_seconds, std::function<void()> callback, std
     get_scheduler()->add_task(std::move(metronome), name, false);
 }
 
-void schedule_sequence(std::vector<std::pair<double, std::function<void()>>> seq, std::string name)
+void schedule_sequence(std::vector<std::pair<double, std::function<void()>>> seq, std::string name, Vruta::ProcessingToken token)
 {
     auto scheduler = get_scheduler();
     if (name.empty()) {
         name = "seq_" + std::to_string(scheduler->get_next_task_id());
     }
-    auto tseq = std::make_shared<Vruta::SoundRoutine>(Kriya::sequence(*get_scheduler(), std::move(seq)));
-    get_scheduler()->add_task(std::move(tseq), name, false);
+
+    auto tseq = Kriya::sequence(std::move(seq), token);
+
+    get_scheduler()->add_task(tseq, name, false);
 }
 
 Vruta::SoundRoutine create_line(float start_value, float end_value, float duration_seconds, uint32_t step_duration, bool retain)

--- a/src/MayaFlux/API/Chronie.cpp
+++ b/src/MayaFlux/API/Chronie.cpp
@@ -35,15 +35,15 @@ bool update_task_params(const std::string& name, Args... args)
     return get_scheduler()->update_task_params(name, args...);
 }
 
-void schedule_metro(double interval_seconds, std::function<void()> callback, std::string name)
+void schedule_metro(double interval_seconds, std::function<void()> callback, std::string name, Vruta::ProcessingToken token)
 {
     auto scheduler = get_scheduler();
     if (name.empty()) {
         name = "metro_" + std::to_string(scheduler->get_next_task_id());
     }
-    auto metronome = std::make_shared<Vruta::SoundRoutine>(Kriya::metro(*get_scheduler(), interval_seconds, std::move(callback)));
+    auto metronome = Kriya::metro(interval_seconds, std::move(callback), token);
 
-    get_scheduler()->add_task(std::move(metronome), name, false);
+    get_scheduler()->add_task(metronome, name, false);
 }
 
 void schedule_sequence(std::vector<std::pair<double, std::function<void()>>> seq, std::string name, Vruta::ProcessingToken token)

--- a/src/MayaFlux/API/Chronie.cpp
+++ b/src/MayaFlux/API/Chronie.cpp
@@ -61,14 +61,15 @@ Vruta::SoundRoutine create_line(float start_value, float end_value, float durati
     return Kriya::line(*get_scheduler(), start_value, end_value, duration_seconds, step_duration, retain);
 }
 
-void schedule_pattern(std::function<std::any(uint64_t)> pattern_func, std::function<void(std::any)> callback, double interval_seconds, std::string name)
+void schedule_pattern(std::function<std::any(uint64_t)> pattern_func, std::function<void(std::any)> callback, double interval_seconds, std::string name, Vruta::ProcessingToken token)
 {
     auto scheduler = get_scheduler();
     if (name.empty()) {
         name = "pattern_" + std::to_string(scheduler->get_next_task_id());
     }
-    auto pattern = std::make_shared<Vruta::SoundRoutine>(Kriya::pattern(*get_scheduler(), std::move(pattern_func), std::move(callback), interval_seconds));
-    get_scheduler()->add_task(std::move(pattern), name, false);
+
+    auto pattern = Kriya::pattern(std::move(pattern_func), std::move(callback), interval_seconds, token);
+    get_scheduler()->add_task(pattern, name, false);
 }
 
 float* get_line_value(const std::string& name)

--- a/src/MayaFlux/API/Chronie.cpp
+++ b/src/MayaFlux/API/Chronie.cpp
@@ -58,9 +58,17 @@ void schedule_sequence(std::vector<std::pair<double, std::function<void()>>> seq
     get_scheduler()->add_task(tseq, name, false);
 }
 
-Vruta::SoundRoutine create_line(float start_value, float end_value, float duration_seconds, uint32_t step_duration, bool retain)
+std::shared_ptr<Vruta::SoundRoutine> schedule_line(float start_value, float end_value, float duration_seconds, uint32_t step_duration, bool retain, std::string name)
 {
-    return Kriya::line(*get_scheduler(), start_value, end_value, duration_seconds, step_duration, retain);
+    auto scheduler = get_scheduler();
+    if (name.empty()) {
+        name = "seq_" + std::to_string(scheduler->get_next_task_id());
+    }
+
+    auto line = std::make_shared<Vruta::SoundRoutine>(Kriya::line(start_value, end_value, duration_seconds, step_duration, retain));
+
+    get_scheduler()->add_task(line, name, true);
+    return line;
 }
 
 void schedule_pattern(std::function<std::any(uint64_t)> pattern_func, std::function<void(std::any)> callback, double interval_seconds, std::string name, Vruta::ProcessingToken token)

--- a/src/MayaFlux/API/Chronie.cpp
+++ b/src/MayaFlux/API/Chronie.cpp
@@ -35,25 +35,15 @@ bool update_task_params(const std::string& name, Args... args)
     return get_scheduler()->update_task_params(name, args...);
 }
 
-Vruta::SoundRoutine create_metro(double interval_seconds, std::function<void()> callback)
-{
-    return Kriya::metro(*get_scheduler(), interval_seconds, std::move(callback));
-}
-
 void schedule_metro(double interval_seconds, std::function<void()> callback, std::string name)
 {
     auto scheduler = get_scheduler();
     if (name.empty()) {
         name = "metro_" + std::to_string(scheduler->get_next_task_id());
     }
-    auto metronome = std::make_shared<Vruta::SoundRoutine>(create_metro(interval_seconds, std::move(callback)));
+    auto metronome = std::make_shared<Vruta::SoundRoutine>(Kriya::metro(*get_scheduler(), interval_seconds, std::move(callback)));
 
     get_scheduler()->add_task(std::move(metronome), name, false);
-}
-
-Vruta::SoundRoutine create_sequence(std::vector<std::pair<double, std::function<void()>>> seq)
-{
-    return Kriya::sequence(*get_scheduler(), std::move(seq));
 }
 
 void schedule_sequence(std::vector<std::pair<double, std::function<void()>>> seq, std::string name)
@@ -62,7 +52,7 @@ void schedule_sequence(std::vector<std::pair<double, std::function<void()>>> seq
     if (name.empty()) {
         name = "seq_" + std::to_string(scheduler->get_next_task_id());
     }
-    auto tseq = std::make_shared<Vruta::SoundRoutine>(create_sequence(std::move(seq)));
+    auto tseq = std::make_shared<Vruta::SoundRoutine>(Kriya::sequence(*get_scheduler(), std::move(seq)));
     get_scheduler()->add_task(std::move(tseq), name, false);
 }
 
@@ -71,18 +61,13 @@ Vruta::SoundRoutine create_line(float start_value, float end_value, float durati
     return Kriya::line(*get_scheduler(), start_value, end_value, duration_seconds, step_duration, retain);
 }
 
-Vruta::SoundRoutine create_pattern(std::function<std::any(uint64_t)> pattern_func, std::function<void(std::any)> callback, double interval_seconds)
-{
-    return Kriya::pattern(*get_scheduler(), std::move(pattern_func), std::move(callback), interval_seconds);
-}
-
 void schedule_pattern(std::function<std::any(uint64_t)> pattern_func, std::function<void(std::any)> callback, double interval_seconds, std::string name)
 {
     auto scheduler = get_scheduler();
     if (name.empty()) {
         name = "pattern_" + std::to_string(scheduler->get_next_task_id());
     }
-    auto pattern = std::make_shared<Vruta::SoundRoutine>(create_pattern(std::move(pattern_func), std::move(callback), interval_seconds));
+    auto pattern = std::make_shared<Vruta::SoundRoutine>(Kriya::pattern(*get_scheduler(), std::move(pattern_func), std::move(callback), interval_seconds));
     get_scheduler()->add_task(std::move(pattern), name, false);
 }
 

--- a/src/MayaFlux/API/Chronie.hpp
+++ b/src/MayaFlux/API/Chronie.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "MayaFlux/Core/ProcessingTokens.hpp"
 #include "MayaFlux/IO/Keys.hpp"
 
 namespace MayaFlux {
@@ -87,10 +88,11 @@ MAYAFLUX_API Vruta::SoundRoutine create_line(float start_value, float end_value,
  * @param interval_seconds Time between pattern steps
  * @param name Name of the metronome task (optional but recommended).
      If not provided, a default name will be generated.
+ * @param token Processing token to determine which scheduler rate to use (default: SAMPLE_ACCURATE)
  *
  * Uses the task scheduler from the default engine.
  */
-MAYAFLUX_API void schedule_pattern(std::function<std::any(uint64_t)> pattern_func, std::function<void(std::any)> callback, double interval_seconds, std::string name = "");
+MAYAFLUX_API void schedule_pattern(std::function<std::any(uint64_t)> pattern_func, std::function<void(std::any)> callback, double interval_seconds, std::string name = "", Vruta::ProcessingToken token = Vruta::ProcessingToken::SAMPLE_ACCURATE);
 
 /**
  * @brief Gets a pointer to a task's current value

--- a/src/MayaFlux/API/Chronie.hpp
+++ b/src/MayaFlux/API/Chronie.hpp
@@ -70,17 +70,19 @@ MAYAFLUX_API void schedule_metro(double interval_seconds, std::function<void()> 
 MAYAFLUX_API void schedule_sequence(std::vector<std::pair<double, std::function<void()>>> sequence, std::string name = "", Vruta::ProcessingToken token = Vruta::ProcessingToken::SAMPLE_ACCURATE);
 
 /**
- * @brief Creates a line generator that interpolates between values over time
+ * @brief Creates a line generator that interpolates between values over time and schedules it for evaluation
  * @param start_value Starting value
  * @param end_value Ending value
  * @param duration_seconds Total duration in seconds
  * @param step_duration Time between steps in seconds
  * @param retain Whether the coroutine should stay alive for potential restarts (default: true)
- * @return SoundRoutine object representing the line generator
+ * @param name Name of the line task (optional but recommended).
+     If not provided, a default name will be generated.
+ * @return shared_ptr to SoundRoutine object representing the line generator
  *
  * Uses the task scheduler from the default engine.
  */
-MAYAFLUX_API Vruta::SoundRoutine create_line(float start_value, float end_value, float duration_seconds, uint32_t step_duration = 5, bool retain = true);
+MAYAFLUX_API std::shared_ptr<Vruta::SoundRoutine> schedule_line(float start_value, float end_value, float duration_seconds, uint32_t step_duration = 5, bool retain = true, std::string name = "");
 
 /**
  * @brief Schedules a pattern generator that produces values based on a pattern function

--- a/src/MayaFlux/API/Chronie.hpp
+++ b/src/MayaFlux/API/Chronie.hpp
@@ -45,14 +45,6 @@ MAYAFLUX_API std::shared_ptr<Vruta::TaskScheduler> get_scheduler();
 MAYAFLUX_API std::shared_ptr<Vruta::EventManager> get_event_manager();
 
 /**
- * @brief Creates a simple task that calls a function at a specified interval
- * @param interval_seconds Time between calls in seconds
- * @param callback Function to call on each tick
- * This is conceptually similar to Metronomes in PureData and MaxMSP
- */
-MAYAFLUX_API Vruta::SoundRoutine create_metro(double interval_seconds, std::function<void()> callback);
-
-/**
  * @brief Creates a metronome task and addes it to the default scheduler list for evaluation
  * @param interval_seconds Time between calls in seconds
  * @param callback Function to call on each tick
@@ -62,17 +54,6 @@ MAYAFLUX_API Vruta::SoundRoutine create_metro(double interval_seconds, std::func
  * Uses the task scheduler from the default engine.
  */
 MAYAFLUX_API void schedule_metro(double interval_seconds, std::function<void()> callback, std::string name = "");
-
-/**
- * @brief Creates a sequence task that calls functions at specified times
- * @param sequence Vector of (time, function) pairs
- * @param name Name of the metronome task (optional but recommended).
-     If not provided, a default name will be generated.
- * @return SoundRoutine object representing the scheduled task
- *
- * Uses the task scheduler from the default engine.
- */
-MAYAFLUX_API Vruta::SoundRoutine create_sequence(std::vector<std::pair<double, std::function<void()>>> sequence);
 
 /**
  * @brief Creates a sequence task that calls functions at specified times
@@ -97,17 +78,6 @@ MAYAFLUX_API void schedule_sequence(std::vector<std::pair<double, std::function<
  * Uses the task scheduler from the default engine.
  */
 MAYAFLUX_API Vruta::SoundRoutine create_line(float start_value, float end_value, float duration_seconds, uint32_t step_duration = 5, bool retain = true);
-
-/**
- * @brief Schedules a pattern generator that produces values based on a pattern function
- * @param pattern_func Function that generates pattern values based on step index
- * @param callback Function to call with each pattern value
- * @param interval_seconds Time between pattern steps
- * @return SoundRoutine object representing the scheduled task
- *
- * Uses the task scheduler from the default engine.
- */
-MAYAFLUX_API Vruta::SoundRoutine create_pattern(std::function<std::any(uint64_t)> pattern_func, std::function<void(std::any)> callback, double interval_seconds);
 
 /**
  * @brief Schedules a pattern generator that produces values based on a pattern function

--- a/src/MayaFlux/API/Chronie.hpp
+++ b/src/MayaFlux/API/Chronie.hpp
@@ -62,10 +62,11 @@ MAYAFLUX_API void schedule_metro(double interval_seconds, std::function<void()> 
  * @param sequence Vector of (time, function) pairs
  * @param name Name of the metronome task (optional but recommended).
      If not provided, a default name will be generated.
+ * @param token Processing token to determine which scheduler rate to use (default: SAMPLE_ACCURATE)
  *
  * Uses the task scheduler from the default engine.
  */
-MAYAFLUX_API void schedule_sequence(std::vector<std::pair<double, std::function<void()>>> sequence, std::string name = "");
+MAYAFLUX_API void schedule_sequence(std::vector<std::pair<double, std::function<void()>>> sequence, std::string name = "", Vruta::ProcessingToken token = Vruta::ProcessingToken::SAMPLE_ACCURATE);
 
 /**
  * @brief Creates a line generator that interpolates between values over time

--- a/src/MayaFlux/API/Chronie.hpp
+++ b/src/MayaFlux/API/Chronie.hpp
@@ -51,10 +51,11 @@ MAYAFLUX_API std::shared_ptr<Vruta::EventManager> get_event_manager();
  * @param callback Function to call on each tick
  * @param name Name of the metronome task (optional but recommended).
      If not provided, a default name will be generated.
+ * @param token Processing token to determine which scheduler rate to use (default: SAMPLE_ACCURATE)
  *
  * Uses the task scheduler from the default engine.
  */
-MAYAFLUX_API void schedule_metro(double interval_seconds, std::function<void()> callback, std::string name = "");
+MAYAFLUX_API void schedule_metro(double interval_seconds, std::function<void()> callback, std::string name = "", Vruta::ProcessingToken token = Vruta::ProcessingToken::SAMPLE_ACCURATE);
 
 /**
  * @brief Creates a sequence task that calls functions at specified times

--- a/src/MayaFlux/API/Proxy/Temporal.cpp
+++ b/src/MayaFlux/API/Proxy/Temporal.cpp
@@ -16,9 +16,10 @@ std::shared_ptr<Nodes::Node> operator|(const TemporalWrapper<Nodes::Node>& wrapp
     auto node = wrapper.entity();
     const auto& spec = wrapper.spec();
     auto node_token = get_node_token(ctx.domain.value());
+    auto task_token = get_task_token(ctx.domain.value());
 
     auto activation = std::make_shared<Kriya::TemporalActivation>(
-        *get_scheduler(), *get_node_graph_manager(), *get_buffer_manager());
+        *get_scheduler(), *get_node_graph_manager(), *get_buffer_manager(), task_token);
 
     if (ctx.channels.has_value()) {
         activation->activate_node(node, spec.seconds, node_token, ctx.channels.value());
@@ -45,9 +46,10 @@ std::shared_ptr<Buffers::Buffer> operator|(const TemporalWrapper<Buffers::Buffer
     auto buffer = wrapper.entity();
     const auto& spec = wrapper.spec();
     auto buffer_token = get_buffer_token(ctx.domain.value());
+    auto task_token = get_task_token(ctx.domain.value());
 
     auto activation = std::make_shared<Kriya::TemporalActivation>(
-        *get_scheduler(), *get_node_graph_manager(), *get_buffer_manager());
+        *get_scheduler(), *get_node_graph_manager(), *get_buffer_manager(), task_token);
 
     if (ctx.channel.has_value()) {
         activation->activate_buffer(buffer, spec.seconds, buffer_token, ctx.channel.value());
@@ -74,9 +76,10 @@ std::shared_ptr<Nodes::Network::NodeNetwork> operator|(const TemporalWrapper<Nod
     auto network = wrapper.entity();
     const auto& spec = wrapper.spec();
     auto node_token = get_node_token(ctx.domain.value());
+    auto task_token = get_task_token(ctx.domain.value());
 
     auto activation = std::make_shared<Kriya::TemporalActivation>(
-        *get_scheduler(), *get_node_graph_manager(), *get_buffer_manager());
+        *get_scheduler(), *get_node_graph_manager(), *get_buffer_manager(), task_token);
 
     activation->activate_network(network, spec.seconds, node_token);
 

--- a/src/MayaFlux/Kriya/Awaiters/DelayAwaiters.hpp
+++ b/src/MayaFlux/Kriya/Awaiters/DelayAwaiters.hpp
@@ -142,7 +142,7 @@ struct MAYAFLUX_API FrameDelay {
      */
     using promise_handle = Vruta::graphics_promise;
 
-    uint32_t frames_to_wait;
+    uint64_t frames_to_wait;
 
     [[nodiscard]] constexpr bool await_ready() const noexcept
     {
@@ -157,7 +157,7 @@ struct MAYAFLUX_API FrameDelay {
 struct MAYAFLUX_API MultiRateDelay {
 
     uint64_t samples_to_wait;
-    uint32_t frames_to_wait;
+    uint64_t frames_to_wait;
 
     [[nodiscard]] constexpr bool await_ready() const noexcept
     {

--- a/src/MayaFlux/Kriya/Chain.cpp
+++ b/src/MayaFlux/Kriya/Chain.cpp
@@ -6,20 +6,19 @@
 
 #include "MayaFlux/Journal/Archivist.hpp"
 
-static const auto node_token = MayaFlux::Nodes::ProcessingToken::AUDIO_RATE;
-
 namespace MayaFlux::Kriya {
 
-EventChain::EventChain(Vruta::TaskScheduler& scheduler, std::string name)
+EventChain::EventChain(Vruta::TaskScheduler& scheduler, std::string name, Vruta::ProcessingToken token)
     : m_Scheduler(scheduler)
     , m_name(std::move(name))
-    , m_default_rate(scheduler.get_rate())
+    , m_token(token)
+    , m_default_rate(scheduler.get_rate(token))
 {
 }
 
 EventChain& EventChain::then(std::function<void()> action, double delay_seconds)
 {
-    m_events.push_back({ std::move(action), delay_seconds });
+    m_events.push_back({ .action = std::move(action), .delay_seconds = delay_seconds });
     return *this;
 }
 
@@ -60,10 +59,10 @@ void EventChain::start()
 
     m_on_complete_fired = false;
 
-    auto coroutine_func = [](std::vector<TimedEvent> events,
-                              uint64_t rate,
-                              std::function<void()> on_complete_callback,
-                              size_t repeat_count) -> MayaFlux::Vruta::SoundRoutine {
+    auto s_coro_func = [](std::vector<TimedEvent> events,
+                           uint64_t rate,
+                           std::function<void()> on_complete_callback,
+                           size_t repeat_count) -> MayaFlux::Vruta::SoundRoutine {
         auto& promise = co_await Kriya::GetAudioPromise {};
 
         for (size_t iteration = 0; iteration < repeat_count; ++iteration) {
@@ -112,9 +111,68 @@ void EventChain::start()
         }
     };
 
+    auto g_coro_func = [](std::vector<TimedEvent> events,
+                           uint64_t rate,
+                           std::function<void()> on_complete_callback,
+                           size_t repeat_count) -> MayaFlux::Vruta::GraphicsRoutine {
+        auto& promise = co_await Kriya::GetGraphicsPromise {};
+
+        for (size_t iteration = 0; iteration < repeat_count; ++iteration) {
+            for (const auto& event : events) {
+                if (promise.should_terminate) {
+                    break;
+                }
+
+                co_await FrameDelay { Vruta::seconds_to_frames(event.delay_seconds, rate) };
+                try {
+                    if (event.action) {
+                        event.action();
+                    }
+                } catch (const std::exception& e) {
+                    MF_RT_ERROR(
+                        Journal::Component::Kriya,
+                        Journal::Context::CoroutineScheduling,
+                        "Exception in EventChain action: {}", e.what());
+                } catch (...) {
+                    MF_RT_ERROR(
+                        Journal::Component::Kriya,
+                        Journal::Context::CoroutineScheduling,
+                        "Unknown exception in EventChain action");
+                }
+            }
+
+            if (promise.should_terminate) {
+                break;
+            }
+        }
+
+        if (on_complete_callback) {
+            try {
+                on_complete_callback();
+            } catch (const std::exception& e) {
+                MF_RT_ERROR(
+                    Journal::Component::Kriya,
+                    Journal::Context::CoroutineScheduling,
+                    "Exception in EventChain on_complete: {}", e.what());
+            } catch (...) {
+                MF_RT_ERROR(
+                    Journal::Component::Kriya,
+                    Journal::Context::CoroutineScheduling,
+                    "Unknown exception in EventChain on_complete");
+            }
+        }
+    };
+
     std::string task_name = m_name.empty() ? "EventChain_" + std::to_string(m_Scheduler.get_next_task_id()) : m_name;
-    m_routine = std::make_shared<Vruta::SoundRoutine>(
-        coroutine_func(m_events, m_default_rate, m_on_complete, m_repeat_count));
+
+    if (m_token == Vruta::ProcessingToken::SAMPLE_ACCURATE) {
+        m_routine = std::make_shared<Vruta::SoundRoutine>(
+            s_coro_func(m_events, m_default_rate, m_on_complete, m_repeat_count));
+    } else {
+        m_routine = std::make_shared<Vruta::GraphicsRoutine>(
+            g_coro_func(m_events, m_default_rate, m_on_complete, m_repeat_count));
+    }
+
     m_Scheduler.add_task(m_routine, task_name, true);
 }
 

--- a/src/MayaFlux/Kriya/Chain.hpp
+++ b/src/MayaFlux/Kriya/Chain.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "MayaFlux/Core/ProcessingTokens.hpp"
+
 namespace MayaFlux::Vruta {
 class TaskScheduler;
-class SoundRoutine;
+class Routine;
 }
 
 namespace MayaFlux::Kriya {
@@ -44,12 +46,13 @@ public:
      * @brief Constructs an EventChain with an explicit scheduler
      * @param scheduler The TaskScheduler to use for timing
      * @param name Optional name for the event chain (useful for debugging)
+     * @param token Processing token to determine which scheduler rate to use
      *
      * Creates a new EventChain that will use the provided scheduler for timing
      * operations. This allows for more control over which scheduler is used,
      * which is useful in contexts where multiple processing engines might exist.
      */
-    EventChain(Vruta::TaskScheduler& scheduler, std::string name = "");
+    EventChain(Vruta::TaskScheduler& scheduler, std::string name = "", Vruta::ProcessingToken token = Vruta::ProcessingToken::SAMPLE_ACCURATE);
 
     /**
      * @brief Adds an event to the chain with a specified delay
@@ -185,12 +188,21 @@ private:
     Vruta::TaskScheduler& m_Scheduler;
 
     /**
+     * @brief Processing token to determine which scheduler rate to use
+     *
+     * This token indicates which processing engine's timing should be used
+     * for the events in this chain. It allows the EventChain to be flexible
+     * and work with different types of processing timelines.
+     */
+    Vruta::ProcessingToken m_token;
+
+    /**
      * @brief The underlying computational routine that implements the chain
      *
      * This coroutine handles the actual timing and execution of events
      * in the chain. It's created when start() is called.
      */
-    std::shared_ptr<Vruta::SoundRoutine> m_routine;
+    std::shared_ptr<Vruta::Routine> m_routine;
 
     /**
      * @brief Optional callback to execute when the chain completes

--- a/src/MayaFlux/Kriya/Tasks.cpp
+++ b/src/MayaFlux/Kriya/Tasks.cpp
@@ -53,7 +53,7 @@ std::shared_ptr<Vruta::Routine> sequence(std::vector<std::pair<double, std::func
     return std::make_shared<Vruta::SoundRoutine>(coro(std::move(sequence)));
 }
 
-Vruta::SoundRoutine line(Vruta::TaskScheduler& scheduler, float start_value, float end_value, float duration_seconds, uint32_t step_duration, bool restartable)
+Vruta::SoundRoutine line(float start_value, float end_value, float duration_seconds, uint32_t step_duration, bool restartable)
 {
     auto& promise_ref = co_await GetAudioPromise {};
 
@@ -61,7 +61,7 @@ Vruta::SoundRoutine line(Vruta::TaskScheduler& scheduler, float start_value, flo
     promise_ref.set_state("end_value", end_value);
     promise_ref.set_state("restart", false);
 
-    const unsigned int sample_rate = scheduler.get_rate();
+    const unsigned int sample_rate = Vruta::s_registered_sample_rate;
     if (step_duration < 1) {
         step_duration = 1;
     }
@@ -139,7 +139,6 @@ std::shared_ptr<Vruta::Routine> pattern(std::function<std::any(uint64_t)> patter
 }
 
 Vruta::SoundRoutine Gate(
-    Vruta::TaskScheduler& scheduler,
     std::function<void()> callback,
     std::shared_ptr<Nodes::Generator::Logic> logic_node,
     bool open)
@@ -172,7 +171,6 @@ Vruta::SoundRoutine Gate(
 }
 
 Vruta::SoundRoutine Trigger(
-    Vruta::TaskScheduler& scheduler,
     bool target_state,
     std::function<void()> callback,
     std::shared_ptr<Nodes::Generator::Logic> logic_node)
@@ -200,7 +198,6 @@ Vruta::SoundRoutine Trigger(
 }
 
 Vruta::SoundRoutine Toggle(
-    Vruta::TaskScheduler& scheduler,
     std::function<void()> callback,
     std::shared_ptr<Nodes::Generator::Logic> logic_node)
 {

--- a/src/MayaFlux/Kriya/Tasks.cpp
+++ b/src/MayaFlux/Kriya/Tasks.cpp
@@ -3,6 +3,8 @@
 #include "MayaFlux/Nodes/Generators/Logic.hpp"
 #include "MayaFlux/Vruta/Scheduler.hpp"
 
+#include "MayaFlux/Vruta/ChronUtils.hpp"
+
 #include "MayaFlux/Journal/Archivist.hpp"
 
 namespace MayaFlux::Kriya {
@@ -90,16 +92,29 @@ Vruta::SoundRoutine line(Vruta::TaskScheduler& scheduler, float start_value, flo
     }
 }
 
-Vruta::SoundRoutine pattern(Vruta::TaskScheduler& scheduler, std::function<std::any(uint64_t)> pattern_func, std::function<void(std::any)> callback, double interval_seconds)
+std::shared_ptr<Vruta::Routine> pattern(std::function<std::any(uint64_t)> pattern_func, std::function<void(std::any)> callback, double interval_seconds, Vruta::ProcessingToken token)
 {
-    uint64_t interval_samples = scheduler.seconds_to_samples(interval_seconds);
-    uint64_t step = 0;
-
-    while (true) {
-        std::any value = pattern_func(step++);
-        callback(value);
-        co_await SampleDelay(interval_samples);
+    if (token == Vruta::ProcessingToken::FRAME_ACCURATE) {
+        auto coro = [](std::function<std::any(uint64_t)> fn, std::function<void(std::any)> cb, double interval) -> Vruta::GraphicsRoutine {
+            uint64_t units = Vruta::seconds_to_frames(interval);
+            uint64_t step = 0;
+            while (true) {
+                cb(fn(step++));
+                co_await FrameDelay { .frames_to_wait = units };
+            }
+        };
+        return std::make_shared<Vruta::GraphicsRoutine>(coro(std::move(pattern_func), std::move(callback), interval_seconds));
     }
+
+    auto coro = [](std::function<std::any(uint64_t)> fn, std::function<void(std::any)> cb, double interval) -> Vruta::SoundRoutine {
+        uint64_t units = Vruta::seconds_to_samples(interval);
+        uint64_t step = 0;
+        while (true) {
+            cb(fn(step++));
+            co_await SampleDelay { units };
+        }
+    };
+    return std::make_shared<Vruta::SoundRoutine>(coro(std::move(pattern_func), std::move(callback), interval_seconds));
 }
 
 Vruta::SoundRoutine Gate(

--- a/src/MayaFlux/Kriya/Tasks.cpp
+++ b/src/MayaFlux/Kriya/Tasks.cpp
@@ -23,13 +23,24 @@ Vruta::SoundRoutine metro(Vruta::TaskScheduler& scheduler, double interval_secon
     }
 }
 
-Vruta::SoundRoutine sequence(Vruta::TaskScheduler& scheduler, std::vector<std::pair<double, std::function<void()>>> sequence)
+std::shared_ptr<Vruta::Routine> sequence(std::vector<std::pair<double, std::function<void()>>> sequence, Vruta::ProcessingToken token)
 {
-    for (const auto& [time, callback] : sequence) {
-        uint64_t delay_samples = scheduler.seconds_to_samples(time);
-        co_await SampleDelay(delay_samples);
-        callback();
+    if (token == Vruta::ProcessingToken::FRAME_ACCURATE) {
+        auto coro = [](std::vector<std::pair<double, std::function<void()>>> seq) -> Vruta::GraphicsRoutine {
+            for (const auto& [time, cb] : seq) {
+                co_await FrameDelay { .frames_to_wait = Vruta::seconds_to_frames(time) };
+                cb();
+            }
+        };
+        return std::make_shared<Vruta::GraphicsRoutine>(coro(std::move(sequence)));
     }
+    auto coro = [](std::vector<std::pair<double, std::function<void()>>> seq) -> Vruta::SoundRoutine {
+        for (const auto& [time, cb] : seq) {
+            co_await SampleDelay { Vruta::seconds_to_samples(time) };
+            cb();
+        }
+    };
+    return std::make_shared<Vruta::SoundRoutine>(coro(std::move(sequence)));
 }
 
 Vruta::SoundRoutine line(Vruta::TaskScheduler& scheduler, float start_value, float end_value, float duration_seconds, uint32_t step_duration, bool restartable)

--- a/src/MayaFlux/Kriya/Tasks.cpp
+++ b/src/MayaFlux/Kriya/Tasks.cpp
@@ -9,18 +9,28 @@
 
 namespace MayaFlux::Kriya {
 
-Vruta::SoundRoutine metro(Vruta::TaskScheduler& scheduler, double interval_seconds, std::function<void()> callback)
+std::shared_ptr<Vruta::Routine> metro(double interval_seconds, std::function<void()> callback, Vruta::ProcessingToken token)
 {
-    uint64_t interval_samples = scheduler.seconds_to_samples(interval_seconds);
-    auto& promise = co_await Kriya::GetAudioPromise {};
-
-    while (true) {
-        if (promise.should_terminate) {
-            break;
-        }
-        callback();
-        co_await SampleDelay(interval_samples);
+    if (token == Vruta::ProcessingToken::FRAME_ACCURATE) {
+        auto coro = [](double interval, std::function<void()> cb) -> Vruta::GraphicsRoutine {
+            uint64_t units = Vruta::seconds_to_frames(interval);
+            auto& p = co_await GetGraphicsPromise {};
+            while (!p.should_terminate) {
+                cb();
+                co_await FrameDelay { .frames_to_wait = units };
+            }
+        };
+        return std::make_shared<Vruta::GraphicsRoutine>(coro(interval_seconds, std::move(callback)));
     }
+    auto coro = [](double interval, std::function<void()> cb) -> Vruta::SoundRoutine {
+        uint64_t units = Vruta::seconds_to_samples(interval);
+        auto& p = co_await GetAudioPromise {};
+        while (!p.should_terminate) {
+            cb();
+            co_await SampleDelay { units };
+        }
+    };
+    return std::make_shared<Vruta::SoundRoutine>(coro(interval_seconds, std::move(callback)));
 }
 
 std::shared_ptr<Vruta::Routine> sequence(std::vector<std::pair<double, std::function<void()>>> sequence, Vruta::ProcessingToken token)

--- a/src/MayaFlux/Kriya/Tasks.hpp
+++ b/src/MayaFlux/Kriya/Tasks.hpp
@@ -82,7 +82,6 @@ namespace Kriya {
 
     /**
      * @brief Creates a continuous interpolation generator between two values over time
-     * @param scheduler The task scheduler that will manage this generator
      * @param start_value Initial value of the interpolation
      * @param end_value Final value of the interpolation
      * @param duration_seconds Total duration of the interpolation in seconds
@@ -117,7 +116,7 @@ namespace Kriya {
      * If restartable is true, the interpolation task will remain active after reaching the
      * end value and can be restarted by calling restart() on the SoundRoutine.
      */
-    MAYAFLUX_API Vruta::SoundRoutine line(Vruta::TaskScheduler& scheduler, float start_value, float end_value, float duration_seconds, uint32_t step_duration = 5, bool restartable = false);
+    MAYAFLUX_API Vruta::SoundRoutine line(float start_value, float end_value, float duration_seconds, uint32_t step_duration = 5, bool restartable = false);
 
     /**
      * @brief Creates a generative algorithm that produces values based on a pattern function
@@ -163,39 +162,34 @@ namespace Kriya {
 
     /**
      * @brief Coroutine that executes callback continuously while logic node outputs true
-     * @param scheduler Task scheduler instance
      * @param callback Function to execute while condition is true
      * @param logic_node Logic node to monitor (creates default threshold node if null)
      * @param open Whether to subscribe to gate open (true) or close (false)
      * @return SoundRoutine coroutine handle
      */
     MAYAFLUX_API Vruta::SoundRoutine Gate(
-        Vruta::TaskScheduler& scheduler, std::function<void()> callback,
+        std::function<void()> callback,
         std::shared_ptr<Nodes::Generator::Logic> logic_node, bool open = true);
 
     /**
      * @brief Coroutine that executes callback when logic node changes to specific state
-     * @param scheduler Task scheduler instance
      * @param logic_node Logic node to monitor (creates default threshold node if null)
      * @param target_state State to trigger on (true/false)
      * @param callback Function to execute on state change
      * @return SoundRoutine coroutine handle
      */
     MAYAFLUX_API Vruta::SoundRoutine Trigger(
-        Vruta::TaskScheduler& scheduler,
         bool target_state,
         std::function<void()> callback,
         std::shared_ptr<Nodes::Generator::Logic> logic_node);
 
     /**
      * @brief Coroutine that executes callback on any logic node state change
-     * @param scheduler Task scheduler instance
      * @param logic_node Logic node to monitor (creates default threshold node if null)
      * @param callback Function to execute on any state flip
      * @return SoundRoutine coroutine handle
      */
     MAYAFLUX_API Vruta::SoundRoutine Toggle(
-        Vruta::TaskScheduler& scheduler,
         std::function<void()> callback,
         std::shared_ptr<Nodes::Generator::Logic> logic_node);
 }

--- a/src/MayaFlux/Kriya/Tasks.hpp
+++ b/src/MayaFlux/Kriya/Tasks.hpp
@@ -4,6 +4,8 @@ namespace MayaFlux {
 namespace Vruta {
     class TaskScheduler;
     class SoundRoutine;
+    class GraphicsRoutine;
+    class Routine;
 }
 
 namespace Nodes::Generator {

--- a/src/MayaFlux/Kriya/Tasks.hpp
+++ b/src/MayaFlux/Kriya/Tasks.hpp
@@ -18,10 +18,10 @@ namespace Kriya {
 
     /**
      * @brief Creates a periodic event generator that executes a callback at regular intervals
-     * @param scheduler The task scheduler that will manage this event generator
      * @param interval_seconds Time between callback executions in seconds
      * @param callback Function to execute on each interval
-     * @return A SoundRoutine that implements the periodic behavior
+     * @param token Processing token to determine which scheduler rate to use (default: SAMPLE_ACCURATE)
+     * @return A Routine shared_ptr of type determined by the processing token of the scheduler (SoundRoutine, GraphicsRoutine, etc.)
      *
      * The metro task provides a fundamental temporal mechanism for creating
      * time-based structures in computational systems. It executes the provided
@@ -37,16 +37,16 @@ namespace Kriya {
      * Example usage:
      * ```cpp
      * // Create a periodic event generator (2Hz)
-     * auto periodic_task = Kriya::metro(*scheduler, 0.5, []() {
+     * auto periodic_task = Kriya::metro(0.5, []() {
      *     trigger_event(); // Could affect audio, visuals, data, etc.
      * });
-     * scheduler->add_task(std::make_shared<SoundRoutine>(std::move(periodic_task)));
+     * scheduler->add_task(periodic_task);
      * ```
      *
      * The metro task continues indefinitely until explicitly cancelled, creating
      * a persistent temporal structure within the computational system.
      */
-    MAYAFLUX_API Vruta::SoundRoutine metro(Vruta::TaskScheduler& scheduler, double interval_seconds, std::function<void()> callback);
+    MAYAFLUX_API std::shared_ptr<Vruta::Routine> metro(double interval_seconds, std::function<void()> callback, Vruta::ProcessingToken token = Vruta::ProcessingToken::SAMPLE_ACCURATE);
 
     /**
      * @brief Creates a temporal sequence that executes callbacks at specified time offsets

--- a/src/MayaFlux/Kriya/Tasks.hpp
+++ b/src/MayaFlux/Kriya/Tasks.hpp
@@ -52,7 +52,8 @@ namespace Kriya {
      * @brief Creates a temporal sequence that executes callbacks at specified time offsets
      * @param scheduler The task scheduler that will manage this sequence
      * @param sequence Vector of (time_offset, callback) pairs to execute in order
-     * @return A SoundRoutine that implements the sequence behavior
+     * @param token Processing token to determine which scheduler rate to use (default: SAMPLE_ACCURATE)
+     * @return A Routine shared_ptr of type determined by the processing token of the scheduler (SoundRoutine, GraphicsRoutine, etc.)
      *
      * The sequence task enables the creation of precisely timed event chains with
      * specific temporal relationships. Each event consists of a time offset (in seconds)
@@ -66,18 +67,18 @@ namespace Kriya {
      * Example usage:
      * ```cpp
      * // Create a temporal sequence of events
-     * auto event_sequence = Kriya::sequence(*scheduler, {
+     * auto event_sequence = Kriya::sequence({
      *     {0.0, []() { trigger_event_a(); }},  // Immediate
      *     {0.5, []() { trigger_event_b(); }},  // 0.5 seconds later
      *     {1.0, []() { trigger_event_c(); }},  // 1.0 seconds later
      *     {1.5, []() { trigger_event_d(); }}   // 1.5 seconds later
      * });
-     * scheduler->add_task(std::make_shared<SoundRoutine>(std::move(event_sequence)));
+     * scheduler->add_task(event_sequence);
      * ```
      *
      * The sequence task completes after executing all events in the defined timeline.
      */
-    MAYAFLUX_API Vruta::SoundRoutine sequence(Vruta::TaskScheduler& scheduler, std::vector<std::pair<double, std::function<void()>>> sequence);
+    MAYAFLUX_API std::shared_ptr<Vruta::Routine> sequence(std::vector<std::pair<double, std::function<void()>>> sequence, Vruta::ProcessingToken token = Vruta::ProcessingToken::SAMPLE_ACCURATE);
 
     /**
      * @brief Creates a continuous interpolation generator between two values over time
@@ -120,7 +121,6 @@ namespace Kriya {
 
     /**
      * @brief Creates a generative algorithm that produces values based on a pattern function
-     * @param scheduler The task scheduler that will manage this generator
      * @param pattern_func Function that generates values based on a step index
      * @param callback Function to execute with each generated value
      * @param interval_seconds Time between pattern steps in seconds
@@ -140,7 +140,7 @@ namespace Kriya {
      * ```cpp
      * // Create a generative algorithm based on a mathematical sequence
      * std::vector<int> fibonacci = {0, 1, 1, 2, 3, 5, 8, 13, 21};
-     * auto generator = Kriya::pattern(*scheduler,
+     * auto generator = Kriya::pattern(
      *     // Pattern function - apply algorithmic rules
      *     [&fibonacci](uint64_t step) -> std::any {
      *         return fibonacci[step % fibonacci.size()];

--- a/src/MayaFlux/Kriya/Tasks.hpp
+++ b/src/MayaFlux/Kriya/Tasks.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "MayaFlux/Core/ProcessingTokens.hpp"
+
 namespace MayaFlux {
 namespace Vruta {
     class TaskScheduler;
@@ -122,7 +124,7 @@ namespace Kriya {
      * @param pattern_func Function that generates values based on a step index
      * @param callback Function to execute with each generated value
      * @param interval_seconds Time between pattern steps in seconds
-     * @return A SoundRoutine that implements the generative behavior
+     * @return A Routine shared_ptr of type determined by the processing token of the scheduler (SoundRoutine, GraphicsRoutine, etc.)
      *
      * The pattern task provides a powerful framework for algorithmic generation
      * of values according to any computational pattern or rule system. At regular
@@ -151,13 +153,13 @@ namespace Kriya {
      *     },
      *     0.125 // Generate 8 values per second
      * );
-     * scheduler->add_task(std::make_shared<SoundRoutine>(std::move(generator)));
+     * scheduler->add_task(generator);
      * ```
      *
      * The pattern task continues indefinitely until explicitly cancelled, creating
      * an ongoing generative process within the computational system.
      */
-    MAYAFLUX_API Vruta::SoundRoutine pattern(Vruta::TaskScheduler& scheduler, std::function<std::any(uint64_t)> pattern_func, std::function<void(std::any)> callback, double interval_seconds);
+    MAYAFLUX_API std::shared_ptr<Vruta::Routine> pattern(std::function<std::any(uint64_t)> pattern_func, std::function<void(std::any)> callback, double interval_seconds, Vruta::ProcessingToken token = Vruta::ProcessingToken::SAMPLE_ACCURATE);
 
     /**
      * @brief Coroutine that executes callback continuously while logic node outputs true

--- a/src/MayaFlux/Kriya/Timers.cpp
+++ b/src/MayaFlux/Kriya/Timers.cpp
@@ -9,9 +9,10 @@
 
 namespace MayaFlux::Kriya {
 
-Timer::Timer(Vruta::TaskScheduler& scheduler)
+Timer::Timer(Vruta::TaskScheduler& scheduler, Vruta::ProcessingToken token)
     : m_Scheduler(scheduler)
     , m_active(false)
+    , m_token(token)
 {
 }
 
@@ -21,22 +22,35 @@ void Timer::schedule(double delay_seconds, std::function<void()> callback)
     m_callback = std::move(callback);
     m_active = true;
 
-    auto routine_func = [](Vruta::TaskScheduler& scheduler, uint64_t delay_samples, Timer* timer_ptr) -> Vruta::SoundRoutine {
-        auto& promise = co_await Kriya::GetAudioPromise {};
-        co_await SampleDelay { delay_samples };
+    if (m_token == Vruta::ProcessingToken::FRAME_ACCURATE) {
+        auto routine_func = [](Vruta::TaskScheduler& scheduler, uint64_t delay_frames, Timer* timer_ptr) -> Vruta::GraphicsRoutine {
+            auto& promise = co_await Kriya::GetGraphicsPromise {};
 
-        if (timer_ptr && timer_ptr->is_active()) {
-            timer_ptr->m_callback();
-            timer_ptr->m_active = false;
-        }
-    };
+            co_await FrameDelay { .frames_to_wait = delay_frames };
 
-    m_routine = std::make_shared<Vruta::SoundRoutine>(
-        routine_func(m_Scheduler, m_Scheduler.seconds_to_samples(delay_seconds), this));
+            if (timer_ptr && timer_ptr->is_active()) {
+                timer_ptr->m_callback();
+                timer_ptr->m_active = false;
+            }
+        };
+        m_routine = std::make_shared<Vruta::GraphicsRoutine>(
+            routine_func(m_Scheduler, m_Scheduler.seconds_to_units(delay_seconds, Vruta::ProcessingToken::FRAME_ACCURATE), this));
+    } else {
+        auto routine_func = [](Vruta::TaskScheduler& scheduler, uint64_t delay_samples, Timer* timer_ptr) -> Vruta::SoundRoutine {
+            auto& promise = co_await Kriya::GetAudioPromise {};
 
-    Vruta::ProcessingToken token = m_routine->get_processing_token();
-    uint64_t current_time = m_Scheduler.current_units(token);
+            co_await SampleDelay { delay_samples };
 
+            if (timer_ptr && timer_ptr->is_active()) {
+                timer_ptr->m_callback();
+                timer_ptr->m_active = false;
+            }
+        };
+        m_routine = std::make_shared<Vruta::SoundRoutine>(
+            routine_func(m_Scheduler, m_Scheduler.seconds_to_samples(delay_seconds), this));
+    }
+
+    uint64_t current_time = m_Scheduler.current_units(m_token);
     m_Scheduler.add_task(m_routine, "", false);
 
     m_routine->initialize_state(current_time);
@@ -51,9 +65,10 @@ void Timer::cancel()
     }
 }
 
-TimedAction::TimedAction(Vruta::TaskScheduler& scheduler)
+TimedAction::TimedAction(Vruta::TaskScheduler& scheduler, Vruta::ProcessingToken token)
     : m_Scheduler(scheduler)
-    , m_timer(scheduler)
+    , m_timer(scheduler, token)
+    , m_token(token)
 {
 }
 
@@ -76,11 +91,12 @@ bool TimedAction::is_pending() const
 
 TemporalActivation::TemporalActivation(Vruta::TaskScheduler& scheduler,
     Nodes::NodeGraphManager& node_graph_manager,
-    Buffers::BufferManager& buffer_manager)
+    Buffers::BufferManager& buffer_manager, Vruta::ProcessingToken token)
     : m_scheduler(scheduler)
     , m_node_graph_manager(node_graph_manager)
     , m_buffer_manager(buffer_manager)
-    , m_timer(scheduler)
+    , m_timer(scheduler, token)
+    , m_execution_token(token)
 {
 }
 

--- a/src/MayaFlux/Kriya/Timers.hpp
+++ b/src/MayaFlux/Kriya/Timers.hpp
@@ -49,12 +49,13 @@ public:
     /**
      * @brief Constructs a Timer with the specified scheduler
      * @param scheduler The TaskScheduler that will manage this timer
+     * @param token The processing token that determines the timing context for this timer (default is SAMPLE_ACCURATE)
      *
      * Creates a new Timer that will use the provided scheduler for
      * timing operations. The scheduler provides the sample clock and
      * task management infrastructure needed for precise timing.
      */
-    Timer(Vruta::TaskScheduler& scheduler);
+    Timer(Vruta::TaskScheduler& scheduler, Vruta::ProcessingToken token = Vruta::ProcessingToken::SAMPLE_ACCURATE);
     ~Timer() = default;
 
     /**
@@ -104,7 +105,7 @@ private:
      * It's created when schedule() is called and destroyed when the
      * callback executes or cancel() is called.
      */
-    std::shared_ptr<Vruta::SoundRoutine> m_routine;
+    std::shared_ptr<Vruta::Routine> m_routine;
 
     /**
      * @brief Flag indicating whether a callback is currently scheduled
@@ -121,6 +122,11 @@ private:
      * when the timer fires. It's cleared when cancel() is called.
      */
     std::function<void()> m_callback;
+
+    /**
+     * @brief The processing token that determines the timing context and thread evaluator for this timer
+     */
+    Vruta::ProcessingToken m_token;
 };
 
 /**
@@ -153,12 +159,13 @@ public:
     /**
      * @brief Constructs a TimedAction with the specified scheduler
      * @param scheduler The TaskScheduler that will manage this action
+     * @param token The processing token that determines the timing context for this action (default is SAMPLE_ACCURATE)
      *
      * Creates a new TimedAction that will use the provided scheduler for
      * timing operations. The scheduler provides the sample clock and
      * task management infrastructure needed for precise timing.
      */
-    TimedAction(Vruta::TaskScheduler& scheduler);
+    TimedAction(Vruta::TaskScheduler& scheduler, Vruta::ProcessingToken token = Vruta::ProcessingToken::SAMPLE_ACCURATE);
     ~TimedAction() = default;
 
     /**
@@ -209,6 +216,11 @@ private:
      * specified duration has elapsed.
      */
     Timer m_timer;
+
+    /**
+     * @brief The processing token that determines the timing context and thread evaluator for this action
+     */
+    Vruta::ProcessingToken m_token;
 };
 
 /**
@@ -236,6 +248,7 @@ public:
      * @param scheduler The TaskScheduler that will manage this timer
      * @param graph_manager The NodeGraphManager that will manage the processing nodes
      * @param buffer_manager The BufferManager that will manage any buffers needed for processing
+     * @param token The processing token that determines the timing context for this activation (default is SAMPLE_ACCURATE)
      *
      * Creates a new NodeTimer that will use the provided scheduler and
      * graph manager for timing and node management operations.
@@ -243,7 +256,8 @@ public:
     TemporalActivation(
         Vruta::TaskScheduler& scheduler,
         Nodes::NodeGraphManager& graph_manager,
-        Buffers::BufferManager& buffer_manager);
+        Buffers::BufferManager& buffer_manager,
+        Vruta::ProcessingToken token = Vruta::ProcessingToken::SAMPLE_ACCURATE);
 
     ~TemporalActivation() = default;
 
@@ -404,6 +418,15 @@ private:
      * buffer finishes playing or is cancelled.
      */
     Buffers::ProcessingToken m_buffer_token;
+
+    /**
+     * @brief The processing token associated with the currently active node, network or buffer
+     *
+     * This token is used to identify the processing context for the active node, network or buffer.
+     * It is set when play_for() or play_with_processing() is called and reset when the
+     * node, network or buffer finishes playing or is cancelled.
+     */
+    Vruta::ProcessingToken m_execution_token;
 
     /**
      * @brief The output channels the current node is connected to

--- a/src/MayaFlux/Nexus/Wiring.cpp
+++ b/src/MayaFlux/Nexus/Wiring.cpp
@@ -21,15 +21,17 @@ namespace MayaFlux::Nexus {
 // Scheduling modifiers
 // =============================================================================
 
-Wiring& Wiring::every(double interval_seconds)
+Wiring& Wiring::every(double interval_seconds, Vruta::ProcessingToken token)
 {
     m_interval = interval_seconds;
+    m_metro_token = token;
     return *this;
 }
 
-Wiring& Wiring::for_duration(double seconds)
+Wiring& Wiring::for_duration(double seconds, Vruta::ProcessingToken token)
 {
     m_duration = seconds;
+    m_duration_token = token;
     return *this;
 }
 
@@ -317,7 +319,7 @@ void Wiring::finalise()
         (*m_bind_attach)();
 
         if (m_duration.has_value() && m_bind_detach.has_value()) {
-            auto timer = std::make_shared<Kriya::Timer>(scheduler);
+            auto timer = std::make_shared<Kriya::Timer>(scheduler, m_duration_token);
             auto detach = *m_bind_detach;
             timer->schedule(*m_duration, [timer, detach]() {
                 detach();
@@ -447,9 +449,7 @@ void Wiring::finalise()
                     },
                         fab.m_registrations[id].member);
                 }
-                fab.fire(id);
-            }),
-            name, false);
+                fab.fire(id); }, m_metro_token), name, false);
 
         if (m_duration.has_value()) {
             auto cancel_name = make_name("nexus_metro_cancel");

--- a/src/MayaFlux/Nexus/Wiring.cpp
+++ b/src/MayaFlux/Nexus/Wiring.cpp
@@ -439,17 +439,16 @@ void Wiring::finalise()
         auto& fab = m_fabric;
 
         scheduler.add_task(
-            std::make_shared<Vruta::SoundRoutine>(
-                Kriya::metro(scheduler, *m_interval, [&fab, id, pos_fn]() mutable {
-                    if (pos_fn.has_value()) {
-                        glm::vec3 p = (*pos_fn)();
-                        std::visit([&p](const auto& ptr) {
-                            ptr->set_position(p);
-                        },
-                            fab.m_registrations[id].member);
-                    }
-                    fab.fire(id);
-                })),
+            Kriya::metro(*m_interval, [&fab, id, pos_fn]() mutable {
+                if (pos_fn.has_value()) {
+                    glm::vec3 p = (*pos_fn)();
+                    std::visit([&p](const auto& ptr) {
+                        ptr->set_position(p);
+                    },
+                        fab.m_registrations[id].member);
+                }
+                fab.fire(id);
+            }),
             name, false);
 
         if (m_duration.has_value()) {

--- a/src/MayaFlux/Nexus/Wiring.hpp
+++ b/src/MayaFlux/Nexus/Wiring.hpp
@@ -6,6 +6,8 @@
 #include "MayaFlux/Vruta/NetworkSource.hpp"
 #include "MayaFlux/Vruta/WindowEventSource.hpp"
 
+#include "MayaFlux/Core/ProcessingTokens.hpp"
+
 namespace MayaFlux::Core {
 class Window;
 }
@@ -53,14 +55,16 @@ public:
     /**
      * @brief Fire the entity on a recurring interval.
      * @param interval_seconds Period between invocations.
+     * @param token Scheduler rate to use (default: SAMPLE_ACCURATE).
      */
-    Wiring& every(double interval_seconds);
+    Wiring& every(double interval_seconds, Vruta::ProcessingToken token = Vruta::ProcessingToken::SAMPLE_ACCURATE);
 
     /**
      * @brief Limit a recurring registration to a fixed duration then cancel.
      * @param seconds Total active time. Pairs with @c every().
+     * @param token If set, uses the specified scheduler's clock for timing; otherwise defaults to SAMPLE_ACCURATE.
      */
-    Wiring& for_duration(double seconds);
+    Wiring& for_duration(double seconds, Vruta::ProcessingToken token = Vruta::ProcessingToken::SAMPLE_ACCURATE);
 
     /**
      * @brief Fire the entity on a key event from a window.
@@ -263,6 +267,8 @@ private:
     std::string m_position_fn_name;
     std::vector<MoveStep> m_move_steps;
     size_t m_times { 1 };
+    Vruta::ProcessingToken m_metro_token { Vruta::ProcessingToken::SAMPLE_ACCURATE };
+    Vruta::ProcessingToken m_duration_token { Vruta::ProcessingToken::SAMPLE_ACCURATE };
 
     Trigger m_trigger;
     Factory m_factory;

--- a/src/MayaFlux/Vruta/ChronUtils.hpp
+++ b/src/MayaFlux/Vruta/ChronUtils.hpp
@@ -1,13 +1,17 @@
 #pragma once
 
 namespace MayaFlux::Vruta {
+
+inline uint32_t s_registered_sample_rate { 48000 };
+inline uint32_t s_registered_frame_rate { 60 };
+
 /**
  * @brief Convert frames to seconds at a given frame rate
  * @param frames Number of frames
  * @param frame_rate Frame rate in Hz
  * @return Time duration in seconds
  */
-inline uint64_t frames_to_seconds(uint64_t frames, uint32_t frame_rate)
+inline uint64_t frames_to_seconds(uint64_t frames, uint32_t frame_rate = s_registered_frame_rate)
 {
     return frames / frame_rate;
 }
@@ -17,7 +21,7 @@ inline uint64_t frames_to_seconds(uint64_t frames, uint32_t frame_rate)
  * @param frame_rate Frame rate in Hz
  * @return Duration in milliseconds
  */
-inline std::chrono::milliseconds frame_duration_ms(uint32_t frame_rate)
+inline std::chrono::milliseconds frame_duration_ms(uint32_t frame_rate = s_registered_frame_rate)
 {
     return std::chrono::milliseconds(1000 / frame_rate);
 }
@@ -27,7 +31,7 @@ inline std::chrono::milliseconds frame_duration_ms(uint32_t frame_rate)
  * @param frame_rate Frame rate in Hz
  * @return Duration in microseconds
  */
-inline std::chrono::microseconds frame_duration_us(uint32_t frame_rate)
+inline std::chrono::microseconds frame_duration_us(uint32_t frame_rate = s_registered_frame_rate)
 {
     return std::chrono::microseconds(1000000 / frame_rate);
 }
@@ -38,7 +42,7 @@ inline std::chrono::microseconds frame_duration_us(uint32_t frame_rate)
  * @param frame_rate Frame rate in Hz
  * @return Duration in milliseconds
  */
-inline std::chrono::milliseconds frames_duration_ms(uint64_t num_frames, uint32_t frame_rate)
+inline std::chrono::milliseconds frames_duration_ms(uint64_t num_frames, uint32_t frame_rate = s_registered_frame_rate)
 {
     return std::chrono::milliseconds((num_frames * 1000) / frame_rate);
 }
@@ -49,7 +53,7 @@ inline std::chrono::milliseconds frames_duration_ms(uint64_t num_frames, uint32_
  * @param frame_rate Frame rate in Hz
  * @return Duration in microseconds
  */
-inline std::chrono::microseconds frames_duration_us(uint64_t num_frames, uint32_t frame_rate)
+inline std::chrono::microseconds frames_duration_us(uint64_t num_frames, uint32_t frame_rate = s_registered_frame_rate)
 {
     return std::chrono::microseconds((num_frames * 1000000) / frame_rate);
 }
@@ -59,7 +63,7 @@ inline std::chrono::microseconds frames_duration_us(uint64_t num_frames, uint32_
  * @param sample_rate Sample rate in Hz
  * @return Time duration in seconds
  */
-inline uint64_t samples_to_seconds(uint64_t samples, uint32_t sample_rate)
+inline uint64_t samples_to_seconds(uint64_t samples, uint32_t sample_rate = s_registered_sample_rate)
 {
     return samples / sample_rate;
 }
@@ -71,7 +75,7 @@ inline uint64_t samples_to_seconds(uint64_t samples, uint32_t sample_rate)
  * @param frame_rate Frame rate in Hz
  * @return Number of samples
  */
-inline uint64_t frames_to_samples(uint64_t frames, uint32_t sample_rate, uint32_t frame_rate)
+inline uint64_t frames_to_samples(uint64_t frames, uint32_t sample_rate = s_registered_sample_rate, uint32_t frame_rate = s_registered_frame_rate)
 {
     return (frames * sample_rate) / frame_rate;
 }
@@ -83,7 +87,7 @@ inline uint64_t frames_to_samples(uint64_t frames, uint32_t sample_rate, uint32_
  * @param frame_rate Frame rate in Hz
  * @return Number of frames
  */
-inline uint64_t samples_to_frames(uint64_t samples, uint32_t sample_rate, uint32_t frame_rate)
+inline uint64_t samples_to_frames(uint64_t samples, uint32_t sample_rate = s_registered_sample_rate, uint32_t frame_rate = s_registered_frame_rate)
 {
     return (samples * frame_rate) / sample_rate;
 }
@@ -94,7 +98,7 @@ inline uint64_t samples_to_frames(uint64_t samples, uint32_t sample_rate, uint32
  * @param sample_rate Sample rate in Hz
  * @return Number of samples
  */
-inline uint64_t seconds_to_samples(double seconds, uint32_t sample_rate)
+inline uint64_t seconds_to_samples(double seconds, uint32_t sample_rate = s_registered_sample_rate)
 {
     return static_cast<uint64_t>(seconds * sample_rate);
 }
@@ -105,7 +109,7 @@ inline uint64_t seconds_to_samples(double seconds, uint32_t sample_rate)
  * @param frame_rate Frame rate in Hz
  * @return Number of frames
  */
-inline uint64_t seconds_to_frames(double seconds, uint32_t frame_rate)
+inline uint64_t seconds_to_frames(double seconds, uint32_t frame_rate = s_registered_frame_rate)
 {
     return static_cast<uint64_t>(seconds * frame_rate);
 }

--- a/src/MayaFlux/Vruta/Scheduler.cpp
+++ b/src/MayaFlux/Vruta/Scheduler.cpp
@@ -1,5 +1,7 @@
 #include "Scheduler.hpp"
 
+#include "ChronUtils.hpp"
+
 #include "MayaFlux/Journal/Archivist.hpp"
 
 namespace MayaFlux::Vruta {
@@ -10,6 +12,8 @@ TaskScheduler::TaskScheduler(uint32_t default_sample_rate, uint32_t default_fram
     , m_registered_sample_rate(default_sample_rate)
     , m_registered_frame_rate(default_frame_rate)
 {
+    s_registered_sample_rate = default_sample_rate;
+    s_registered_frame_rate = default_frame_rate;
     ensure_domain(ProcessingToken::SAMPLE_ACCURATE, default_sample_rate);
     ensure_domain(ProcessingToken::FRAME_ACCURATE, default_frame_rate);
     ensure_domain(ProcessingToken::MULTI_RATE, default_sample_rate);

--- a/tests/core/engine_test.cpp
+++ b/tests/core/engine_test.cpp
@@ -273,9 +273,9 @@ TEST_F(EngineTest, SchedulerIntegrationWithCoroutines)
     EXPECT_NO_THROW(engine->Start());
 
     int execution_count = 0;
-    auto metro_routine = std::make_shared<Vruta::SoundRoutine>(Kriya::metro(*engine->get_scheduler(), 0.005, [&execution_count]() {
+    auto metro_routine = Kriya::metro(0.005, [&execution_count]() {
         execution_count++;
-    }));
+    });
 
     auto scheduler = engine->get_scheduler();
     ASSERT_NE(scheduler, nullptr);

--- a/tests/core/engine_test.cpp
+++ b/tests/core/engine_test.cpp
@@ -345,7 +345,7 @@ TEST_F(EngineTest, DataDrivenProcessingCapabilities)
         { 0.010, []() { /* Digital event 3 */ } }
     };
 
-    auto sequence_routine = std::make_shared<Vruta::SoundRoutine>(Kriya::sequence(*scheduler, sequence));
+    auto sequence_routine = Kriya::sequence(sequence);
     EXPECT_NO_THROW(scheduler->add_task(std::move(sequence_routine), "", false));
 
     EXPECT_NE(scheduler, nullptr);

--- a/tests/core/scheduler_test.cpp
+++ b/tests/core/scheduler_test.cpp
@@ -189,12 +189,11 @@ TEST_F(SchedulerTest, MetroTask)
     constexpr double interval = 0.01;
     uint64_t expected_samples = scheduler->seconds_to_samples(interval);
 
-    auto metro_task = Kriya::metro(*scheduler, interval, [&metro_count]() {
+    auto metro_task = Kriya::metro(interval, [&metro_count]() {
         metro_count++;
     });
 
-    auto task_ptr = std::make_shared<Vruta::SoundRoutine>(std::move(metro_task));
-    scheduler->add_task(task_ptr);
+    scheduler->add_task(metro_task);
 
     scheduler->process_token(token, expected_samples);
     EXPECT_EQ(metro_count, 1);
@@ -202,7 +201,7 @@ TEST_F(SchedulerTest, MetroTask)
     scheduler->process_token(token, expected_samples);
     EXPECT_EQ(metro_count, 2);
 
-    EXPECT_TRUE(scheduler->cancel_task(task_ptr));
+    EXPECT_TRUE(scheduler->cancel_task(metro_task));
 }
 
 TEST_F(SchedulerTest, LineTask)

--- a/tests/core/scheduler_test.cpp
+++ b/tests/core/scheduler_test.cpp
@@ -211,7 +211,7 @@ TEST_F(SchedulerTest, LineTask)
     float duration = 0.1f;
     uint32_t step_duration = 10;
 
-    auto line_task = Kriya::line(*scheduler, start_value, end_value, duration, step_duration, false);
+    auto line_task = Kriya::line(start_value, end_value, duration, step_duration, false);
     auto task_ptr = std::make_shared<Vruta::SoundRoutine>(std::move(line_task));
     ASSERT_NE(task_ptr, nullptr);
 
@@ -252,7 +252,7 @@ TEST_F(SchedulerTest, LineTaskRestart)
     uint32_t step_duration = 10;
     bool restartable = true;
 
-    auto line_task = Kriya::line(*scheduler, start_value, end_value, duration, step_duration, restartable);
+    auto line_task = Kriya::line(start_value, end_value, duration, step_duration, restartable);
     auto task_ptr = std::make_shared<Vruta::SoundRoutine>(std::move(line_task));
     scheduler->add_task(task_ptr, "", true);
 
@@ -286,7 +286,7 @@ TEST_F(SchedulerTest, TaskStateManagement)
 {
     const std::string task_name = "state_test";
 
-    auto line_task = Kriya::line(*scheduler, 0.0f, 10.0f, 0.1f, 5, false);
+    auto line_task = Kriya::line(0.0f, 10.0f, 0.1f, 5, false);
     auto task_ptr = std::make_shared<Vruta::SoundRoutine>(std::move(line_task));
     scheduler->add_task(task_ptr, task_name, true);
 

--- a/tests/tasks/tasks_test.cpp
+++ b/tests/tasks/tasks_test.cpp
@@ -222,7 +222,7 @@ TEST_F(TasksTest, LineTask)
     float end_value = 1.0F;
     float duration = 0.05F;
 
-    auto line_routine = std::make_shared<Vruta::SoundRoutine>(Kriya::line(*scheduler, start_value, end_value, duration, 5, false));
+    auto line_routine = std::make_shared<Vruta::SoundRoutine>(Kriya::line(start_value, end_value, duration, 5, false));
     scheduler->add_task(line_routine, "", true);
 
     auto current_value = line_routine->get_state<float>("current_value");
@@ -239,7 +239,7 @@ TEST_F(TasksTest, LineTask)
 
     EXPECT_FLOAT_EQ(*current_value, end_value);
 
-    auto restartable_line = std::make_shared<Vruta::SoundRoutine>(Kriya::line(*scheduler, 0.0F, 10.F, 0.05F, 5, true));
+    auto restartable_line = std::make_shared<Vruta::SoundRoutine>(Kriya::line(0.0F, 10.F, 0.05F, 5, true));
     scheduler->add_task(restartable_line, "", true);
 
     scheduler->process_token(Vruta::ProcessingToken::SAMPLE_ACCURATE, scheduler->seconds_to_samples(0.05));
@@ -324,7 +324,7 @@ TEST_F(TasksTest, GateTask)
     });
 
     auto gate_routine = std::make_shared<Vruta::SoundRoutine>(
-        Kriya::Gate(*scheduler, [&]() {
+        Kriya::Gate([&]() {
             gate_called = true;
             gate_count++; }, custom_logic, true));
 
@@ -353,7 +353,7 @@ TEST_F(TasksTest, GateTaskWithDefaultLogic)
     bool gate_called = false;
 
     auto gate_routine = std::make_shared<Vruta::SoundRoutine>(
-        Kriya::Gate(*scheduler, [&]() { gate_called = true; }, nullptr, true));
+        Kriya::Gate([&]() { gate_called = true; }, nullptr, true));
 
     scheduler->add_task(gate_routine);
 
@@ -376,7 +376,7 @@ TEST_F(TasksTest, TriggerTask)
     });
 
     auto rising_routine = std::make_shared<Vruta::SoundRoutine>(
-        Kriya::Trigger(*scheduler, true, [&]() {
+        Kriya::Trigger(true, [&]() {
             rising_triggered = true;
             rising_count++; }, toggle_logic));
 
@@ -386,7 +386,7 @@ TEST_F(TasksTest, TriggerTask)
     });
 
     auto falling_routine = std::make_shared<Vruta::SoundRoutine>(
-        Kriya::Trigger(*scheduler, false, [&]() {
+        Kriya::Trigger(false, [&]() {
             falling_triggered = true;
             falling_count++; }, toggle_logic2));
 
@@ -427,7 +427,7 @@ TEST_F(TasksTest, ToggleTask)
     });
 
     auto toggle_routine = std::make_shared<Vruta::SoundRoutine>(
-        Kriya::Toggle(*scheduler, [&]() {
+        Kriya::Toggle([&]() {
             toggle_called = true;
             toggle_count++; }, flip_logic));
 
@@ -461,7 +461,7 @@ TEST_F(TasksTest, LogicTasksWithEdgeDetection)
     edge_logic->set_edge_detection(Nodes::Generator::EdgeType::BOTH, 0.0);
 
     auto edge_routine = std::make_shared<Vruta::SoundRoutine>(
-        Kriya::Toggle(*scheduler, [&]() { edge_detected = true; }, edge_logic));
+        Kriya::Toggle([&]() { edge_detected = true; }, edge_logic));
 
     scheduler->add_task(edge_routine);
 
@@ -478,7 +478,7 @@ TEST_F(TasksTest, LogicTasksWithHysteresis)
     hysteresis_logic->set_hysteresis(0.2, 0.8);
 
     auto hysteresis_routine = std::make_shared<Vruta::SoundRoutine>(
-        Kriya::Trigger(*scheduler, true, [&]() { state_changed = true; }, hysteresis_logic));
+        Kriya::Trigger(true, [&]() { state_changed = true; }, hysteresis_logic));
 
     scheduler->add_task(hysteresis_routine);
 
@@ -505,13 +505,13 @@ TEST_F(TasksTest, MultipleLogicTasks)
     });
 
     auto gate1 = std::make_shared<Vruta::SoundRoutine>(
-        Kriya::Gate(*scheduler, [&]() { gate1_active = true; }, always_true));
+        Kriya::Gate([&]() { gate1_active = true; }, always_true));
 
     auto gate2 = std::make_shared<Vruta::SoundRoutine>(
-        Kriya::Gate(*scheduler, [&]() { gate2_active = true; }, toggle_logic));
+        Kriya::Gate([&]() { gate2_active = true; }, toggle_logic));
 
     auto change_task = std::make_shared<Vruta::SoundRoutine>(
-        Kriya::Toggle(*scheduler, [&]() { any_change = true; }, change_detector));
+        Kriya::Toggle([&]() { any_change = true; }, change_detector));
 
     scheduler->add_task(gate1);
     scheduler->add_task(gate2);
@@ -744,7 +744,7 @@ TEST_F(TasksTest, LogicTasksIntegration)
         });
 
     auto gate_routine = std::make_shared<Vruta::SoundRoutine>(
-        Kriya::Gate(*MayaFlux::get_scheduler(), [&]() { integration_triggered = true; }, time_logic));
+        Kriya::Gate([&]() { integration_triggered = true; }, time_logic));
 
     MayaFlux::get_scheduler()->add_task(gate_routine, "integration_gate");
 
@@ -798,7 +798,7 @@ TEST_F(TasksTest, TaskSchedulerTokenDomains)
 TEST_F(TasksTest, CoroutineStatePersistence)
 {
     auto line_routine = std::make_shared<Vruta::SoundRoutine>(
-        Kriya::line(*scheduler, 0.0F, 10.0F, 0.1F, 5, true));
+        Kriya::line(0.0F, 10.0F, 0.1F, 5, true));
 
     scheduler->add_task(line_routine, "persistent_line", true);
 

--- a/tests/tasks/tasks_test.cpp
+++ b/tests/tasks/tasks_test.cpp
@@ -266,9 +266,9 @@ TEST_F(TasksTest, PatternTask)
         return static_cast<int>(index * 10);
     };
 
-    auto callback = std::make_shared<Vruta::SoundRoutine>(Kriya::pattern(*scheduler, pattern_func, [&](std::any value) {
+    auto callback = Kriya::pattern(pattern_func, [&](std::any value) {
         pattern_count++;
-        received_values.push_back(std::any_cast<int>(value)); }, 0.01));
+        received_values.push_back(std::any_cast<int>(value)); }, 0.01);
 
     scheduler->add_task(callback);
 

--- a/tests/tasks/tasks_test.cpp
+++ b/tests/tasks/tasks_test.cpp
@@ -290,10 +290,10 @@ TEST_F(TasksTest, SequenceTask)
 {
     std::vector<int> execution_order;
 
-    auto sequence_routine = std::make_shared<Vruta::SoundRoutine>(Kriya::sequence(*scheduler,
+    auto sequence_routine = Kriya::sequence(
         { { 0.0, [&]() { execution_order.push_back(1); } },
             { 0.01, [&]() { execution_order.push_back(2); } },
-            { 0.01, [&]() { execution_order.push_back(3); } } }));
+            { 0.01, [&]() { execution_order.push_back(3); } } });
 
     scheduler->add_task(sequence_routine);
 

--- a/tests/tasks/tasks_test.cpp
+++ b/tests/tasks/tasks_test.cpp
@@ -189,10 +189,10 @@ TEST_F(TasksTest, CoroutineTasks)
     int metro_count = 0;
     double interval = 0.01;
 
-    auto metro_routine = std::make_shared<Vruta::SoundRoutine>(Kriya::metro(*scheduler, interval, [&]() {
+    auto metro_routine = Kriya::metro(interval, [&]() {
         metro_called = true;
         metro_count++;
-    }));
+    });
 
     scheduler->add_task(metro_routine);
 
@@ -760,7 +760,7 @@ TEST_F(TasksTest, LogicTasksIntegration)
 TEST_F(TasksTest, ProcessingTokens)
 {
 
-    auto routine = std::make_shared<Vruta::SoundRoutine>(Kriya::metro(*scheduler, 0.01, []() { }));
+    auto routine = Kriya::metro(0.01, []() { });
 
     EXPECT_EQ(routine->get_processing_token(), Vruta::ProcessingToken::SAMPLE_ACCURATE);
 
@@ -784,7 +784,7 @@ TEST_F(TasksTest, NodeGraphManagerIntegration)
 TEST_F(TasksTest, TaskSchedulerTokenDomains)
 {
 
-    auto sample_routine = std::make_shared<Vruta::SoundRoutine>(Kriya::metro(*scheduler, 0.01, []() { }));
+    auto sample_routine = Kriya::metro(0.01, []() { });
 
     scheduler->add_task(sample_routine, "sample_test");
 


### PR DESCRIPTION

MayaFlux treats audio and graphics as equal numerical substrates. The scheduling layer, however, had not caught up - every Kriya temporal primitive (`metro`, `sequence`, `line`, `pattern`, `Timer`, `EventChain`, `TemporalActivation`) was hardwired to the sample clock and resumed exclusively on the audio thread. Any callback scheduled through Kriya, regardless of what it actually did, occupied audio thread budget.

This PR closes that gap. Every temporal primitive now routes to the correct thread pump based on a `ProcessingToken`. The default is `SAMPLE_ACCURATE` so nothing breaks. Passing `FRAME_ACCURATE` produces a `GraphicsRoutine` that the frame clock pump resumes, with zero audio thread involvement.

## What changed and why

**ChronUtils globals.** `s_registered_sample_rate` and `s_registered_frame_rate` added as `inline` globals, written by `TaskScheduler` at construction. Every Kriya free function previously took a `TaskScheduler&` solely to call `seconds_to_samples`. That dependency is gone. `ChronUtils` free functions gain default parameters from these globals so existing call sites with explicit rates are unaffected.

**Kriya tasks drop the scheduler parameter.** `metro`, `sequence`, `pattern`, `line`, `Gate`, `Trigger`, `Toggle` no longer take `TaskScheduler&`. The scheduler was only ever used for rate conversion, which `ChronUtils` now provides directly. The signature reduction is real: every call site that previously passed `*scheduler` or `*get_scheduler()` just drops that argument.

**Token-driven dispatch.** `metro`, `sequence`, `pattern` each gain a `ProcessingToken` parameter defaulting to `SAMPLE_ACCURATE`. Internally they branch: `FRAME_ACCURATE` constructs a `GraphicsRoutine` using `GetGraphicsPromise`/`FrameDelay`; everything else constructs a `SoundRoutine`. Return type is `shared_ptr<Routine>` - the base the scheduler already consumes. No type erasure cost; the concrete type is alive inside the `shared_ptr`.

**`line` stays audio-only.** `line` is stateful - callers poll `get_state<float>("current_value")` through the base `Routine` interface. There is no visual-domain semantic for a sample-accurate interpolation. It stays `SoundRoutine` by value, which is the correct type for that use case.

**Timer, TimedAction, TemporalActivation, EventChain.** All four accept `ProcessingToken` at construction, defaulting to `SAMPLE_ACCURATE`. The token is forwarded to the internal coroutine bodies and to the cancel timer. A frame-clocked entity stays entirely on the graphics thread from start to cancellation.

**Temporal.cpp auto-derives the token from Domain.** `get_task_token()` already existed and already extracted `Vruta::ProcessingToken` from a `Domain`. `Temporal.cpp` now calls it and forwards to `TemporalActivation`. The result: `node >> Time(2.0) | Graphics` automatically produces a frame-clocked timer with no user action required.

**Wiring::every and for_duration.** Both gain a `ProcessingToken` parameter. The token is stored and passed to `Kriya::metro` and the cancel `Timer` in `finalise()`. A frame-clocked entity registered via `.every(0.016, ProcessingToken::FRAME_ACCURATE)` fires on the graphics thread and cancels on the graphics thread.

**Chronie cleanup.** The `create_` intermediate functions (`create_metro`, `create_sequence`, `create_pattern`) are removed. They existed as a half-step that `schedule_` then completed. `schedule_` functions now call Kriya directly. `create_line` is replaced by `schedule_line` which constructs, schedules, and returns a `shared_ptr<SoundRoutine>` - making the state access pattern explicit.

## What this enables

Graphics-domain callbacks - shader parameter updates, texture coordinate writes, Forma element mutations - can now be driven by Kriya primitives at frame rate without any audio thread contention. The pattern:

```cpp
Kriya::metro(1.0 / 60.0, [&]() {
    // update shader uniform, write to Forma element, etc.
}, ProcessingToken::FRAME_ACCURATE);
```

or through Nexus:

```cpp
fabric.wire(emitter)
    .every(1.0 / 60.0, ProcessingToken::FRAME_ACCURATE)
    .finalise();
```

Both are now first-class. The audio thread sees none of this.

## What is not changed

`BufferPipeline` and `CycleCoordinator` remain audio-centric. The buffer/cycle concept maps to audio blocks; there is no frame-domain equivalent with the same semantics.

`Gate`, `Trigger`, `Toggle` remain `SoundRoutine`. They drive a `Logic` node per sample, which is inherently sample-domain work. Frame-domain equivalents have no concrete caller yet.

`TaskScheduler` rate conversion methods (`seconds_to_samples`, `seconds_to_units`) are not removed despite the redundancy with `ChronUtils`. They have call sites outside the scope of this PR and removing them is a separate, non-urgent cleanup.

## Breaking changes

**Via Chronie API (`schedule_metro`, `schedule_sequence`, etc.):** none. All new parameters default to `SAMPLE_ACCURATE`.

**Direct Kriya calls:** breaking. The `TaskScheduler&` first parameter is removed from `metro`, `sequence`, `pattern`, `line`, `Gate`, `Trigger`, and `Toggle`. Any code calling these directly - outside the provided API wrappers - must drop the scheduler argument. The migration is mechanical: remove the first argument. No behavioral change unless a `ProcessingToken` is explicitly passed.

For reference, the before/after at the call site:

```cpp
// before
Kriya::metro(*scheduler, 0.5, cb);

// after
Kriya::metro(0.5, cb);
```

Users who built on top of Chronie are unaffected. Users who called Kriya functions directly - which the API surface never discouraged - have a straightforward mechanical update.

`metro`, `sequence`, and `pattern` also change their return type from a concrete routine value (`SoundRoutine` by value) to `shared_ptr<Routine>`. Code that stored the return as a typed value:

```cpp
// before
Vruta::SoundRoutine task = Kriya::metro(0.5, cb);
auto task_ptr = std::make_shared<Vruta::SoundRoutine>(std::move(task));
scheduler->add_task(task_ptr);

// after
auto task = Kriya::metro(0.5, cb); // shared_ptr<Routine>
scheduler->add_task(task);
```

Code that passed the return directly to `make_shared<SoundRoutine>(...)` - the common pattern - simplifies to a direct `add_task` call. Code that stored the return as `SoundRoutine` by value and called methods on it directly will not compile and must be updated to go through the `shared_ptr` or via name-based scheduler lookup.

`line` is the exception - it still returns `SoundRoutine` by value and is unchanged in this regard.