### PR TITLE
Window frame capture and broadcast event pipeline

### DIFF
--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.cpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.cpp
@@ -672,7 +672,8 @@ void BackendWindowHandler::render_empty_window(WindowRenderContext& ctx)
 
 void BackendWindowHandler::capture_frame(WindowRenderContext& ctx)
 {
-    if (!ctx.swapchain || ctx.window->get_rendering_buffers().empty())
+    if (!ctx.swapchain || ctx.window->get_rendering_buffers().empty()
+        || !ctx.window->is_capture_enabled())
         return;
 
     auto dev = m_context.get_device();

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.cpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.cpp
@@ -1,8 +1,9 @@
 #include "BackendWindowHandler.hpp"
 
-#include "MayaFlux/Core/Backends/Graphics/Vulkan/BackendResoureManager.hpp"
-#include "MayaFlux/Core/Backends/Graphics/Vulkan/VKImage.hpp"
+#include "BackendResoureManager.hpp"
 #include "VKCommandManager.hpp"
+#include "VKEnumUtils.hpp"
+#include "VKImage.hpp"
 #include "VKSwapchain.hpp"
 
 #include "MayaFlux/Core/Backends/Windowing/Window.hpp"
@@ -16,6 +17,24 @@ void WindowRenderContext::cleanup(VKContext& context)
     vk::Device device = context.get_device();
 
     device.waitIdle();
+
+    if (capture) {
+        capture->readback_running.store(false, std::memory_order_release);
+        if (capture->readback_thread.joinable())
+            capture->readback_thread.join();
+
+        for (auto& slot : capture->slots) {
+            if (slot->fence) {
+                (void)device.waitForFences(1, &slot->fence, VK_TRUE, UINT64_MAX);
+                device.destroyFence(slot->fence);
+            }
+            if (slot->image)
+                device.destroyImage(slot->image);
+            if (slot->mem)
+                device.freeMemory(slot->mem);
+        }
+        capture.reset();
+    }
 
     for (auto& img : image_available) {
         if (img) {
@@ -643,6 +662,190 @@ void BackendWindowHandler::render_empty_window(WindowRenderContext& ctx)
     }
 }
 
+void BackendWindowHandler::capture_frame(WindowRenderContext& ctx)
+{
+    if (!ctx.swapchain || ctx.window->get_rendering_buffers().empty())
+        return;
+
+    auto dev = m_context.get_device();
+    const auto ext = ctx.swapchain->get_extent();
+    const vk::Format fmt = ctx.swapchain->get_image_format();
+    const uint32_t bpp = Core::vk_format_bytes_per_pixel(fmt);
+    const vk::Image src = ctx.swapchain->get_images()[ctx.current_image_index];
+
+    if (!ctx.capture) {
+        ctx.capture = std::make_unique<CaptureState>();
+        ctx.capture->format = fmt;
+        ctx.capture->bpp = bpp;
+
+        const uint32_t count = ctx.swapchain->get_image_count();
+        ctx.capture->slots.reserve(count);
+        for (uint32_t i = 0; i < count; ++i) {
+            auto slot = std::make_unique<CaptureSlot>();
+            slot->cmd = m_command_manager.allocate_command_buffer(
+                vk::CommandBufferLevel::ePrimary);
+            slot->fence = dev.createFence({});
+            ctx.capture->slots.push_back(std::move(slot));
+        }
+
+        start_readback_thread(*ctx.capture, dev);
+    }
+
+    auto& slot = *ctx.capture->slots[ctx.capture->slot_index];
+
+    if (slot.pending.load(std::memory_order_acquire))
+        return;
+
+    if (slot.image && slot.extent != ext) {
+        dev.destroyImage(slot.image);
+        dev.freeMemory(slot.mem);
+        slot.image = vk::Image {};
+        slot.mem = vk::DeviceMemory {};
+    }
+
+    if (!slot.image) {
+        vk::ImageCreateInfo ici {};
+        ici.imageType = vk::ImageType::e2D;
+        ici.format = fmt;
+        ici.extent = vk::Extent3D { ext.width, ext.height, 1 };
+        ici.arrayLayers = 1;
+        ici.mipLevels = 1;
+        ici.samples = vk::SampleCountFlagBits::e1;
+        ici.tiling = vk::ImageTiling::eLinear;
+        ici.usage = vk::ImageUsageFlagBits::eTransferDst;
+
+        slot.image = dev.createImage(ici);
+
+        auto req = dev.getImageMemoryRequirements(slot.image);
+        vk::MemoryAllocateInfo mai {};
+        mai.allocationSize = req.size;
+        mai.memoryTypeIndex = m_resource_manager->find_memory_type(
+            req.memoryTypeBits,
+            vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent);
+
+        slot.mem = dev.allocateMemory(mai);
+        dev.bindImageMemory(slot.image, slot.mem, 0);
+        slot.extent = ext;
+    }
+
+    slot.cmd.reset({});
+    vk::CommandBufferBeginInfo bi {};
+    bi.flags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit;
+    slot.cmd.begin(bi);
+
+    vk::ImageMemoryBarrier b {};
+    b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    b.subresourceRange = { vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1 };
+
+    b.image = slot.image;
+    b.oldLayout = vk::ImageLayout::eUndefined;
+    b.newLayout = vk::ImageLayout::eTransferDstOptimal;
+    b.srcAccessMask = {};
+    b.dstAccessMask = vk::AccessFlagBits::eTransferWrite;
+    slot.cmd.pipelineBarrier(vk::PipelineStageFlagBits::eTransfer,
+        vk::PipelineStageFlagBits::eTransfer, {}, {}, {}, b);
+
+    b.image = src;
+    b.oldLayout = vk::ImageLayout::ePresentSrcKHR;
+    b.newLayout = vk::ImageLayout::eTransferSrcOptimal;
+    b.srcAccessMask = vk::AccessFlagBits::eMemoryRead;
+    b.dstAccessMask = vk::AccessFlagBits::eTransferRead;
+    slot.cmd.pipelineBarrier(vk::PipelineStageFlagBits::eTransfer,
+        vk::PipelineStageFlagBits::eTransfer, {}, {}, {}, b);
+
+    vk::ImageCopy copy {};
+    copy.srcSubresource = { vk::ImageAspectFlagBits::eColor, 0, 0, 1 };
+    copy.dstSubresource = { vk::ImageAspectFlagBits::eColor, 0, 0, 1 };
+    copy.extent = vk::Extent3D { ext.width, ext.height, 1 };
+    slot.cmd.copyImage(src, vk::ImageLayout::eTransferSrcOptimal,
+        slot.image, vk::ImageLayout::eTransferDstOptimal, 1, &copy);
+
+    b.image = slot.image;
+    b.oldLayout = vk::ImageLayout::eTransferDstOptimal;
+    b.newLayout = vk::ImageLayout::eGeneral;
+    b.srcAccessMask = vk::AccessFlagBits::eTransferWrite;
+    b.dstAccessMask = vk::AccessFlagBits::eMemoryRead;
+    slot.cmd.pipelineBarrier(vk::PipelineStageFlagBits::eTransfer,
+        vk::PipelineStageFlagBits::eTransfer, {}, {}, {}, b);
+
+    b.image = src;
+    b.oldLayout = vk::ImageLayout::eTransferSrcOptimal;
+    b.newLayout = vk::ImageLayout::ePresentSrcKHR;
+    b.srcAccessMask = vk::AccessFlagBits::eTransferRead;
+    b.dstAccessMask = vk::AccessFlagBits::eMemoryRead;
+    slot.cmd.pipelineBarrier(vk::PipelineStageFlagBits::eTransfer,
+        vk::PipelineStageFlagBits::eTransfer, {}, {}, {}, b);
+
+    slot.cmd.end();
+
+    (void)dev.resetFences(1, &slot.fence);
+
+    vk::SubmitInfo si {};
+    si.commandBufferCount = 1;
+    si.pCommandBuffers = &slot.cmd;
+
+    slot.pending.store(true, std::memory_order_release);
+
+    if (auto result = m_context.get_graphics_queue().submit(1, &si, slot.fence); result != vk::Result::eSuccess) {
+        MF_RT_ERROR(Journal::Component::Core, Journal::Context::GraphicsCallback,
+            "Failed to submit capture command buffer for window '{}': {}",
+            ctx.window->get_create_info().title, vk::to_string(result));
+        slot.pending.store(false, std::memory_order_release);
+        return;
+    }
+
+    ctx.capture->slot_index = (ctx.capture->slot_index + 1) % ctx.capture->slots.size();
+}
+
+void BackendWindowHandler::start_readback_thread(CaptureState& state, vk::Device dev)
+{
+    state.readback_running.store(true, std::memory_order_release);
+
+    state.readback_thread = std::thread([&state, dev]() {
+        while (state.readback_running.load(std::memory_order_acquire)) {
+            bool any = false;
+
+            for (auto& slot_ptr : state.slots) {
+                auto& slot = *slot_ptr;
+
+                if (!slot.pending.load(std::memory_order_acquire))
+                    continue;
+
+                if (dev.getFenceStatus(slot.fence) != vk::Result::eSuccess)
+                    continue;
+
+                const size_t nb = static_cast<size_t>(slot.extent.width)
+                    * slot.extent.height * state.bpp;
+
+                vk::SubresourceLayout layout = dev.getImageSubresourceLayout(
+                    slot.image, { vk::ImageAspectFlagBits::eColor, 0, 0 });
+
+                const auto* mapped = static_cast<const uint8_t*>(
+                    dev.mapMemory(slot.mem, 0, VK_WHOLE_SIZE));
+                mapped += layout.offset;
+
+                auto buf = std::make_shared<std::vector<uint8_t>>(nb);
+                const uint32_t row_bytes = slot.extent.width * state.bpp;
+                for (uint32_t y = 0; y < slot.extent.height; ++y) {
+                    std::memcpy(buf->data() + static_cast<size_t>(y * row_bytes),
+                        mapped + y * layout.rowPitch,
+                        row_bytes);
+                }
+
+                dev.unmapMemory(slot.mem);
+
+                state.last_frame.store(std::move(buf), std::memory_order_release);
+                slot.pending.store(false, std::memory_order_release);
+                any = true;
+            }
+
+            if (!any)
+                std::this_thread::sleep_for(std::chrono::microseconds(200));
+        }
+    });
+}
+
 void BackendWindowHandler::submit_and_present(
     const std::shared_ptr<Window>& window,
     const vk::CommandBuffer& command_buffer)
@@ -698,6 +901,9 @@ void BackendWindowHandler::submit_and_present(
     if (!present_success) {
         ctx->needs_recreation = true;
     }
+
+    if (present_success)
+        capture_frame(*ctx);
 
     ctx->current_frame = (frame_index + 1) % ctx->in_flight.size();
 

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.cpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.cpp
@@ -1080,7 +1080,7 @@ void BackendWindowHandler::start_readback_thread(CaptureState& state, vk::Device
                 if (old)
                     state.retire_last_frame(old);
 #else
-                state.last_frame.store(std::move(buf), std::memory_order_release);
+                state.last_frame.store(buf, std::memory_order_release);
 #endif
 
 // ---------------------------------------------------------------

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.cpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.cpp
@@ -327,6 +327,57 @@ void BackendWindowHandler::setup_backend_service(const std::shared_ptr<Registry:
             return nullptr;
         return ctx->capture->last_frame.load(std::memory_order_acquire);
     };
+
+    display_service->register_frame_observer = [this](
+                                                   const std::shared_ptr<void>& window_ptr,
+                                                   const std::function<void(
+                                                       const std::shared_ptr<std::vector<uint8_t>>&,
+                                                       uint32_t, uint32_t, uint32_t)>&
+                                                       cb) -> uint32_t {
+        auto* ctx = find_window_context(std::static_pointer_cast<Window>(window_ptr));
+        if (!ctx) {
+            MF_WARN(Journal::Component::Core, Journal::Context::GraphicsBackend,
+                "register_frame_observer: window not registered with graphics backend");
+            return 0;
+        }
+        if (!ctx->capture) {
+            MF_WARN(Journal::Component::Core, Journal::Context::GraphicsBackend,
+                "register_frame_observer: capture not active for '{}'; call set_capture_enabled(true) before registering an observer",
+                ctx->window->get_create_info().title);
+            return 0;
+        }
+
+        auto& state = *ctx->capture;
+        uint32_t id = state.next_observer_id.fetch_add(1, std::memory_order_relaxed);
+
+        auto current = state.observers.load(std::memory_order_acquire);
+        std::shared_ptr<CaptureState::ObserverMap> next;
+        do {
+            next = std::make_shared<CaptureState::ObserverMap>(*current);
+            (*next)[id] = cb;
+        } while (!state.observers.compare_exchange_weak(
+            current, next,
+            std::memory_order_release, std::memory_order_acquire));
+
+        return id;
+    };
+
+    display_service->unregister_frame_observer = [this](
+                                                     const std::shared_ptr<void>& window_ptr, uint32_t id) {
+        auto* ctx = find_window_context(std::static_pointer_cast<Window>(window_ptr));
+        if (!ctx || !ctx->capture)
+            return;
+
+        auto& state = *ctx->capture;
+        auto current = state.observers.load(std::memory_order_acquire);
+        std::shared_ptr<CaptureState::ObserverMap> next;
+        do {
+            next = std::make_shared<CaptureState::ObserverMap>(*current);
+            next->erase(id);
+        } while (!state.observers.compare_exchange_weak(
+            current, next,
+            std::memory_order_release, std::memory_order_acquire));
+    };
 }
 
 WindowRenderContext* BackendWindowHandler::find_window_context(const std::shared_ptr<Window>& window)
@@ -845,6 +896,16 @@ void BackendWindowHandler::start_readback_thread(CaptureState& state, vk::Device
                 dev.unmapMemory(slot.mem);
 
                 state.last_frame.store(std::move(buf), std::memory_order_release);
+
+                auto obs = state.observers.load(std::memory_order_acquire);
+                for (auto& [id, cb] : *obs) {
+                    cb(buf, slot.extent.width, slot.extent.height,
+                        static_cast<uint32_t>(state.format));
+                }
+
+                slot.pending.store(false, std::memory_order_release);
+                any = true;
+
                 slot.pending.store(false, std::memory_order_release);
                 any = true;
             }

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.cpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.cpp
@@ -319,6 +319,14 @@ void BackendWindowHandler::setup_backend_service(const std::shared_ptr<Registry:
         }
         return static_cast<uint32_t>(ctx->depth_image->get_format());
     };
+
+    display_service->get_last_frame = [this](const std::shared_ptr<void>& window_ptr)
+        -> std::shared_ptr<std::vector<uint8_t>> {
+        auto* ctx = find_window_context(std::static_pointer_cast<Window>(window_ptr));
+        if (!ctx || !ctx->capture)
+            return nullptr;
+        return ctx->capture->last_frame.load(std::memory_order_acquire);
+    };
 }
 
 WindowRenderContext* BackendWindowHandler::find_window_context(const std::shared_ptr<Window>& window)

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.cpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.cpp
@@ -16,10 +16,10 @@ void WindowRenderContext::cleanup(VKContext& context)
 {
     vk::Device device = context.get_device();
 
-    device.waitIdle();
-
     if (capture) {
         capture->readback_running.store(false, std::memory_order_release);
+        device.waitIdle();
+
         if (capture->readback_thread.joinable())
             capture->readback_thread.join();
 
@@ -35,6 +35,8 @@ void WindowRenderContext::cleanup(VKContext& context)
         }
         capture.reset();
     }
+
+    device.waitIdle();
 
     for (auto& img : image_available) {
         if (img) {
@@ -365,8 +367,17 @@ void BackendWindowHandler::setup_backend_service(const std::shared_ptr<Registry:
     display_service->unregister_frame_observer = [this](
                                                      const std::shared_ptr<void>& window_ptr, uint32_t id) {
         auto* ctx = find_window_context(std::static_pointer_cast<Window>(window_ptr));
-        if (!ctx || !ctx->capture)
+        if (!ctx) {
+            MF_WARN(Journal::Component::Core, Journal::Context::GraphicsBackend,
+                "unregister_frame_observer: window not registered with graphics backend");
             return;
+        }
+        if (!ctx->capture) {
+            MF_WARN(Journal::Component::Core, Journal::Context::GraphicsBackend,
+                "unregister_frame_observer: capture not active for '{}'",
+                ctx->window->get_create_info().title);
+            return;
+        }
 
         auto& state = *ctx->capture;
         auto current = state.observers.load(std::memory_order_acquire);
@@ -902,9 +913,6 @@ void BackendWindowHandler::start_readback_thread(CaptureState& state, vk::Device
                     cb(buf, slot.extent.width, slot.extent.height,
                         static_cast<uint32_t>(state.format));
                 }
-
-                slot.pending.store(false, std::memory_order_release);
-                any = true;
 
                 slot.pending.store(false, std::memory_order_release);
                 any = true;

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.cpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.cpp
@@ -343,10 +343,7 @@ void BackendWindowHandler::setup_backend_service(const std::shared_ptr<Registry:
             return 0;
         }
         if (!ctx->capture) {
-            MF_WARN(Journal::Component::Core, Journal::Context::GraphicsBackend,
-                "register_frame_observer: capture not active for '{}'; call set_capture_enabled(true) before registering an observer",
-                ctx->window->get_create_info().title);
-            return 0;
+            ensure_capture_state(*ctx);
         }
 
         auto& state = *ctx->capture;
@@ -732,6 +729,32 @@ void BackendWindowHandler::render_empty_window(WindowRenderContext& ctx)
     }
 }
 
+void BackendWindowHandler::ensure_capture_state(WindowRenderContext& ctx)
+{
+    if (ctx.capture || !ctx.swapchain || !ctx.window->is_capture_enabled())
+        return;
+
+    auto dev = m_context.get_device();
+    const vk::Format fmt = ctx.swapchain->get_image_format();
+    const uint32_t bpp = Core::vk_format_bytes_per_pixel(fmt);
+
+    ctx.capture = std::make_unique<CaptureState>();
+    ctx.capture->format = fmt;
+    ctx.capture->bpp = bpp;
+
+    const uint32_t count = ctx.swapchain->get_image_count();
+    ctx.capture->slots.reserve(count);
+    for (uint32_t i = 0; i < count; ++i) {
+        auto slot = std::make_unique<CaptureSlot>();
+        slot->cmd = m_command_manager.allocate_command_buffer(
+            vk::CommandBufferLevel::ePrimary);
+        slot->fence = dev.createFence({});
+        ctx.capture->slots.push_back(std::move(slot));
+    }
+
+    start_readback_thread(*ctx.capture, dev);
+}
+
 void BackendWindowHandler::capture_frame(WindowRenderContext& ctx)
 {
     if (!ctx.swapchain || ctx.window->get_rendering_buffers().empty()
@@ -745,21 +768,7 @@ void BackendWindowHandler::capture_frame(WindowRenderContext& ctx)
     const vk::Image src = ctx.swapchain->get_images()[ctx.current_image_index];
 
     if (!ctx.capture) {
-        ctx.capture = std::make_unique<CaptureState>();
-        ctx.capture->format = fmt;
-        ctx.capture->bpp = bpp;
-
-        const uint32_t count = ctx.swapchain->get_image_count();
-        ctx.capture->slots.reserve(count);
-        for (uint32_t i = 0; i < count; ++i) {
-            auto slot = std::make_unique<CaptureSlot>();
-            slot->cmd = m_command_manager.allocate_command_buffer(
-                vk::CommandBufferLevel::ePrimary);
-            slot->fence = dev.createFence({});
-            ctx.capture->slots.push_back(std::move(slot));
-        }
-
-        start_readback_thread(*ctx.capture, dev);
+        ensure_capture_state(ctx);
     }
 
     auto& slot = *ctx.capture->slots[ctx.capture->slot_index];

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.cpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.cpp
@@ -12,6 +12,46 @@
 
 namespace MayaFlux::Core {
 
+// ---------------------------------------------------------------------------
+// CaptureState retirement implementations (macOS only)
+// ---------------------------------------------------------------------------
+#ifdef MAYAFLUX_PLATFORM_MACOS
+
+void CaptureState::retire_last_frame(const std::vector<uint8_t>* ptr)
+{
+    for (;;) {
+        bool in_use = false;
+        for (size_t i = 0; i < LAST_FRAME_MAX_READERS; ++i) {
+            if (last_frame_hazard_ptrs[i].load(std::memory_order_acquire) == ptr) {
+                in_use = true;
+                break;
+            }
+        }
+        if (!in_use)
+            break;
+        std::this_thread::yield();
+    }
+    delete ptr;
+}
+
+void CaptureState::retire_observers(const ObserverMap* ptr)
+{
+    for (;;) {
+        bool in_use = false;
+        for (size_t i = 0; i < OBSERVERS_MAX_READERS; ++i) {
+            if (observers_hazard_ptrs[i].load(std::memory_order_acquire) == ptr) {
+                in_use = true;
+                break;
+            }
+        }
+        if (!in_use)
+            break;
+        std::this_thread::yield();
+    }
+    delete ptr;
+}
+#endif
+
 void WindowRenderContext::cleanup(VKContext& context)
 {
     vk::Device device = context.get_device();
@@ -322,14 +362,55 @@ void BackendWindowHandler::setup_backend_service(const std::shared_ptr<Registry:
         return static_cast<uint32_t>(ctx->depth_image->get_format());
     };
 
+    // ======================================================================
+    // get_last_frame – hazard‑pointer protected read + copy
+    // ======================================================================
     display_service->get_last_frame = [this](const std::shared_ptr<void>& window_ptr)
         -> std::shared_ptr<std::vector<uint8_t>> {
         auto* ctx = find_window_context(std::static_pointer_cast<Window>(window_ptr));
         if (!ctx || !ctx->capture)
             return nullptr;
+
+#ifdef MAYAFLUX_PLATFORM_MACOS
+        auto& state = *ctx->capture;
+
+        size_t slot = CaptureState::LAST_FRAME_MAX_READERS;
+        for (size_t i = 0; i < CaptureState::LAST_FRAME_MAX_READERS; ++i) {
+            bool expected = false;
+            if (state.last_frame_slot_active[i].compare_exchange_strong(expected, true, std::memory_order_acquire)) {
+                slot = i;
+                break;
+            }
+        }
+        if (slot == CaptureState::LAST_FRAME_MAX_READERS)
+            return nullptr;
+
+        const std::vector<uint8_t>* raw;
+        do {
+            raw = state.last_frame.load(std::memory_order_acquire);
+            state.last_frame_hazard_ptrs[slot].store(raw, std::memory_order_release);
+        } while (raw != state.last_frame.load(std::memory_order_acquire));
+
+        if (!raw) {
+            state.last_frame_hazard_ptrs[slot].store(nullptr, std::memory_order_release);
+            state.last_frame_slot_active[slot].store(false, std::memory_order_release);
+            return nullptr;
+        }
+
+        return std::shared_ptr<std::vector<uint8_t>>(
+            const_cast<std::vector<uint8_t>*>(raw),
+            [&state, slot](std::vector<uint8_t>*) {
+                state.last_frame_hazard_ptrs[slot].store(nullptr, std::memory_order_release);
+                state.last_frame_slot_active[slot].store(false, std::memory_order_release);
+            });
+#else
         return ctx->capture->last_frame.load(std::memory_order_acquire);
+#endif
     };
 
+    // ======================================================================
+    // register_frame_observer – hazard‑pointer update of observer map
+    // ======================================================================
     display_service->register_frame_observer = [this](
                                                    const std::shared_ptr<void>& window_ptr,
                                                    const std::function<void(
@@ -349,6 +430,41 @@ void BackendWindowHandler::setup_backend_service(const std::shared_ptr<Registry:
         auto& state = *ctx->capture;
         uint32_t id = state.next_observer_id.fetch_add(1, std::memory_order_relaxed);
 
+#ifdef MAYAFLUX_PLATFORM_MACOS
+        size_t obs_slot = CaptureState::OBSERVERS_MAX_READERS;
+        for (size_t i = 0; i < CaptureState::OBSERVERS_MAX_READERS; ++i) {
+            bool expected = false;
+            if (state.observers_slot_active[i].compare_exchange_strong(expected, true, std::memory_order_acquire)) {
+                obs_slot = i;
+                break;
+            }
+        }
+        if (obs_slot == CaptureState::OBSERVERS_MAX_READERS)
+            return 0;
+
+        const CaptureState::ObserverMap* current;
+        CaptureState::ObserverMap* new_map = nullptr;
+
+        do {
+            if (new_map)
+                delete new_map;
+
+            do {
+                current = state.observers.load(std::memory_order_acquire);
+                state.observers_hazard_ptrs[obs_slot].store(current, std::memory_order_release);
+            } while (current != state.observers.load(std::memory_order_acquire));
+
+            new_map = new CaptureState::ObserverMap(current ? *current : CaptureState::ObserverMap {});
+            (*new_map)[id] = cb;
+
+        } while (!state.observers.compare_exchange_weak(current, new_map, std::memory_order_acq_rel, std::memory_order_acquire));
+
+        state.observers_hazard_ptrs[obs_slot].store(nullptr, std::memory_order_release);
+        state.observers_slot_active[obs_slot].store(false, std::memory_order_release);
+
+        if (current)
+            state.retire_observers(current);
+#else
         auto current = state.observers.load(std::memory_order_acquire);
         std::shared_ptr<CaptureState::ObserverMap> next;
         do {
@@ -357,10 +473,13 @@ void BackendWindowHandler::setup_backend_service(const std::shared_ptr<Registry:
         } while (!state.observers.compare_exchange_weak(
             current, next,
             std::memory_order_release, std::memory_order_acquire));
-
+#endif
         return id;
     };
 
+    // ======================================================================
+    // unregister_frame_observer – hazard‑pointer update
+    // ======================================================================
     display_service->unregister_frame_observer = [this](
                                                      const std::shared_ptr<void>& window_ptr, uint32_t id) {
         auto* ctx = find_window_context(std::static_pointer_cast<Window>(window_ptr));
@@ -377,6 +496,42 @@ void BackendWindowHandler::setup_backend_service(const std::shared_ptr<Registry:
         }
 
         auto& state = *ctx->capture;
+
+#ifdef MAYAFLUX_PLATFORM_MACOS
+        size_t obs_slot = CaptureState::OBSERVERS_MAX_READERS;
+        for (size_t i = 0; i < CaptureState::OBSERVERS_MAX_READERS; ++i) {
+            bool expected = false;
+            if (state.observers_slot_active[i].compare_exchange_strong(expected, true, std::memory_order_acquire)) {
+                obs_slot = i;
+                break;
+            }
+        }
+        if (obs_slot == CaptureState::OBSERVERS_MAX_READERS)
+            return;
+
+        const CaptureState::ObserverMap* current;
+        CaptureState::ObserverMap* new_map = nullptr;
+
+        do {
+            if (new_map)
+                delete new_map;
+
+            do {
+                current = state.observers.load(std::memory_order_acquire);
+                state.observers_hazard_ptrs[obs_slot].store(current, std::memory_order_release);
+            } while (current != state.observers.load(std::memory_order_acquire));
+
+            new_map = new CaptureState::ObserverMap(current ? *current : CaptureState::ObserverMap {});
+            new_map->erase(id);
+
+        } while (!state.observers.compare_exchange_weak(current, new_map, std::memory_order_acq_rel, std::memory_order_acquire));
+
+        state.observers_hazard_ptrs[obs_slot].store(nullptr, std::memory_order_release);
+        state.observers_slot_active[obs_slot].store(false, std::memory_order_release);
+
+        if (current)
+            state.retire_observers(current);
+#else
         auto current = state.observers.load(std::memory_order_acquire);
         std::shared_ptr<CaptureState::ObserverMap> next;
         do {
@@ -385,6 +540,7 @@ void BackendWindowHandler::setup_backend_service(const std::shared_ptr<Registry:
         } while (!state.observers.compare_exchange_weak(
             current, next,
             std::memory_order_release, std::memory_order_acquire));
+#endif
     };
 }
 
@@ -915,13 +1071,57 @@ void BackendWindowHandler::start_readback_thread(CaptureState& state, vk::Device
 
                 dev.unmapMemory(slot.mem);
 
+                // ---------------------------------------------------------------
+                // Store new frame into last_frame (same pattern as InputManager)
+                // ---------------------------------------------------------------
+#ifdef MAYAFLUX_PLATFORM_MACOS
+                auto* raw_frame = new std::vector<uint8_t>(std::move(*buf));
+                auto* old = state.last_frame.exchange(raw_frame, std::memory_order_acq_rel);
+                if (old)
+                    state.retire_last_frame(old);
+#else
                 state.last_frame.store(std::move(buf), std::memory_order_release);
+#endif
 
-                auto obs = state.observers.load(std::memory_order_acquire);
-                for (auto& [id, cb] : *obs) {
-                    cb(buf, slot.extent.width, slot.extent.height,
-                        static_cast<uint32_t>(state.format));
+// ---------------------------------------------------------------
+// Read observers and invoke callbacks
+// ---------------------------------------------------------------
+#ifdef MAYAFLUX_PLATFORM_MACOS
+                size_t obs_slot = CaptureState::OBSERVERS_MAX_READERS;
+                for (size_t i = 0; i < CaptureState::OBSERVERS_MAX_READERS; ++i) {
+                    bool expected = false;
+                    if (state.observers_slot_active[i].compare_exchange_strong(expected, true, std::memory_order_acquire)) {
+                        obs_slot = i;
+                        break;
+                    }
                 }
+
+                if (obs_slot != CaptureState::OBSERVERS_MAX_READERS) {
+                    const CaptureState::ObserverMap* obs_current;
+                    do {
+                        obs_current = state.observers.load(std::memory_order_acquire);
+                        state.observers_hazard_ptrs[obs_slot].store(obs_current, std::memory_order_release);
+                    } while (obs_current != state.observers.load(std::memory_order_acquire));
+
+                    if (obs_current) {
+                        for (const auto& [id, cb] : *obs_current) {
+                            cb(buf, slot.extent.width, slot.extent.height,
+                                static_cast<uint32_t>(state.format));
+                        }
+                    }
+
+                    state.observers_hazard_ptrs[obs_slot].store(nullptr, std::memory_order_release);
+                    state.observers_slot_active[obs_slot].store(false, std::memory_order_release);
+                }
+#else
+                auto obs = state.observers.load(std::memory_order_acquire);
+                if (obs) {
+                    for (const auto& [id, cb] : *obs) {
+                        cb(buf, slot.extent.width, slot.extent.height,
+                            static_cast<uint32_t>(state.format));
+                    }
+                }
+#endif
 
                 slot.pending.store(false, std::memory_order_release);
                 any = true;
@@ -1036,4 +1236,4 @@ void BackendWindowHandler::cleanup()
     m_window_contexts.clear();
 }
 
-}
+} // namespace MayaFlux::Core

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.hpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.hpp
@@ -15,6 +15,32 @@ class VKCommandManager;
 class Window;
 class BackendResourceManager;
 
+struct CaptureSlot {
+    vk::Image image {};
+    vk::DeviceMemory mem {};
+    vk::Extent2D extent {};
+    vk::CommandBuffer cmd {};
+    vk::Fence fence {};
+    std::atomic<bool> pending { false };
+};
+
+struct CaptureState {
+    std::atomic<std::shared_ptr<std::vector<uint8_t>>> last_frame;
+    std::vector<std::unique_ptr<CaptureSlot>> slots;
+    size_t slot_index {};
+    vk::Format format {};
+    uint32_t bpp {};
+    std::thread readback_thread;
+    std::atomic<bool> readback_running { false };
+
+    ~CaptureState()
+    {
+        readback_running.store(false, std::memory_order_release);
+        if (readback_thread.joinable())
+            readback_thread.join();
+    }
+};
+
 struct WindowRenderContext {
     std::shared_ptr<Window> window;
     vk::SurfaceKHR surface;
@@ -30,6 +56,8 @@ struct WindowRenderContext {
     bool needs_recreation {};
     size_t current_frame {};
     uint32_t current_image_index {};
+
+    std::unique_ptr<CaptureState> capture;
 
     WindowRenderContext() = default;
     ~WindowRenderContext() = default;
@@ -130,6 +158,27 @@ private:
      * to input events.
      */
     void render_empty_window(WindowRenderContext& ctx);
+
+    /**
+     * @brief Capture the current frame from a window's swapchain
+     * @param ctx Window render context to capture from
+     *
+     * This initiates an asynchronous readback of the current swapchain image into
+     * CPU-accessible memory. The result is stored in the capture state for retrieval
+     * via the display service.
+     */
+    void capture_frame(WindowRenderContext& ctx);
+
+    /**
+     * @brief Thread function to perform asynchronous readback of captured frames
+     * @param state Capture state containing pending readbacks
+     * @param dev Vulkan device to use for readback operations
+     *
+     * This thread continuously checks for pending capture slots and performs the necessary
+     * Vulkan commands to read back the image data into CPU memory. The last captured frame
+     * is stored atomically for retrieval by the display service.
+     */
+    void start_readback_thread(CaptureState& state, vk::Device dev);
 
     BackendResourceManager* m_resource_manager {};
 };

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.hpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.hpp
@@ -170,6 +170,16 @@ private:
     void render_empty_window(WindowRenderContext& ctx);
 
     /**
+     * @brief Ensure capture state is initialized for a window context
+     * @param ctx Window render context to initialize capture state for
+     *
+     * If the context does not already have capture state and the associated window has
+     * capture enabled, this initializes the capture state including allocating command buffers
+     * and synchronization objects for readback.
+     */
+    void ensure_capture_state(WindowRenderContext& ctx);
+
+    /**
      * @brief Capture the current frame from a window's swapchain
      * @param ctx Window render context to capture from
      *

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.hpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.hpp
@@ -25,7 +25,18 @@ struct CaptureSlot {
 };
 
 struct CaptureState {
+#ifdef MAYAFLUX_PLATFORM_MACOS
+    std::atomic<const std::vector<uint8_t>*> last_frame { nullptr };
+
+    static constexpr size_t LAST_FRAME_MAX_READERS = 32;
+    mutable std::array<std::atomic<const std::vector<uint8_t>*>, LAST_FRAME_MAX_READERS> last_frame_hazard_ptrs {};
+    mutable std::array<std::atomic<bool>, LAST_FRAME_MAX_READERS> last_frame_slot_active { false };
+
+    void retire_last_frame(const std::vector<uint8_t>* ptr);
+#else
     std::atomic<std::shared_ptr<std::vector<uint8_t>>> last_frame;
+#endif
+
     std::vector<std::unique_ptr<CaptureSlot>> slots;
     size_t slot_index {};
     vk::Format format {};
@@ -39,15 +50,36 @@ struct CaptureState {
     using ObserverMap = std::unordered_map<uint32_t, FrameObserver>;
 
     std::atomic<uint32_t> next_observer_id { 1 };
+
+#ifdef MAYAFLUX_PLATFORM_MACOS
+    std::atomic<const ObserverMap*> observers { nullptr };
+
+    static constexpr size_t OBSERVERS_MAX_READERS = 32;
+    mutable std::array<std::atomic<const ObserverMap*>, OBSERVERS_MAX_READERS> observers_hazard_ptrs {};
+    mutable std::array<std::atomic<bool>, OBSERVERS_MAX_READERS> observers_slot_active { false };
+
+    void retire_observers(const ObserverMap* ptr);
+#else
     std::atomic<std::shared_ptr<ObserverMap>> observers {
         std::make_shared<ObserverMap>()
     };
+#endif
 
     ~CaptureState()
     {
         readback_running.store(false, std::memory_order_release);
         if (readback_thread.joinable())
             readback_thread.join();
+
+#ifdef MAYAFLUX_PLATFORM_MACOS
+        auto* old_frame = last_frame.exchange(nullptr);
+        if (old_frame)
+            retire_last_frame(old_frame);
+
+        auto* old_obs = observers.exchange(nullptr);
+        if (old_obs)
+            retire_observers(old_obs);
+#endif
     }
 };
 

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.hpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.hpp
@@ -33,6 +33,16 @@ struct CaptureState {
     std::thread readback_thread;
     std::atomic<bool> readback_running { false };
 
+    using FrameObserver = std::function<void(
+        const std::shared_ptr<std::vector<uint8_t>>&,
+        uint32_t, uint32_t, uint32_t)>;
+    using ObserverMap = std::unordered_map<uint32_t, FrameObserver>;
+
+    std::atomic<uint32_t> next_observer_id { 1 };
+    std::atomic<std::shared_ptr<ObserverMap>> observers {
+        std::make_shared<ObserverMap>()
+    };
+
     ~CaptureState()
     {
         readback_running.store(false, std::memory_order_release);

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKSwapchain.cpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKSwapchain.cpp
@@ -84,6 +84,13 @@ bool VKSwapchain::create(VKContext& context,
     create_info.imageArrayLayers = 1;
     create_info.imageUsage = vk::ImageUsageFlagBits::eColorAttachment | vk::ImageUsageFlagBits::eTransferDst;
 
+    if (support.capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eTransferSrc) {
+        create_info.imageUsage |= vk::ImageUsageFlagBits::eTransferSrc;
+    } else {
+        MF_WARN(Journal::Component::Core, Journal::Context::GraphicsBackend,
+            "Surface does not support eTransferSrc; frame capture will be unavailable");
+    }
+
     const auto& queue_families = m_context->get_queue_families();
 
     std::vector<uint32_t> queue_family_indices;

--- a/src/MayaFlux/Core/Backends/Windowing/Glfw/GlfwWindow.hpp
+++ b/src/MayaFlux/Core/Backends/Windowing/Glfw/GlfwWindow.hpp
@@ -136,6 +136,9 @@ public:
      */
     [[nodiscard]] std::vector<std::shared_ptr<Buffers::VKBuffer>> get_rendering_buffers() const override;
 
+    [[nodiscard]] bool is_capture_enabled() const override { return m_capture_enabled.load(std::memory_order_acquire); }
+    void set_capture_enabled(bool enabled) override { m_capture_enabled.store(enabled, std::memory_order_release); }
+
 private:
     GLFWwindow* m_window = nullptr;
     WindowCreateInfo m_create_info;
@@ -144,6 +147,7 @@ private:
     WindowEventCallback m_event_callback;
 
     std::atomic<bool> m_graphics_registered { false };
+    std::atomic<bool> m_capture_enabled { false };
 
     Vruta::WindowEventSource m_event_source;
 

--- a/src/MayaFlux/Core/Backends/Windowing/Wayland/WaylandWindow.hpp
+++ b/src/MayaFlux/Core/Backends/Windowing/Wayland/WaylandWindow.hpp
@@ -75,6 +75,9 @@ public:
     void clear_frame_commands() override;
     [[nodiscard]] std::vector<std::shared_ptr<Buffers::VKBuffer>> get_rendering_buffers() const override;
 
+    [[nodiscard]] bool is_capture_enabled() const override { return m_capture_enabled.load(std::memory_order_acquire); }
+    void set_capture_enabled(bool enabled) override { m_capture_enabled.store(enabled, std::memory_order_release); }
+
 private:
     // -------------------------------------------------------------------------
     // Wayland globals
@@ -124,6 +127,7 @@ private:
     std::atomic<bool> m_should_close { false };
     std::atomic<bool> m_graphics_registered { false };
     std::atomic<bool> m_pending_configure { false };
+    std::atomic<bool> m_capture_enabled { false };
     uint32_t m_pending_width {};
     uint32_t m_pending_height {};
 

--- a/src/MayaFlux/Core/Backends/Windowing/Win32/Win32Window.hpp
+++ b/src/MayaFlux/Core/Backends/Windowing/Win32/Win32Window.hpp
@@ -77,6 +77,9 @@ public:
     void clear_frame_commands() override;
     [[nodiscard]] std::vector<std::shared_ptr<Buffers::VKBuffer>> get_rendering_buffers() const override;
 
+    [[nodiscard]] bool is_capture_enabled() const override { return m_capture_enabled.load(std::memory_order_acquire); }
+    void set_capture_enabled(bool enabled) override { m_capture_enabled.store(enabled, std::memory_order_release); }
+
 private:
     HWND m_hwnd { nullptr };
     HINSTANCE m_hinstance { nullptr };
@@ -84,6 +87,7 @@ private:
     std::thread m_ui_thread;
     std::atomic<bool> m_hwnd_ready { false };
     std::atomic<bool> m_should_close { false };
+    std::atomic<bool> m_capture_enabled { false };
 
     static constexpr size_t EVENT_QUEUE_CAPACITY = 256;
 

--- a/src/MayaFlux/Core/Backends/Windowing/Window.hpp
+++ b/src/MayaFlux/Core/Backends/Windowing/Window.hpp
@@ -174,6 +174,21 @@ public:
     virtual void clear_frame_commands() = 0;
 
     /**
+     * @brief Whether per-frame surface capture is enabled for this window.
+     *
+     * Defaults to false. When false, the graphics backend skips the capture
+     * copy and readback entirely, so trivial windows incur no capture cost.
+     * Enable only on windows whose frames are consumed via
+     * DisplayService::get_last_frame or Kakshya readback.
+     */
+    [[nodiscard]] virtual bool is_capture_enabled() const = 0;
+
+    /**
+     * @brief Enable or disable per-frame surface capture for this window.
+     */
+    virtual void set_capture_enabled(bool enabled) = 0;
+
+    /**
      * @brief Get all VKBuffers currently rendering to this window
      * @return Vector of buffers (weak_ptr to avoid ownership issues)
      */

--- a/src/MayaFlux/Core/Engine.cpp
+++ b/src/MayaFlux/Core/Engine.cpp
@@ -331,6 +331,10 @@ void Engine::End()
 
     Portal::Forma::shutdown();
 
+    if (m_event_manager) {
+        m_event_manager->terminate_all_events();
+    }
+
     if (m_node_graph_manager) {
         m_node_graph_manager->terminate_active_processing();
     }

--- a/src/MayaFlux/Kakshya/Processors/WindowAccessProcessor.cpp
+++ b/src/MayaFlux/Kakshya/Processors/WindowAccessProcessor.cpp
@@ -26,6 +26,15 @@ void WindowAccessProcessor::on_attach(
     m_width = static_cast<uint32_t>(s.get_width());
     m_height = static_cast<uint32_t>(s.get_height());
 
+    m_previous_window_capture_supported = wc->get_window()->is_capture_enabled();
+
+    if (!m_previous_window_capture_supported) {
+        wc->get_window()->set_capture_enabled(true);
+        MF_WARN(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
+            "WindowAccessProcessor: capture was not enabled for '{}'; enabling now",
+            wc->get_window()->get_create_info().title);
+    }
+
     m_surface_format = query_surface_format(wc->get_window());
 
     const uint32_t bpp = Core::vk_format_bytes_per_pixel(
@@ -41,13 +50,23 @@ void WindowAccessProcessor::on_attach(
 }
 
 void WindowAccessProcessor::on_detach(
-    const std::shared_ptr<SignalSourceContainer>& /*container*/)
+    const std::shared_ptr<SignalSourceContainer>& container)
 {
     m_width = 0;
     m_height = 0;
 
     m_last_readback_bytes = 0;
     m_surface_format = Core::GraphicsSurfaceInfo::SurfaceFormat::B8G8R8A8_SRGB;
+
+    if (!m_previous_window_capture_supported) {
+        auto wc = std::dynamic_pointer_cast<WindowContainer>(container);
+        if (wc) {
+            wc->get_window()->set_capture_enabled(false);
+            MF_WARN(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
+                "WindowAccessProcessor detached: capture disabled for '{}', restoring previous state",
+                wc->get_window()->get_create_info().title);
+        }
+    }
 }
 
 void WindowAccessProcessor::process(

--- a/src/MayaFlux/Kakshya/Processors/WindowAccessProcessor.cpp
+++ b/src/MayaFlux/Kakshya/Processors/WindowAccessProcessor.cpp
@@ -121,6 +121,14 @@ void WindowAccessProcessor::process(
         return;
     }
 
+    const auto* src = std::get_if<std::vector<uint8_t>>(&processed[0]);
+    if (src) {
+        if (uint8_t* dst = wc->mutable_frame_ptr(wc->get_write_head())) {
+            std::memcpy(dst, src->data(), src->size());
+            wc->advance_write_head();
+        }
+    }
+
     const auto vk_fmt = Core::to_vk_format(m_surface_format);
     m_last_readback_bytes = static_cast<size_t>(m_width) * m_height
         * Core::vk_format_bytes_per_pixel(vk_fmt);

--- a/src/MayaFlux/Kakshya/Processors/WindowAccessProcessor.hpp
+++ b/src/MayaFlux/Kakshya/Processors/WindowAccessProcessor.hpp
@@ -70,9 +70,10 @@ public:
 private:
     std::atomic<bool> m_is_processing { false };
 
-    uint32_t m_width { 0 };
-    uint32_t m_height { 0 };
-    size_t m_last_readback_bytes { 0 };
+    uint32_t m_width {};
+    uint32_t m_height {};
+    size_t m_last_readback_bytes {};
+    bool m_previous_window_capture_supported {};
 
     Core::GraphicsSurfaceInfo::SurfaceFormat m_surface_format {
         Core::GraphicsSurfaceInfo::SurfaceFormat::B8G8R8A8_SRGB

--- a/src/MayaFlux/Kakshya/Source/WindowContainer.cpp
+++ b/src/MayaFlux/Kakshya/Source/WindowContainer.cpp
@@ -46,8 +46,10 @@ namespace {
 
 } // namespace
 
-WindowContainer::WindowContainer(std::shared_ptr<Core::Window> window)
+WindowContainer::WindowContainer(std::shared_ptr<Core::Window> window,
+    uint32_t frame_capacity)
     : m_window(std::move(window))
+    , m_frame_capacity(frame_capacity)
 {
     if (!m_window) {
         error<std::invalid_argument>(
@@ -60,9 +62,9 @@ WindowContainer::WindowContainer(std::shared_ptr<Core::Window> window)
     setup_dimensions();
 
     MF_INFO(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
-        "WindowContainer created for window '{}' ({}x{})",
+        "WindowContainer created for window '{}' ({}x{} frames={})",
         m_window->get_create_info().title,
-        m_structure.get_width(), m_structure.get_height());
+        m_structure.get_width(), m_structure.get_height(), m_frame_capacity);
 }
 
 Portal::Graphics::ImageFormat WindowContainer::get_image_format() const
@@ -80,16 +82,40 @@ void WindowContainer::setup_dimensions()
     const uint32_t w = m_window->get_create_info().width;
     const uint32_t h = m_window->get_create_info().height;
     const uint32_t c = fmt.color_channels;
+    const size_t sz = static_cast<size_t>(w) * h * c;
 
     m_structure = ContainerDataStructure::image_interleaved();
+
     m_structure.dimensions = DataDimension::create_dimensions(
-        DataModality::IMAGE_COLOR,
-        { static_cast<uint64_t>(h), static_cast<uint64_t>(w), static_cast<uint64_t>(c) },
+        DataModality::VIDEO_COLOR,
+        { static_cast<uint64_t>(m_frame_capacity),
+            static_cast<uint64_t>(h),
+            static_cast<uint64_t>(w),
+            static_cast<uint64_t>(c) },
         MemoryLayout::ROW_MAJOR);
 
-    const size_t sz = static_cast<size_t>(w) * h * c;
+    m_data.resize(m_frame_capacity);
+    for (auto& slot : m_data)
+        slot = std::vector<uint8_t>(sz, 0U);
+
     m_processed_data.resize(1);
     m_processed_data[0] = std::vector<uint8_t>(sz, 0U);
+}
+
+uint8_t* WindowContainer::mutable_frame_ptr(uint32_t frame_index)
+{
+    if (frame_index >= m_data.size())
+        return nullptr;
+
+    auto* v = std::get_if<std::vector<uint8_t>>(&m_data[frame_index]);
+    return (v && !v->empty()) ? v->data() : nullptr;
+}
+
+void WindowContainer::advance_write_head()
+{
+    m_write_head.store((m_write_head.load(std::memory_order_relaxed) + 1U) % m_frame_capacity,
+        std::memory_order_release);
+    m_frames_written.fetch_add(1U, std::memory_order_release);
 }
 
 // =========================================================================
@@ -154,7 +180,7 @@ std::shared_ptr<Core::VKImage> WindowContainer::to_image() const
 
     if (m_processed_data.empty()) {
         MF_RT_WARN(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
-            "WindowContainer::to_image — no readback data available for '{}'",
+            "WindowContainer::to_image : no readback data available for '{}'",
             m_window->get_create_info().title);
         return nullptr;
     }
@@ -162,7 +188,7 @@ std::shared_ptr<Core::VKImage> WindowContainer::to_image() const
     const auto* pixels = std::get_if<std::vector<uint8_t>>(&m_processed_data[0]);
     if (!pixels || pixels->empty()) {
         MF_RT_WARN(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
-            "WindowContainer::to_image — processed_data[0] is not uint8_t or is empty for '{}'",
+            "WindowContainer::to_image : processed_data[0] is not uint8_t or is empty for '{}'",
             m_window->get_create_info().title);
         return nullptr;
     }
@@ -177,7 +203,7 @@ std::shared_ptr<Core::VKImage> WindowContainer::to_image() const
 
     if (!img) {
         MF_RT_ERROR(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
-            "WindowContainer::to_image — TextureLoom::create_2d failed for '{}'",
+            "WindowContainer::to_image : TextureLoom::create_2d failed for '{}'",
             m_window->get_create_info().title);
     }
 
@@ -191,7 +217,7 @@ std::shared_ptr<Core::VKImage> WindowContainer::to_image(
 
     if (m_processed_data.empty()) {
         MF_RT_WARN(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
-            "WindowContainer::to_image(staging) — no readback data for '{}'",
+            "WindowContainer::to_image(staging) : no readback data for '{}'",
             m_window->get_create_info().title);
         return nullptr;
     }
@@ -199,7 +225,7 @@ std::shared_ptr<Core::VKImage> WindowContainer::to_image(
     const auto* pixels = std::get_if<std::vector<uint8_t>>(&m_processed_data[0]);
     if (!pixels || pixels->empty()) {
         MF_RT_WARN(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
-            "WindowContainer::to_image(staging) — processed_data[0] is not uint8_t or is empty for '{}'",
+            "WindowContainer::to_image(staging) : processed_data[0] is not uint8_t or is empty for '{}'",
             m_window->get_create_info().title);
         return nullptr;
     }
@@ -214,8 +240,98 @@ std::shared_ptr<Core::VKImage> WindowContainer::to_image(
     auto img = loom.create_2d(w, h, img_fmt, nullptr);
     if (!img) {
         MF_RT_ERROR(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
-            "WindowContainer::to_image(staging) — VKImage allocation failed for '{}'",
+            "WindowContainer::to_image(staging) : VKImage allocation failed for '{}'",
             m_window->get_create_info().title);
+        return nullptr;
+    }
+
+    loom.upload_data(img, pixels->data(), pixels->size(), staging);
+    return img;
+}
+
+std::shared_ptr<Core::VKImage> WindowContainer::image_at(uint32_t frame_index) const
+{
+    std::shared_lock lock(m_data_mutex);
+
+    if (frame_index >= m_data.size()) {
+        MF_RT_WARN(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
+            "WindowContainer::to_image({}) : out of range (capacity={})",
+            frame_index, m_frame_capacity);
+        return nullptr;
+    }
+
+    {
+        const uint64_t written = m_frames_written.load(std::memory_order_acquire);
+        const uint32_t head = m_write_head.load(std::memory_order_acquire);
+        const bool ring_full = written >= m_frame_capacity;
+        const bool slot_valid = ring_full || frame_index < head;
+        if (!slot_valid) {
+            MF_RT_WARN(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
+                "WindowContainer::image_at({}) : frame index is ahead of write head ({}), data may be stale or uninitialized",
+                frame_index, head);
+            return nullptr;
+        }
+    }
+
+    const auto* pixels = std::get_if<std::vector<uint8_t>>(&m_data[frame_index]);
+    if (!pixels || pixels->empty()) {
+        MF_RT_WARN(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
+            "WindowContainer::image_at({}) : slot is empty", frame_index);
+        return nullptr;
+    }
+
+    const auto img_fmt = surface_format_to_image_format(query_surface_format(m_window));
+    auto img = Portal::Graphics::TextureLoom::instance().create_2d(
+        m_structure.get_width(), m_structure.get_height(), img_fmt, pixels->data());
+
+    if (!img) {
+        MF_RT_ERROR(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
+            "WindowContainer::image_at({}) : TextureLoom::create_2d failed", frame_index);
+    }
+
+    return img;
+}
+
+std::shared_ptr<Core::VKImage> WindowContainer::image_at(
+    const std::shared_ptr<Buffers::VKBuffer>& staging, uint32_t frame_index) const
+{
+    std::shared_lock lock(m_data_mutex);
+
+    if (frame_index >= m_data.size()) {
+        MF_RT_WARN(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
+            "WindowContainer::image_at(staging, {}) : out of range (capacity={})",
+            frame_index, m_frame_capacity);
+        return nullptr;
+    }
+
+    {
+        const uint64_t written = m_frames_written.load(std::memory_order_acquire);
+        const uint32_t head = m_write_head.load(std::memory_order_acquire);
+        const bool ring_full = written >= m_frame_capacity;
+        const bool slot_valid = ring_full || frame_index < head;
+        if (!slot_valid) {
+            MF_RT_WARN(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
+                "WindowContainer::image_at(staging, {}) : frame index is ahead of write head ({}), data may be stale or uninitialized",
+                frame_index, head);
+            return nullptr;
+        }
+    }
+
+    const auto* pixels = std::get_if<std::vector<uint8_t>>(&m_data[frame_index]);
+    if (!pixels || pixels->empty()) {
+        MF_RT_WARN(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
+            "WindowContainer::image_at(staging, {}) — slot is empty", frame_index);
+        return nullptr;
+    }
+
+    const auto img_fmt = surface_format_to_image_format(query_surface_format(m_window));
+    auto& loom = Portal::Graphics::TextureLoom::instance();
+
+    auto img = loom.create_2d(
+        m_structure.get_width(), m_structure.get_height(), img_fmt, nullptr);
+    if (!img) {
+        MF_RT_ERROR(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
+            "WindowContainer::image_at(staging, {}) : VKImage allocation failed", frame_index);
         return nullptr;
     }
 

--- a/src/MayaFlux/Kakshya/Source/WindowContainer.hpp
+++ b/src/MayaFlux/Kakshya/Source/WindowContainer.hpp
@@ -53,9 +53,12 @@ class MAYAFLUX_API WindowContainer : public SignalSourceContainer {
 public:
     /**
      * @brief Construct from an existing managed window.
-     * @param window Live window whose surface will be addressed as NDData.
+     * @param window         Live window whose surface will be addressed as NDData.
+     * @param frame_capacity Number of rendered images to retain in m_data.
+     *                       Defaults to 1 (current behaviour).
      */
-    explicit WindowContainer(std::shared_ptr<Core::Window> window);
+    explicit WindowContainer(std::shared_ptr<Core::Window> window,
+        uint32_t frame_capacity = 60);
 
     ~WindowContainer() override = default;
 
@@ -77,6 +80,24 @@ public:
      * TextureBuffer to receive the output of to_image().
      */
     [[nodiscard]] Portal::Graphics::ImageFormat get_image_format() const;
+
+    /**
+     * @brief Mutable pointer into m_data[frame_index] for the processor to write into.
+     * @param frame_index Slot index in [0, frame_capacity).
+     * @return Pointer to the pixel buffer, or nullptr if out of range or unallocated.
+     */
+    [[nodiscard]] uint8_t* mutable_frame_ptr(uint32_t frame_index);
+
+    [[nodiscard]] uint32_t get_frame_capacity() const { return m_frame_capacity; }
+
+    /**
+     * @brief Current write head index in m_data, advanced by the default processor after each readback.
+     *        Exposed for testing and potential future use by custom processors.
+     */
+    [[nodiscard]] uint32_t get_write_head() const { return m_write_head.load(); }
+
+    /** @brief Advance the write head index, wrapping around frame_capacity. */
+    void advance_write_head();
 
     // =========================================================================
     // NDDimensionalContainer
@@ -122,6 +143,21 @@ public:
      */
     [[nodiscard]] std::shared_ptr<Core::VKImage> to_image(
         const std::shared_ptr<Buffers::VKBuffer>& staging) const;
+
+    /**
+     * @brief Upload m_data[frame_index] to a new VKImage.
+     * @param frame_index Index into m_data in [0, frame_capacity).
+     */
+    [[nodiscard]] std::shared_ptr<Core::VKImage> image_at(uint32_t frame_index) const;
+
+    /**
+     * @brief Upload m_data[frame_index] reusing a caller-supplied staging buffer.
+     * @param staging     Host-visible VKBuffer sized to at least w * h * bpp.
+     * @param frame_index Index into m_data in [0, frame_capacity).
+     */
+    [[nodiscard]] std::shared_ptr<Core::VKImage> image_at(
+        const std::shared_ptr<Buffers::VKBuffer>& staging,
+        uint32_t frame_index) const;
 
     /**
      * @brief Crop a region from the last readback and upload it as a VKImage.
@@ -259,6 +295,9 @@ private:
     std::atomic<uint32_t> m_registered_readers { 0 };
     std::atomic<uint32_t> m_consumed_readers { 0 };
     std::atomic<uint32_t> m_next_reader_id { 0 };
+    std::atomic<uint32_t> m_write_head { 0 };
+    uint32_t m_frame_capacity { 1 };
+    std::atomic<uint64_t> m_frames_written { 0 };
 
     void setup_dimensions();
 };

--- a/src/MayaFlux/Kakshya/Utils/SurfaceUtils.cpp
+++ b/src/MayaFlux/Kakshya/Utils/SurfaceUtils.cpp
@@ -1,6 +1,5 @@
 #include "SurfaceUtils.hpp"
 
-#include "MayaFlux/Buffers/Staging/StagingUtils.hpp"
 #include "MayaFlux/Kakshya/NDData/DataAccess.hpp"
 
 #include "MayaFlux/Registry/BackendRegistry.hpp"
@@ -132,8 +131,7 @@ DataAccess readback_region(
     static DataAccess s_fail { s_empty_var, s_empty_dims, DataModality::UNKNOWN };
 
     auto* display = get_display_service();
-    auto* buf_svc = get_buffer_service();
-    if (!display || !buf_svc)
+    if (!display)
         return s_fail;
 
     const auto window_handle = std::static_pointer_cast<void>(window);
@@ -144,47 +142,51 @@ DataAccess readback_region(
     const auto traits = Core::get_surface_format_traits(mf_fmt);
     const uint32_t bpp = Core::vk_format_bytes_per_pixel(vk_fmt);
 
-    const size_t byte_count = static_cast<size_t>(pixel_width) * pixel_height * bpp;
-
-    auto staging = Buffers::create_staging_buffer(byte_count);
-    if (!staging) {
-        MF_RT_ERROR(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
-            "SurfaceUtils::readback_region: staging allocation failed ({} bytes) for '{}'",
-            byte_count, window->get_create_info().title);
+    uint32_t full_w = 0, full_h = 0;
+    display->get_swapchain_extent(window_handle, full_w, full_h);
+    if (full_w == 0 || full_h == 0)
         return s_fail;
-    }
 
-    const auto& res = staging->get_buffer_resources();
-
-    buf_svc->invalidate_range(res.memory, 0, byte_count);
-    void* mapped = buf_svc->map_buffer(res.memory, 0, byte_count);
-    if (!mapped) {
-        buf_svc->destroy_buffer(std::static_pointer_cast<void>(staging));
+    auto frame = display->get_last_frame(window_handle);
+    if (!frame || frame->empty()) {
         MF_RT_ERROR(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
-            "SurfaceUtils::readback_region: staging map failed for '{}'",
+            "SurfaceUtils::readback_region: no captured frame for '{}'",
             window->get_create_info().title);
         return s_fail;
     }
 
-    const bool ok = display->readback_swapchain_region(
-        window_handle,
-        mapped,
-        x_offset, y_offset,
-        pixel_width, pixel_height,
-        byte_count);
-
-    if (!ok) {
-        buf_svc->unmap_buffer(res.memory);
-        buf_svc->destroy_buffer(std::static_pointer_cast<void>(staging));
+    if (x_offset + pixel_width > full_w || y_offset + pixel_height > full_h) {
         MF_RT_ERROR(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
-            "SurfaceUtils::readback_region: GPU copy failed for '{}'",
+            "SurfaceUtils::readback_region: region {}x{} at ({},{}) exceeds surface {}x{} for '{}'",
+            pixel_width, pixel_height, x_offset, y_offset, full_w, full_h,
             window->get_create_info().title);
         return s_fail;
     }
 
-    fill_variant_from_raw(mapped, byte_count, traits, out_variant);
-    buf_svc->unmap_buffer(res.memory);
-    buf_svc->destroy_buffer(std::static_pointer_cast<void>(staging));
+    const size_t full_row = static_cast<size_t>(full_w) * bpp;
+    const size_t region_row = static_cast<size_t>(pixel_width) * bpp;
+    const size_t byte_count = region_row * pixel_height;
+
+    const size_t expected = full_row * full_h;
+    if (frame->size() < expected) {
+        MF_RT_ERROR(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
+            "SurfaceUtils::readback_region: frame {} bytes, expected {} for '{}'",
+            frame->size(), expected, window->get_create_info().title);
+        return s_fail;
+    }
+
+    std::vector<uint8_t> region(byte_count);
+    const uint8_t* base = frame->data()
+        + static_cast<size_t>(y_offset) * full_row
+        + static_cast<size_t>(x_offset) * bpp;
+
+    for (uint32_t row = 0; row < pixel_height; ++row) {
+        std::memcpy(region.data() + row * region_row,
+            base + row * full_row,
+            region_row);
+    }
+
+    fill_variant_from_raw(region.data(), byte_count, traits, out_variant);
 
     auto dims = make_pixel_dimensions(pixel_width, pixel_height, traits.channel_count);
     return { out_variant, dims, DataModality::IMAGE_COLOR };

--- a/src/MayaFlux/Kakshya/Utils/SurfaceUtils.hpp
+++ b/src/MayaFlux/Kakshya/Utils/SurfaceUtils.hpp
@@ -30,24 +30,28 @@ MAYAFLUX_API Core::GraphicsSurfaceInfo::SurfaceFormat query_surface_format(
  * @brief Read a pixel rectangle from the last completed swapchain frame into
  *        a DataVariant whose element type matches the live swapchain format.
  *
- * Format → DataVariant mapping:
+ * Format -> DataVariant mapping:
  *   B8G8R8A8_SRGB / R8G8B8A8_SRGB / B8G8R8A8_UNORM / R8G8B8A8_UNORM
- *     → std::vector<uint8_t>  (4 bytes/pixel)
+ *     -> std::vector<uint8_t>  (4 bytes/pixel)
  *   R16G16B16A16_SFLOAT
- *     → std::vector<uint16_t> (8 bytes/pixel, raw half-float bits)
+ *     -> std::vector<uint16_t> (8 bytes/pixel, raw half-float bits)
  *   A2B10G10R10_UNORM
- *     → std::vector<uint32_t> (4 bytes/pixel, packed word)
+ *     -> std::vector<uint32_t> (4 bytes/pixel, packed word)
  *   R32G32B32A32_SFLOAT
- *     → std::vector<float>    (16 bytes/pixel)
+ *     -> std::vector<float>    (16 bytes/pixel)
  *
- * "Last completed frame" semantics: the swapchain image whose in-flight
- * fence has already signaled. Safe to call without stalling the render
- * pipeline.
+ * The rectangle is cropped host-side from the full surface published by the
+ * per-window readback thread. The data is one frame late relative to the
+ * current render, not synchronously captured at call time. No GPU work and
+ * no staging buffer: the function reads the cached frame, validates the
+ * region against the swapchain extent, and copies the rows out. Safe to call
+ * without stalling the render pipeline. Returns failure if no frame has been
+ * captured yet or the region exceeds the surface bounds.
  *
  * Dimensions on the returned DataAccess (IMAGE_COLOR convention):
- *   [0] SPATIAL_Y  — pixel_height
- *   [1] SPATIAL_X  — pixel_width
- *   [2] CHANNEL    — channel_count derived from format traits
+ *   [0] SPATIAL_Y  - pixel_height
+ *   [1] SPATIAL_X  - pixel_width
+ *   [2] CHANNEL    - channel_count derived from format traits
  *
  * @param window       Window whose surface is being read.
  * @param x_offset     Left edge of the pixel rectangle (inclusive).

--- a/src/MayaFlux/Kriya/BroadcastEvents.cpp
+++ b/src/MayaFlux/Kriya/BroadcastEvents.cpp
@@ -1,7 +1,9 @@
 #include "BroadcastEvents.hpp"
 
+#include "MayaFlux/Core/Backends/Windowing/Window.hpp"
 #include "MayaFlux/Registry/BackendRegistry.hpp"
 #include "MayaFlux/Registry/Service/AudioBackendService.hpp"
+#include "MayaFlux/Registry/Service/DisplayService.hpp"
 
 namespace MayaFlux::Kriya {
 
@@ -30,6 +32,54 @@ std::shared_ptr<Vruta::BroadcastSource<bool>> audio_output_tick()
         [s = state.get()](const double*, uint32_t) {
             s->source.signal(true);
         });
+
+    return { state, &state->source };
+}
+
+std::shared_ptr<Vruta::BroadcastSource<WindowFrame>> window_frame_tick(
+    const std::shared_ptr<Core::Window>& window)
+{
+    auto* svc = Registry::BackendRegistry::instance()
+                    .get_service<Registry::Service::DisplayService>();
+
+    if (!svc || !window)
+        return nullptr;
+
+    struct State {
+        Vruta::BroadcastSource<WindowFrame> source;
+        Registry::Service::DisplayService* svc { nullptr };
+        std::shared_ptr<Core::Window> window;
+        uint32_t observer_id { 0 };
+
+        ~State()
+        {
+            if (svc && observer_id) {
+                svc->unregister_frame_observer(
+                    std::static_pointer_cast<void>(window), observer_id);
+            }
+        }
+    };
+
+    auto state = std::make_shared<State>();
+    state->svc = svc;
+    state->window = window;
+
+    state->observer_id = svc->register_frame_observer(
+        std::static_pointer_cast<void>(window),
+
+        [weak = std::weak_ptr<State>(state)](
+            const std::shared_ptr<std::vector<uint8_t>>& buf,
+            uint32_t w, uint32_t h, uint32_t fmt) {
+            if (!buf) {
+                return;
+            }
+
+            if (auto s = weak.lock())
+                s->source.signal({ .data = buf, .width = w, .height = h, .format = fmt });
+        });
+
+    if (!state->observer_id)
+        return nullptr;
 
     return { state, &state->source };
 }

--- a/src/MayaFlux/Kriya/BroadcastEvents.hpp
+++ b/src/MayaFlux/Kriya/BroadcastEvents.hpp
@@ -3,6 +3,10 @@
 #include "Awaiters/BroadcastAwaiter.hpp"
 #include "MayaFlux/Vruta/BroadcastSource.hpp"
 
+namespace MayaFlux::Core {
+class Window;
+}
+
 namespace MayaFlux::Vruta {
 class Event;
 }
@@ -68,6 +72,38 @@ Vruta::Event on_signal_matching(
  * @endcode
  */
 [[nodiscard]] std::shared_ptr<Vruta::BroadcastSource<bool>> audio_output_tick();
+
+struct WindowFrame {
+    std::shared_ptr<std::vector<uint8_t>> data;
+    uint32_t width {};
+    uint32_t height {};
+    uint32_t format {};
+};
+
+/**
+ * @brief Create a BroadcastSource<bool> ticking once per captured window frame.
+ *
+ * Registers a frame observer with DisplayService for the given window.
+ * The window must have capture enabled and the capture state must have been
+ * initialized (either via WindowAccessProcessor or set_capture_enabled before
+ * the first rendered frame).
+ *
+ * Returns nullptr if the DisplayService is unavailable, the window is null,
+ * or capture state is not yet active for the window.
+ *
+ * The observer callback is non-blocking. Signal delivery is safe across
+ * thread boundaries; the BroadcastSource handles the coroutine resume path.
+ *
+ * @code
+ * auto src = Kriya::window_frame_tick(window);
+ * get_event_manager()->add_event(std::make_shared<Vruta::Event>(
+ *     Kriya::on_signal(src, [](const Kriya::WindowFrame& frame) {
+ *         // frame.data, frame.width, frame.height, frame.format
+ *     })));
+ * @endcode
+ */
+[[nodiscard]] std::shared_ptr<Vruta::BroadcastSource<WindowFrame>> window_frame_tick(
+    const std::shared_ptr<Core::Window>& window);
 
 } // namespace MayaFlux::Kriya
 

--- a/src/MayaFlux/Registry/Service/DisplayService.hpp
+++ b/src/MayaFlux/Registry/Service/DisplayService.hpp
@@ -159,6 +159,22 @@ struct MAYAFLUX_API DisplayService {
      * @return vk::Format cast to uint32_t, or eUndefined if no depth image
      */
     std::function<uint32_t(const std::shared_ptr<void>&)> get_depth_format;
+
+    /**
+     * @brief Returns the last completed full-surface pixel readback for a window.
+     *
+     * Published by the per-window readback thread once a capture copy
+     * completes. Lock-free: the readback thread stores the buffer with
+     * release, callers load with acquire via an atomic shared_ptr, so the
+     * pointer is safe to read from any thread. Returns nullptr if no frame
+     * has completed yet or capture is unavailable on this surface.
+     *
+     * Raw bytes in swapchain pixel format. Width and height match the
+     * current swapchain extent from get_swapchain_extent().
+     */
+    std::function<std::shared_ptr<std::vector<uint8_t>>(
+        const std::shared_ptr<void>& window_handle)>
+        get_last_frame;
 };
 
 } // namespace MayaFlux::Registry::Services

--- a/src/MayaFlux/Registry/Service/DisplayService.hpp
+++ b/src/MayaFlux/Registry/Service/DisplayService.hpp
@@ -175,6 +175,38 @@ struct MAYAFLUX_API DisplayService {
     std::function<std::shared_ptr<std::vector<uint8_t>>(
         const std::shared_ptr<void>& window_handle)>
         get_last_frame;
+
+    /**
+     * @brief Register a per-frame observer for a window's captured frames.
+     *
+     * The observer fires on the window's readback thread once per captured
+     * frame, receiving the published frame buffer, its width and height, and
+     * the swapchain format as uint32_t. Fires only for capture-enabled
+     * windows. The observer must not block; post to a queue for further work.
+     *
+     * Requires the window's capture state to exist, which it does once the
+     * window has completed its first captured frame. Returns 0 if capture is
+     * not enabled or no frame has been captured yet; retry after a frame.
+     *
+     * @return Opaque non-zero id for unregister_frame_observer, or 0 on failure.
+     */
+    std::function<uint32_t(
+        const std::shared_ptr<void>& window_handle,
+        std::function<void(
+            const std::shared_ptr<std::vector<uint8_t>>&,
+            uint32_t, uint32_t, uint32_t)>)>
+        register_frame_observer;
+
+    /**
+     * @brief Unregister a previously registered per-frame observer.
+     *
+     * Safe from any thread, including from within the observer callback.
+     *
+     * @param window_handle Window the observer was registered on.
+     * @param id Id returned by register_frame_observer.
+     */
+    std::function<void(const std::shared_ptr<void>&, uint32_t)>
+        unregister_frame_observer;
 };
 
 } // namespace MayaFlux::Registry::Services


### PR DESCRIPTION
The audio pipeline has had a full coroutine event path since early on. The graphics side had no equivalent - a rendered frame landing in host memory was not an addressable event. This PR closes that gap and establishes the graphics capture path as a peer to the audio path.

### The core addition

```cpp
// audio - has worked for a long time
auto src = Kriya::audio_output_tick();

// graphics - now works the same way
auto src = Kriya::window_frame_tick(window);

get_event_manager()->add_event(std::make_shared<Vruta::Event>(
    Kriya::on_signal(src, [](const Kriya::WindowFrame& frame) {
        // frame.data, frame.width, frame.height, frame.format
        // fires once per captured frame, same model as audio
    })));
```

Same mental model. Same lifetime semantics. Same shutdown behavior.

### What this enables

**Frame history and scrubbing**
```cpp
Kriya::on_signal(src, [container, history, display_buf](const Kriya::WindowFrame&) {
    container->process_default();
    history->emplace_back(container->to_image());
    display_buf->set_gpu_texture(history->back());
})
```
`WindowContainer` now holds an N-frame ring buffer. `image_at(idx)` addresses any historical frame. Scrubbing, differencing, temporal blending - these are now container operations.

**Cross-domain coroutines**

A coroutine that reacts to both audio and visual state is a natural `CrossRoutine` - no coordination infrastructure, no shared mutable state outside the coroutine frame. Audio analysis gating visual state, frame content driving synthesis parameters, sample-accurate audio reacting to what is on screen.

**Direct frame access without a container**
```cpp
// any thread, lock-free
auto frame = display_service->get_last_frame(window_handle);

// or register directly for per-frame callbacks
auto id = display_service->register_frame_observer(window_handle, 
    [](const std::shared_ptr<std::vector<uint8_t>>& buf, 
       uint32_t w, uint32_t h, uint32_t fmt) {
        // fires on readback thread, must not block
    });
```

### Performance

The readback that was costing ~21ms inline on the graphics thread is now off-thread. The graphics thread only submits a copy command.

- Graphics thread cost: ~0.05ms per frame
- Capture is opt-in per window, off by default - windows that do not need it pay nothing
- Observer map is copy-on-write atomic swap - lock-free register/unregister including from within a callback

### Platform coverage

`atomic<shared_ptr<T>>` is absent from Apple Clang's libc++. A hazard-pointer fallback covers `last_frame` and the observer map on macOS, keeping the same lock-free semantics and the same `DisplayService` API across all three platforms.

### Direction

This is the first infrastructure that makes cross-domain reaction a first-class pattern. The longer trajectory is a visual pipeline as independently composable as the audio pipeline - the Blender-not-SonicVisualizer position MayaFlux has always aimed at.