### PR TITLE
featture: video write path: VideoEncodeContext, VideoFileWriter, IOManager capture_window

### DIFF
--- a/src/MayaFlux/IO/IOManager.cpp
+++ b/src/MayaFlux/IO/IOManager.cpp
@@ -1,6 +1,7 @@
 #include "IOManager.hpp"
 
 #include "MayaFlux/Buffers/BufferManager.hpp"
+#include "MayaFlux/Core/Backends/Windowing/Window.hpp"
 #include "MayaFlux/Kakshya/Source/DynamicSoundStream.hpp"
 
 #include "MayaFlux/Nodes/Network/MeshNetwork.hpp"
@@ -79,9 +80,9 @@ IOManager::~IOManager()
     {
         std::vector<uint32_t> ids;
         {
-            std::lock_guard lock(m_captures_mutex);
-            ids.reserve(m_captures.size());
-            for (const auto& [id, _] : m_captures)
+            std::lock_guard lock(m_audio_captures_mutex);
+            ids.reserve(m_audio_captures.size());
+            for (const auto& [id, _] : m_audio_captures)
                 ids.push_back(id);
         }
         for (auto id : ids)
@@ -415,24 +416,24 @@ uint32_t IOManager::capture_output(const std::string& filepath, AVCodecID codec_
         m_writers.push_back(writer);
     }
 
-    std::lock_guard lock(m_captures_mutex);
-    m_captures.emplace(obs_id, CaptureState { .container = ct, .writer = writer, .observer_id = obs_id });
+    std::lock_guard lock(m_audio_captures_mutex);
+    m_audio_captures.emplace(obs_id, AudioCaptureState { .container = ct, .writer = writer, .observer_id = obs_id });
     return obs_id;
 }
 
 void IOManager::stop_capture(uint32_t capture_id)
 {
-    CaptureState state;
+    AudioCaptureState state;
     {
-        std::lock_guard lock(m_captures_mutex);
-        auto it = m_captures.find(capture_id);
-        if (it == m_captures.end()) {
+        std::lock_guard lock(m_audio_captures_mutex);
+        auto it = m_audio_captures.find(capture_id);
+        if (it == m_audio_captures.end()) {
             MF_WARN(Journal::Component::IO, Journal::Context::FileIO,
                 "stop_capture: unknown capture_id={}", capture_id);
             return;
         }
         state = std::move(it->second);
-        m_captures.erase(it);
+        m_audio_captures.erase(it);
     }
 
     auto* svc = Registry::BackendRegistry::instance()
@@ -449,14 +450,90 @@ void IOManager::stop_capture(uint32_t capture_id)
     });
 }
 
-std::vector<uint32_t> IOManager::get_capture_ids() const
+std::vector<uint32_t> IOManager::get_audio_capture_ids() const
 {
-    std::lock_guard lock(m_captures_mutex);
+    std::lock_guard lock(m_audio_captures_mutex);
     std::vector<uint32_t> ids;
-    ids.reserve(m_captures.size());
-    for (const auto& [id, _] : m_captures)
+    ids.reserve(m_audio_captures.size());
+    for (const auto& [id, _] : m_audio_captures)
         ids.push_back(id);
     return ids;
+}
+
+std::shared_ptr<VideoFileWriter>
+IOManager::create_writer(const std::string& filepath,
+    uint32_t width,
+    uint32_t height,
+    double frame_rate,
+    AVPixelFormat src_pixel_format,
+    AVCodecID codec_id)
+{
+    auto writer = std::make_shared<VideoFileWriter>();
+    if (!writer->open(filepath, width, height, frame_rate, src_pixel_format, codec_id)) {
+        MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+            "create_writer: open failed for '{}': {}", filepath, writer->last_error());
+        return nullptr;
+    }
+    return writer;
+}
+
+uint32_t IOManager::capture_window(
+    const std::shared_ptr<Core::Window>& window,
+    const std::string& filepath,
+    double frame_rate,
+    AVCodecID codec_id)
+{
+    if (!window) {
+        MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+            "capture_window: null window");
+        return 0;
+    }
+
+    auto writer = std::make_shared<VideoFileWriter>();
+    if (!writer->record(window, filepath, frame_rate, codec_id)) {
+        MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+            "capture_window: record failed for '{}': {}", filepath, writer->last_error());
+        return 0;
+    }
+
+    const uint32_t id = m_next_video_capture_id.fetch_add(1, std::memory_order_relaxed);
+
+    {
+        std::lock_guard lock(m_video_captures_mutex);
+        m_video_captures.emplace(id, VideoCaptureState { .writer = writer, .capture_id = id });
+        m_video_writers.push_back(writer);
+    }
+
+    return id;
+}
+
+void IOManager::stop_capture(const std::shared_ptr<Core::Window>& window)
+{
+    if (!window) {
+        MF_WARN(Journal::Component::IO, Journal::Context::FileIO,
+            "stop_capture(window): null window");
+        return;
+    }
+
+    uint32_t found_id = 0;
+    {
+        std::lock_guard lock(m_video_captures_mutex);
+        for (const auto& [id, state] : m_video_captures) {
+            if (state.writer->capture_window() == window) {
+                found_id = id;
+                break;
+            }
+        }
+    }
+
+    if (found_id == 0) {
+        MF_WARN(Journal::Component::IO, Journal::Context::FileIO,
+            "stop_capture(window): no active capture for window '{}'",
+            window->get_create_info().title);
+        return;
+    }
+
+    stop_capture(found_id);
 }
 
 std::shared_ptr<Kakshya::CameraContainer>

--- a/src/MayaFlux/IO/IOManager.cpp
+++ b/src/MayaFlux/IO/IOManager.cpp
@@ -536,6 +536,22 @@ void IOManager::stop_capture(const std::shared_ptr<Core::Window>& window)
     stop_capture(found_id);
 }
 
+std::vector<uint32_t> IOManager::get_video_capture_ids() const
+{
+    std::lock_guard lock(m_video_captures_mutex);
+    std::vector<uint32_t> ids;
+    ids.reserve(m_video_captures.size());
+    for (const auto& [id, _] : m_video_captures)
+        ids.push_back(id);
+    return ids;
+}
+
+std::vector<std::shared_ptr<VideoFileWriter>> IOManager::get_video_writers() const
+{
+    std::lock_guard lock(m_video_captures_mutex);
+    return m_video_writers;
+}
+
 std::shared_ptr<Kakshya::CameraContainer>
 IOManager::open_camera(const CameraConfig& config)
 {

--- a/src/MayaFlux/IO/IOManager.hpp
+++ b/src/MayaFlux/IO/IOManager.hpp
@@ -4,6 +4,7 @@
 #include "ImageWriter.hpp"
 #include "SoundFileWriter.hpp"
 #include "VideoFileReader.hpp"
+#include "VideoFileWriter.hpp"
 
 #include <future>
 
@@ -400,6 +401,64 @@ public:
     void release_video_reader(uint64_t reader_id);
 
     // ─────────────────────────────────────────────────────────────────────────
+    // Video — write
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * @brief Construct an open VideoFileWriter the caller drives manually.
+     *
+     * Allocates and opens the writer. IOManager does not track this writer;
+     * the caller is responsible for calling close() or stop_recording() when
+     * done.
+     *
+     * @param filepath         Output file path. Extension determines container.
+     * @param width            Frame width in pixels.
+     * @param height           Frame height in pixels.
+     * @param frame_rate       Average frame rate in frames per second.
+     * @param src_pixel_format AVPixelFormat of submitted pixel data.
+     * @param codec_id         Encoder override; AV_CODEC_ID_NONE = container default.
+     * @return Open VideoFileWriter, or nullptr if open() failed.
+     */
+    [[nodiscard]] std::shared_ptr<VideoFileWriter>
+    create_writer(const std::string& filepath,
+        uint32_t width,
+        uint32_t height,
+        double frame_rate,
+        AVPixelFormat src_pixel_format,
+        AVCodecID codec_id = AV_CODEC_ID_NONE);
+
+    /**
+     * @brief Begin continuous capture of a window's rendered frames to a file.
+     *
+     * Delegates to VideoFileWriter::record(). The encoder is opened lazily on
+     * the first delivered frame so pixel format and dimensions come from the
+     * live swapchain. Returns an opaque capture id for use with stop_capture().
+     *
+     * Returns 0 if the window is null or record() fails.
+     *
+     * @param window     Window whose swapchain frames will be captured.
+     * @param filepath   Output file path. Extension determines container format.
+     * @param frame_rate Nominal frame rate written into the container header.
+     * @param codec_id   Encoder override; AV_CODEC_ID_NONE = container default.
+     * @return Capture handle; pass to stop_capture() to finalise.
+     */
+    [[nodiscard]] uint32_t capture_window(
+        const std::shared_ptr<Core::Window>& window,
+        const std::string& filepath,
+        double frame_rate,
+        AVCodecID codec_id = AV_CODEC_ID_NONE);
+
+    /**
+     * @brief Stop the active window capture and finalise the file.
+     *
+     * Convenience overload that resolves the capture id by window pointer.
+     * No-op with a warning if no capture is active for this window.
+     *
+     * @param window Window previously passed to capture_window().
+     */
+    void stop_capture(const std::shared_ptr<Core::Window>& window);
+
+    // ─────────────────────────────────────────────────────────────────────────
     // Image — load
     // ─────────────────────────────────────────────────────────────────────────
 
@@ -553,9 +612,9 @@ public:
     [[nodiscard]] std::vector<std::shared_ptr<ModelReader>> get_model_readers() const { return m_model_readers; };
 
     /**
-     * @brief Returns all active capture IDs.
+     * @brief Returns all active audio capture IDs.
      */
-    [[nodiscard]] std::vector<uint32_t> get_capture_ids() const;
+    [[nodiscard]] std::vector<uint32_t> get_audio_capture_ids() const;
 
     /**
      * @brief Returns all registered SoundFileWriters created via create_writer() or write().
@@ -586,14 +645,27 @@ private:
 
     // ── Audio capture ──────────────────────────────────────────────────────
 
-    struct CaptureState {
+    struct AudioCaptureState {
         std::shared_ptr<Kakshya::AudioOutputContainer> container;
         std::shared_ptr<SoundFileWriter> writer;
         uint32_t observer_id {};
     };
 
-    mutable std::mutex m_captures_mutex;
-    std::unordered_map<uint32_t, CaptureState> m_captures;
+    mutable std::mutex m_audio_captures_mutex;
+    std::unordered_map<uint32_t, AudioCaptureState> m_audio_captures;
+
+    // ── Audio capture ──────────────────────────────────────────────────────
+
+    struct VideoCaptureState {
+        std::shared_ptr<VideoFileWriter> writer;
+        uint32_t capture_id {};
+    };
+
+    mutable std::mutex m_video_captures_mutex;
+    std::unordered_map<uint32_t, VideoCaptureState> m_video_captures;
+    std::atomic<uint32_t> m_next_video_capture_id { 1 };
+
+    std::vector<std::shared_ptr<VideoFileWriter>> m_video_writers;
 
     // ── readers ──────────────────────────────────────────────────────
 

--- a/src/MayaFlux/IO/IOManager.hpp
+++ b/src/MayaFlux/IO/IOManager.hpp
@@ -458,6 +458,16 @@ public:
      */
     void stop_capture(const std::shared_ptr<Core::Window>& window);
 
+    /**
+     * @brief Returns all active video capture IDs (capture_window()).
+     */
+    [[nodiscard]] std::vector<uint32_t> get_video_capture_ids() const;
+
+    /**
+     * @brief Returns all VideoFileWriters created via create_writer().
+     */
+    [[nodiscard]] std::vector<std::shared_ptr<VideoFileWriter>> get_video_writers() const;
+
     // ─────────────────────────────────────────────────────────────────────────
     // Image — load
     // ─────────────────────────────────────────────────────────────────────────

--- a/src/MayaFlux/IO/VideoEncodeContext.cpp
+++ b/src/MayaFlux/IO/VideoEncodeContext.cpp
@@ -1,0 +1,351 @@
+#include "VideoEncodeContext.hpp"
+
+#include "MayaFlux/Journal/Archivist.hpp"
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/imgutils.h>
+#include <libavutil/opt.h>
+#include <libavutil/pixdesc.h>
+#include <libswscale/swscale.h>
+}
+
+namespace MayaFlux::IO {
+
+namespace {
+
+    /**
+     * @brief Select encoder codec for a given container format.
+     *
+     * Falls back to H.264 for any unrecognised container. MP4 and MKV default
+     * to H.264 because it has the widest hardware decode support. WebM defaults
+     * to VP9. AVI defaults to MPEG-4 Part 2 for maximum compatibility.
+     */
+    AVCodecID infer_video_codec(AVFormatContext* fmt_ctx)
+    {
+        if (!fmt_ctx || !fmt_ctx->oformat)
+            return AV_CODEC_ID_H264;
+
+        const char* name = fmt_ctx->oformat->name;
+        if (!name)
+            return AV_CODEC_ID_H264;
+
+        if (std::string_view(name).find("webm") != std::string_view::npos)
+            return AV_CODEC_ID_VP9;
+        if (std::string_view(name).find("avi") != std::string_view::npos)
+            return AV_CODEC_ID_MPEG4;
+
+        return AV_CODEC_ID_H264;
+    }
+
+    /**
+     * @brief Resolve bytes-per-pixel for a packed AVPixelFormat.
+     *
+     * Only the formats the swapchain readback can deliver are handled here.
+     * Any unrecognised format falls back to 4 (BGRA/RGBA assumption).
+     */
+    int bpp_for_format(AVPixelFormat fmt)
+    {
+        switch (fmt) {
+        case AV_PIX_FMT_BGRA:
+        case AV_PIX_FMT_RGBA:
+        case AV_PIX_FMT_ARGB:
+        case AV_PIX_FMT_ABGR:
+            return 4;
+        case AV_PIX_FMT_BGR24:
+        case AV_PIX_FMT_RGB24:
+            return 3;
+        case AV_PIX_FMT_RGBA64LE:
+        case AV_PIX_FMT_RGBA64BE:
+        case AV_PIX_FMT_BGRA64LE:
+        case AV_PIX_FMT_BGRA64BE:
+            return 8;
+        default:
+            return 4;
+        }
+    }
+
+} // namespace
+
+// =========================================================================
+// Destructor
+// =========================================================================
+
+VideoEncodeContext::~VideoEncodeContext()
+{
+    close();
+}
+
+void VideoEncodeContext::close()
+{
+    if (m_scratch_frame) {
+        av_frame_free(&m_scratch_frame);
+        m_scratch_frame = nullptr;
+    }
+    if (sws_context) {
+        sws_freeContext(sws_context);
+        sws_context = nullptr;
+    }
+    if (codec_context) {
+        avcodec_free_context(&codec_context);
+        codec_context = nullptr;
+    }
+    m_stream = nullptr;
+    m_stream_index = -1;
+    m_pts = 0;
+    m_width = 0;
+    m_height = 0;
+    m_last_error.clear();
+}
+
+// =========================================================================
+// Open
+// =========================================================================
+
+bool VideoEncodeContext::open(FFmpegMuxContext& mux,
+    uint32_t width,
+    uint32_t height,
+    double frame_rate,
+    AVPixelFormat src_pixel_format,
+    AVCodecID codec_id)
+{
+    close();
+
+    if (!mux.is_open()) {
+        m_last_error = "VideoEncodeContext::open: mux context is not open";
+        return false;
+    }
+
+    if (width == 0 || height == 0 || frame_rate <= 0.0) {
+        m_last_error = "VideoEncodeContext::open: invalid dimensions or frame rate";
+        return false;
+    }
+
+    m_width = width;
+    m_height = height;
+    m_src_src_bpp = bpp_for_format(src_pixel_format);
+
+    if (codec_id == AV_CODEC_ID_NONE)
+        codec_id = infer_video_codec(mux.format_context);
+
+    const AVCodec* codec = avcodec_find_encoder(codec_id);
+    if (!codec) {
+        m_last_error = std::string("avcodec_find_encoder failed for codec_id=")
+            + std::to_string(static_cast<int>(codec_id));
+        return false;
+    }
+
+    codec_context = avcodec_alloc_context3(codec);
+    if (!codec_context) {
+        m_last_error = "avcodec_alloc_context3 failed";
+        return false;
+    }
+
+    ///< H.264/H.265 require dimensions divisible by 2
+    codec_context->width = static_cast<int>(width % 2 == 0 ? width : width - 1);
+    codec_context->height = static_cast<int>(height % 2 == 0 ? height : height - 1);
+
+    /*
+     * Convert double fps to AVRational. Use millisecond time_base so fractional
+     * rates (23.976, 29.97, 59.94) round-trip without drift.
+     */
+    const int fps_num = static_cast<int>(std::round(frame_rate * 1000.0));
+    codec_context->framerate = { .num = fps_num, .den = 1000 };
+    codec_context->time_base = { .num = 1000, .den = fps_num };
+
+    /*
+     * YUV420P is the universally supported pixel format for H.264/H.265.
+     * VP9 and MPEG4 also accept it. For codecs that require a different native
+     * format, callers must pass an appropriate codec_id and the caller-side
+     * src_pixel_format. The sws_scale below handles any conversion.
+     */
+    codec_context->pix_fmt = AV_PIX_FMT_YUV420P;
+
+    /*
+     *Reasonable quality defaults — not tunable here; callers set codec options
+     * via AVDictionary on codec_context before open() returns if needed.
+     */
+    codec_context->bit_rate = 0; ///< let encoder decide from crf
+    if (codec_id == AV_CODEC_ID_H264 || codec_id == AV_CODEC_ID_H265) {
+        av_opt_set(codec_context->priv_data, "preset", "fast", 0);
+        av_opt_set(codec_context->priv_data, "crf", "23", 0);
+    }
+
+    if (mux.format_context->oformat->flags & AVFMT_GLOBALHEADER)
+        codec_context->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+
+    if (avcodec_open2(codec_context, codec, nullptr) < 0) {
+        m_last_error = "avcodec_open2 failed";
+        close();
+        return false;
+    }
+
+    m_stream = mux.add_stream();
+    if (!m_stream) {
+        m_last_error = "FFmpegMuxContext::add_stream returned nullptr";
+        close();
+        return false;
+    }
+
+    if (avcodec_parameters_from_context(m_stream->codecpar, codec_context) < 0) {
+        m_last_error = "avcodec_parameters_from_context failed";
+        close();
+        return false;
+    }
+
+    m_stream->time_base = codec_context->time_base;
+    m_stream_index = m_stream->index;
+
+    // -------------------------------------------------------------------------
+    // SwsContext: source format -> YUV420P
+    // -------------------------------------------------------------------------
+    sws_context = sws_getContext(
+        codec_context->width,
+        codec_context->height,
+        src_pixel_format,
+        codec_context->width,
+        codec_context->height,
+        codec_context->pix_fmt,
+        SWS_BILINEAR,
+        nullptr, nullptr, nullptr);
+
+    if (!sws_context) {
+        m_last_error = "sws_getContext failed";
+        close();
+        return false;
+    }
+
+    // -------------------------------------------------------------------------
+    // Scratch frame for sws_scale output
+    // -------------------------------------------------------------------------
+    m_scratch_frame = av_frame_alloc();
+    if (!m_scratch_frame) {
+        m_last_error = "av_frame_alloc failed";
+        close();
+        return false;
+    }
+
+    m_scratch_frame->format = codec_context->pix_fmt;
+    m_scratch_frame->width = codec_context->width;
+    m_scratch_frame->height = codec_context->height;
+
+    if (av_frame_get_buffer(m_scratch_frame, 32) < 0) {
+        m_last_error = "av_frame_get_buffer failed";
+        close();
+        return false;
+    }
+
+    MF_INFO(Journal::Component::IO, Journal::Context::FileIO,
+        "[VideoEncodeContext] open: {}x{} @ {:.3f} fps | src={} enc={} stream#{}",
+        codec_context->width, codec_context->height, frame_rate,
+        av_get_pix_fmt_name(src_pixel_format) ? av_get_pix_fmt_name(src_pixel_format) : "unknown",
+        avcodec_get_name(codec_id),
+        m_stream_index);
+
+    return true;
+}
+
+// =========================================================================
+// Encoding
+// =========================================================================
+
+bool VideoEncodeContext::encode_frame(const uint8_t* src_data,
+    size_t src_size,
+    FFmpegMuxContext& mux)
+{
+    if (!is_valid())
+        return false;
+
+    const size_t expected = static_cast<size_t>(codec_context->width)
+        * static_cast<size_t>(codec_context->height)
+        * static_cast<size_t>(m_src_src_bpp);
+
+    if (src_size < expected) {
+        m_last_error = "encode_frame: src_size too small for declared dimensions";
+        return false;
+    }
+
+    if (av_frame_make_writable(m_scratch_frame) < 0) {
+        m_last_error = "av_frame_make_writable failed";
+        return false;
+    }
+
+    ///< Source linesize: packed, no padding
+    const int src_stride = codec_context->width * m_src_src_bpp;
+    sws_scale(sws_context,
+        &src_data, &src_stride,
+        0, codec_context->height,
+        m_scratch_frame->data, m_scratch_frame->linesize);
+
+    m_scratch_frame->pts = m_pts++;
+
+    if (avcodec_send_frame(codec_context, m_scratch_frame) < 0) {
+        m_last_error = "avcodec_send_frame failed";
+        return false;
+    }
+
+    return drain_packets(mux);
+}
+
+// =========================================================================
+// Drain
+// =========================================================================
+
+bool VideoEncodeContext::drain(FFmpegMuxContext& mux)
+{
+    if (!is_valid())
+        return false;
+
+    if (avcodec_send_frame(codec_context, nullptr) < 0) {
+        m_last_error = "avcodec_send_frame(null) failed during drain";
+        return false;
+    }
+
+    return drain_packets(mux);
+}
+
+// =========================================================================
+// Private helpers
+// =========================================================================
+
+bool VideoEncodeContext::drain_packets(FFmpegMuxContext& mux)
+{
+    AVPacket* pkt = av_packet_alloc();
+    if (!pkt) {
+        m_last_error = "av_packet_alloc failed";
+        return false;
+    }
+
+    bool ok = true;
+    while (true) {
+        int ret = avcodec_receive_packet(codec_context, pkt);
+        if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF)
+            break;
+        if (ret < 0) {
+            char errbuf[AV_ERROR_MAX_STRING_SIZE];
+            av_strerror(ret, errbuf, sizeof(errbuf));
+            m_last_error = std::string("avcodec_receive_packet failed: ") + errbuf;
+            ok = false;
+            break;
+        }
+
+        pkt->stream_index = m_stream_index;
+        av_packet_rescale_ts(pkt,
+            codec_context->time_base,
+            m_stream->time_base);
+
+        if (!mux.write_packet(pkt)) {
+            m_last_error = mux.last_error();
+            ok = false;
+            break;
+        }
+
+        av_packet_unref(pkt);
+    }
+
+    av_packet_free(&pkt);
+    return ok;
+}
+
+} // namespace MayaFlux::IO

--- a/src/MayaFlux/IO/VideoEncodeContext.cpp
+++ b/src/MayaFlux/IO/VideoEncodeContext.cpp
@@ -125,6 +125,8 @@ bool VideoEncodeContext::open(FFmpegMuxContext& mux,
     m_width = width;
     m_height = height;
     m_src_src_bpp = bpp_for_format(src_pixel_format);
+    m_src_pixel_fmt = src_pixel_format;
+    m_src_pixel_fmt = src_pixel_format;
 
     if (codec_id == AV_CODEC_ID_NONE)
         codec_id = infer_video_codec(mux.format_context);
@@ -252,13 +254,20 @@ bool VideoEncodeContext::open(FFmpegMuxContext& mux,
 
 bool VideoEncodeContext::encode_frame(const uint8_t* src_data,
     size_t src_size,
+    uint32_t src_width,
+    uint32_t src_height,
     FFmpegMuxContext& mux)
 {
     if (!is_valid())
         return false;
 
-    const size_t expected = static_cast<size_t>(codec_context->width)
-        * static_cast<size_t>(codec_context->height)
+    if (src_width == 0 || src_height == 0) {
+        m_last_error = "encode_frame: zero source dimensions";
+        return false;
+    }
+
+    const size_t expected = static_cast<size_t>(src_width)
+        * static_cast<size_t>(src_height)
         * static_cast<size_t>(m_src_src_bpp);
 
     if (src_size < expected) {
@@ -271,11 +280,33 @@ bool VideoEncodeContext::encode_frame(const uint8_t* src_data,
         return false;
     }
 
-    ///< Source linesize: packed, no padding
-    const int src_stride = codec_context->width * m_src_src_bpp;
+    if (static_cast<int>(src_width) != m_cached_src_width
+        || static_cast<int>(src_height) != m_cached_src_height) {
+
+        sws_freeContext(sws_context);
+        sws_context = sws_getContext(
+            static_cast<int>(src_width),
+            static_cast<int>(src_height),
+            m_src_pixel_fmt,
+            codec_context->width,
+            codec_context->height,
+            codec_context->pix_fmt,
+            SWS_BILINEAR,
+            nullptr, nullptr, nullptr);
+
+        if (!sws_context) {
+            m_last_error = "sws_getContext failed on dimension change";
+            return false;
+        }
+
+        m_cached_src_width = static_cast<int>(src_width);
+        m_cached_src_height = static_cast<int>(src_height);
+    }
+
+    const int src_stride = static_cast<int>(src_width) * m_src_src_bpp;
     sws_scale(sws_context,
         &src_data, &src_stride,
-        0, codec_context->height,
+        0, static_cast<int>(src_height),
         m_scratch_frame->data, m_scratch_frame->linesize);
 
     m_scratch_frame->pts = m_pts++;

--- a/src/MayaFlux/IO/VideoEncodeContext.hpp
+++ b/src/MayaFlux/IO/VideoEncodeContext.hpp
@@ -122,6 +122,8 @@ public:
      */
     bool encode_frame(const uint8_t* src_data,
         size_t src_size,
+        uint32_t src_width,
+        uint32_t src_height,
         FFmpegMuxContext& mux);
 
     /**
@@ -158,7 +160,10 @@ private:
     int m_stream_index { -1 };
     uint32_t m_width {};
     uint32_t m_height {};
-    int m_src_src_bpp { 4 }; ///< Bytes per pixel of the source format.
+    int m_src_src_bpp { 4 };
+    AVPixelFormat m_src_pixel_fmt { AV_PIX_FMT_BGRA };
+    int m_cached_src_width { -1 };
+    int m_cached_src_height { -1 };
 
     std::string m_last_error;
 

--- a/src/MayaFlux/IO/VideoEncodeContext.hpp
+++ b/src/MayaFlux/IO/VideoEncodeContext.hpp
@@ -1,0 +1,168 @@
+#pragma once
+
+#include "FFmpegMuxContext.hpp"
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+struct AVStream;
+struct SwsContext;
+}
+
+namespace MayaFlux::IO {
+
+/**
+ * @class VideoEncodeContext
+ * @brief RAII owner of one video stream's encoder and pixel-format converter on the write path.
+ *
+ * Encapsulates all video-stream-specific FFmpeg objects:
+ * - AVCodecContext for the selected or inferred encoder
+ * - SwsContext converting from the source pixel format (e.g. AV_PIX_FMT_BGRA, as
+ *   delivered by the Vulkan swapchain readback) to the encoder's required format
+ *   (typically AV_PIX_FMT_YUV420P for H.264/H.265)
+ * - AVFrame scratch buffer for sws_scale output
+ * - Monotonically increasing PTS counter
+ *
+ * Does NOT own AVFormatContext — that belongs to FFmpegMuxContext.
+ *
+ * Open sequence:
+ *   1. FFmpegMuxContext::open()
+ *   2. VideoEncodeContext::open()      — adds stream, configures codec + sws
+ *   3. FFmpegMuxContext::write_header()
+ *   4. encode_frame() loop
+ *   5. drain()                         — flushes encoder delay
+ *   6. FFmpegMuxContext::close()       — writes trailer
+ *
+ * The source pixel format passed to open() must match the format delivered
+ * to every subsequent encode_frame() call. Swapchain BGRA readbacks map to
+ * AV_PIX_FMT_BGRA; RGBA readbacks to AV_PIX_FMT_RGBA.
+ *
+ * Not copyable or movable; always stack- or member-allocated inside the owner
+ * (VideoFileWriter worker thread).
+ *
+ * The associated FFmpegMuxContext must outlive this object.
+ */
+class MAYAFLUX_API VideoEncodeContext {
+public:
+    VideoEncodeContext() = default;
+    ~VideoEncodeContext();
+
+    VideoEncodeContext(const VideoEncodeContext&) = delete;
+    VideoEncodeContext& operator=(const VideoEncodeContext&) = delete;
+    VideoEncodeContext(VideoEncodeContext&&) = delete;
+    VideoEncodeContext& operator=(VideoEncodeContext&&) = delete;
+
+    // =========================================================================
+    // Lifecycle
+    // =========================================================================
+
+    /**
+     * @brief Open the encoder and register a video stream in the mux context.
+     *
+     * Selects the encoder: if codec_id is AV_CODEC_ID_NONE the container's
+     * default video codec is used (MP4/MKV -> H.264, WebM -> VP9, AVI -> MPEG4).
+     * Allocates AVCodecContext, initialises SwsContext converting from
+     * src_pixel_format to the encoder's required pixel format, allocates the
+     * scratch AVFrame, and copies codec parameters to the new AVStream.
+     *
+     * Must be called after FFmpegMuxContext::open() and before
+     * FFmpegMuxContext::write_header().
+     *
+     * @param mux              Open mux context that will own the output stream.
+     * @param width            Frame width in pixels.
+     * @param height           Frame height in pixels.
+     * @param frame_rate       Average frame rate in frames per second.
+     * @param src_pixel_format Source AVPixelFormat delivered by the readback thread.
+     * @param codec_id         Encoder override; AV_CODEC_ID_NONE = container default.
+     * @return True on success; false sets the internal error string.
+     */
+    bool open(FFmpegMuxContext& mux,
+        uint32_t width,
+        uint32_t height,
+        double frame_rate,
+        AVPixelFormat src_pixel_format,
+        AVCodecID codec_id);
+
+    /**
+     * @brief Release all owned resources.
+     *        Safe to call multiple times or on a context that never opened.
+     */
+    void close();
+
+    /**
+     * @brief True if codec, scaler, and scratch frame are all ready.
+     */
+    [[nodiscard]] bool is_valid() const
+    {
+        return codec_context && sws_context && m_scratch_frame && m_stream_index >= 0;
+    }
+
+    // =========================================================================
+    // Encoding
+    // =========================================================================
+
+    /**
+     * @brief Encode one raw pixel frame into the mux context.
+     *
+     * Converts src_data from the source pixel format to the encoder's required
+     * format via SwsContext, stamps the monotonic PTS, and submits the frame
+     * to the encoder. Drains any available packets to the mux immediately.
+     *
+     * src_data must be a packed, row-major image of exactly width * height *
+     * bytes_per_pixel(src_pixel_format) bytes as delivered by the swapchain
+     * readback. No stride padding is expected; the source linesize is computed
+     * as width * bytes_per_pixel.
+     *
+     * Non-blocking with respect to the observer thread: this runs exclusively
+     * on the VideoFileWriter worker thread.
+     *
+     * @param src_data Pointer to the first byte of the packed source image.
+     * @param src_size Byte count of src_data; must equal width * height * bpp.
+     * @param mux      Mux context to receive encoded packets.
+     * @return True on success.
+     */
+    bool encode_frame(const uint8_t* src_data,
+        size_t src_size,
+        FFmpegMuxContext& mux);
+
+    /**
+     * @brief Flush all buffered frames from the encoder to the mux.
+     *
+     * Sends a null frame to signal EOS to the encoder and drains all remaining
+     * output packets. Call once before FFmpegMuxContext::close().
+     *
+     * @param mux Mux context to receive remaining packets.
+     * @return True if all remaining packets were written successfully.
+     */
+    bool drain(FFmpegMuxContext& mux);
+
+    // =========================================================================
+    // Error
+    // =========================================================================
+
+    [[nodiscard]] const std::string& last_error() const { return m_last_error; }
+
+    // =========================================================================
+    // Owned handles
+    // =========================================================================
+
+    AVCodecContext* codec_context {}; ///< Owned; freed in destructor.
+    SwsContext* sws_context {}; ///< Owned; freed in destructor.
+
+    [[nodiscard]] uint32_t width() const { return m_width; }
+    [[nodiscard]] uint32_t height() const { return m_height; }
+
+private:
+    AVStream* m_stream {}; ///< Weak ref into FFmpegMuxContext; not owned.
+    AVFrame* m_scratch_frame {}; ///< Owned scratch buffer for encoder input.
+    int64_t m_pts {};
+    int m_stream_index { -1 };
+    uint32_t m_width {};
+    uint32_t m_height {};
+    int m_src_src_bpp { 4 }; ///< Bytes per pixel of the source format.
+
+    std::string m_last_error;
+
+    bool drain_packets(FFmpegMuxContext& mux);
+};
+
+} // namespace MayaFlux::IO

--- a/src/MayaFlux/IO/VideoFileWriter.cpp
+++ b/src/MayaFlux/IO/VideoFileWriter.cpp
@@ -1,0 +1,489 @@
+#include "VideoFileWriter.hpp"
+
+#include "FFmpegMuxContext.hpp"
+#include "VideoEncodeContext.hpp"
+
+#include "MayaFlux/Buffers/Textures/TextureBuffer.hpp"
+
+#include "MayaFlux/Kakshya/Source/TextureContainer.hpp"
+#include "MayaFlux/Kakshya/Source/VideoStreamContainer.hpp"
+
+#include "MayaFlux/Portal/Graphics/TextureLoom.hpp"
+
+#include "MayaFlux/Core/Backends/Graphics/Vulkan/VKImage.hpp"
+#include "MayaFlux/Core/Backends/Windowing/Window.hpp"
+
+#include "MayaFlux/Registry/BackendRegistry.hpp"
+#include "MayaFlux/Registry/Service/DisplayService.hpp"
+
+#include "MayaFlux/Journal/Archivist.hpp"
+
+extern "C" {
+#include <libavutil/pixfmt.h>
+}
+
+namespace MayaFlux::IO {
+
+namespace {
+
+    AVPixelFormat vk_format_to_avpixfmt(uint32_t vk_fmt_uint)
+    {
+        switch (static_cast<vk::Format>(vk_fmt_uint)) {
+        case vk::Format::eR8G8B8A8Unorm:
+        case vk::Format::eR8G8B8A8Srgb:
+            return AV_PIX_FMT_RGBA;
+        case vk::Format::eB8G8R8A8Unorm:
+        case vk::Format::eB8G8R8A8Srgb:
+            return AV_PIX_FMT_BGRA;
+        case vk::Format::eR16G16B16A16Sfloat:
+            return AV_PIX_FMT_RGBA64LE;
+        default:
+            return AV_PIX_FMT_BGRA;
+        }
+    }
+
+    AVPixelFormat image_format_to_avpixfmt(Portal::Graphics::ImageFormat fmt)
+    {
+        using F = Portal::Graphics::ImageFormat;
+        switch (fmt) {
+        case F::RGBA8:
+        case F::RGBA8_SRGB:
+            return AV_PIX_FMT_RGBA;
+        case F::BGRA8:
+        case F::BGRA8_SRGB:
+            return AV_PIX_FMT_BGRA;
+        case F::RGB8:
+            return AV_PIX_FMT_RGB24;
+        case F::RGBA16F:
+        case F::RGBA16:
+            return AV_PIX_FMT_RGBA64LE;
+        case F::RGBA32F:
+            return AV_PIX_FMT_RGBAF32LE;
+        default:
+            return AV_PIX_FMT_NONE;
+        }
+    }
+
+} // namespace
+
+// =========================================================================
+// Constructor / destructor
+// =========================================================================
+
+VideoFileWriter::VideoFileWriter()
+    : m_queue(std::make_unique<Memory::LockFreeQueue<WorkItem, k_queue_capacity>>())
+{
+}
+
+VideoFileWriter::~VideoFileWriter()
+{
+    if (m_observer_id.load(std::memory_order_acquire) != 0) {
+        stop_recording().get();
+    } else if (m_open.load(std::memory_order_acquire) && !m_closing.exchange(true)) {
+        auto fut = close();
+        if (fut.wait_for(std::chrono::seconds(5)) == std::future_status::timeout) {
+            MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+                "VideoFileWriter destructor timed out; worker detached, file may be incomplete");
+            m_worker.detach();
+            return;
+        }
+    }
+    if (m_worker.joinable())
+        m_worker.join();
+}
+
+// =========================================================================
+// Screen capture — untouched, works
+// =========================================================================
+
+bool VideoFileWriter::record(const std::shared_ptr<Core::Window>& window,
+    const std::string& filepath,
+    double frame_rate,
+    AVCodecID codec_id)
+{
+    if (!window) {
+        set_error("record: null window");
+        return false;
+    }
+
+    auto* svc = Registry::BackendRegistry::instance()
+                    .get_service<Registry::Service::DisplayService>();
+    if (!svc || !svc->register_frame_observer) {
+        set_error("record: DisplayService unavailable");
+        return false;
+    }
+
+    if (m_observer_id.load(std::memory_order_acquire) != 0)
+        stop_recording().get();
+
+    m_capture_filepath = filepath;
+    m_capture_frame_rate = frame_rate;
+    m_capture_codec_id = codec_id;
+    m_capture_window = window;
+    m_capture_opened.store(false, std::memory_order_release);
+
+    if (!window->is_capture_enabled()) {
+        window->set_capture_enabled(true);
+        m_capture_did_enable = true;
+    }
+
+    auto handle = std::static_pointer_cast<void>(window);
+
+    uint32_t obs_id = svc->register_frame_observer(handle,
+        [this](const std::shared_ptr<std::vector<uint8_t>>& buf,
+            uint32_t w, uint32_t h, uint32_t vk_fmt) {
+            if (!buf || buf->empty())
+                return;
+
+            if (!m_capture_opened.exchange(true, std::memory_order_acq_rel)) {
+                const AVPixelFormat av_fmt = vk_format_to_avpixfmt(vk_fmt);
+                if (!open(m_capture_filepath, w, h,
+                        m_capture_frame_rate, av_fmt, m_capture_codec_id)) {
+                    MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+                        "[VideoFileWriter] record: failed to open encoder for "
+                        "'{}': {}",
+                        m_capture_filepath, last_error());
+                    m_capture_opened.store(false, std::memory_order_release);
+                    return;
+                }
+            }
+
+            write(buf->data(), buf->size());
+        });
+
+    if (obs_id == 0) {
+        set_error("record: register_frame_observer returned 0 — "
+                  "capture not yet active for this window");
+        if (m_capture_did_enable) {
+            window->set_capture_enabled(false);
+            m_capture_did_enable = false;
+        }
+        m_capture_window.reset();
+        return false;
+    }
+
+    m_observer_id.store(obs_id, std::memory_order_release);
+
+    MF_INFO(Journal::Component::IO, Journal::Context::FileIO,
+        "[VideoFileWriter] record: observer {} registered for '{}' -> '{}'",
+        obs_id, window->get_create_info().title, filepath);
+
+    return true;
+}
+
+std::future<bool> VideoFileWriter::stop_recording()
+{
+    const uint32_t obs_id = m_observer_id.exchange(0, std::memory_order_acq_rel);
+
+    if (obs_id != 0) {
+        auto* svc = Registry::BackendRegistry::instance()
+                        .get_service<Registry::Service::DisplayService>();
+        if (svc && svc->unregister_frame_observer && m_capture_window) {
+            svc->unregister_frame_observer(
+                std::static_pointer_cast<void>(m_capture_window), obs_id);
+        }
+
+        if (m_capture_did_enable && m_capture_window) {
+            m_capture_window->set_capture_enabled(false);
+            m_capture_did_enable = false;
+        }
+
+        m_capture_window.reset();
+    }
+
+    if (m_open.load(std::memory_order_acquire))
+        return close();
+
+    std::promise<bool> p;
+    p.set_value(false);
+    return p.get_future();
+}
+
+// =========================================================================
+// Lifecycle
+// =========================================================================
+
+bool VideoFileWriter::open(const std::string& filepath,
+    uint32_t width,
+    uint32_t height,
+    double frame_rate,
+    AVPixelFormat src_pixel_format,
+    AVCodecID explicit_codec)
+{
+    if (m_open.load(std::memory_order_acquire)) {
+        set_error("open() called while already open");
+        return false;
+    }
+
+    m_width = width;
+    m_height = height;
+    m_src_fmt = src_pixel_format;
+    m_close_promise = std::promise<bool> {};
+    m_closing.store(false, std::memory_order_release);
+
+    m_worker = std::thread(&VideoFileWriter::worker_loop, this,
+        filepath, width, height, frame_rate, src_pixel_format, explicit_codec);
+
+    constexpr int k_spin_ms = 500;
+    constexpr int k_sleep_us = 500;
+    for (int i = 0; i < (k_spin_ms * 1000 / k_sleep_us); ++i) {
+        if (m_open.load(std::memory_order_acquire))
+            return true;
+        std::this_thread::sleep_for(std::chrono::microseconds(k_sleep_us));
+    }
+
+    if (m_worker.joinable())
+        m_worker.join();
+    return false;
+}
+
+std::future<bool> VideoFileWriter::close()
+{
+    if (!m_closing.exchange(true))
+        post(CloseCmd {});
+    return m_close_promise.get_future();
+}
+
+// =========================================================================
+// Write — raw pixels (capture path lands here; m_width/m_height from open())
+// =========================================================================
+
+void VideoFileWriter::write(const uint8_t* pixels, size_t size)
+{
+    if (!m_open.load(std::memory_order_acquire) || !pixels || size == 0)
+        return;
+    post(RawFrame {
+        .pixels = std::vector<uint8_t>(pixels, pixels + size),
+        .width = m_width,
+        .height = m_height });
+}
+
+void VideoFileWriter::write(std::span<const uint8_t> pixels)
+{
+    if (!m_open.load(std::memory_order_acquire) || pixels.empty())
+        return;
+    post(RawFrame {
+        .pixels = std::vector<uint8_t>(pixels.begin(), pixels.end()),
+        .width = m_width,
+        .height = m_height });
+}
+
+// =========================================================================
+// Write — TextureContainer
+// =========================================================================
+
+void VideoFileWriter::write(const std::shared_ptr<Kakshya::TextureContainer>& container,
+    uint32_t layer)
+{
+    if (!m_open.load(std::memory_order_acquire) || !container)
+        return;
+
+    auto span = container->pixel_bytes(layer);
+    if (span.empty()) {
+        MF_WARN(Journal::Component::IO, Journal::Context::FileIO,
+            "VideoFileWriter::write(TextureContainer): pixel_bytes empty for layer {}",
+            layer);
+        return;
+    }
+
+    post(RawFrame {
+        .pixels = std::vector<uint8_t>(span.begin(), span.end()),
+        .width = container->get_width(),
+        .height = container->get_height() });
+}
+
+// =========================================================================
+// Write — VideoStreamContainer / CameraContainer
+// =========================================================================
+
+void VideoFileWriter::write(const std::shared_ptr<Kakshya::VideoStreamContainer>& container,
+    uint64_t frame_index)
+{
+    if (!m_open.load(std::memory_order_acquire) || !container)
+        return;
+
+    auto span = container->get_frame_pixels(frame_index);
+    if (span.empty()) {
+        MF_WARN(Journal::Component::IO, Journal::Context::FileIO,
+            "VideoFileWriter::write(VideoStreamContainer): get_frame_pixels({}) returned empty",
+            frame_index);
+        return;
+    }
+
+    post(RawFrame {
+        .pixels = std::vector<uint8_t>(span.begin(), span.end()),
+        .width = container->get_width(),
+        .height = container->get_height() });
+}
+
+// =========================================================================
+// Write — TextureBuffer
+// =========================================================================
+
+void VideoFileWriter::write(const std::shared_ptr<Buffers::TextureBuffer>& buffer)
+{
+    if (!m_open.load(std::memory_order_acquire) || !buffer)
+        return;
+
+    if (buffer->get_pixel_data().empty() && !buffer->has_texture()) {
+        MF_WARN(Journal::Component::IO, Journal::Context::FileIO,
+            "VideoFileWriter::write(TextureBuffer): no CPU pixels and no GPU texture");
+        return;
+    }
+
+    post(DownloadCmd { .buffer = buffer });
+}
+
+// =========================================================================
+// Error / post
+// =========================================================================
+
+std::string VideoFileWriter::last_error() const
+{
+    std::lock_guard lock(m_error_mutex);
+    return m_last_error;
+}
+
+void VideoFileWriter::set_error(std::string msg)
+{
+    std::lock_guard lock(m_error_mutex);
+    m_last_error = std::move(msg);
+}
+
+bool VideoFileWriter::post(const WorkItem& item)
+{
+    return m_queue->push(item);
+}
+
+// =========================================================================
+// Worker loop
+// =========================================================================
+
+void VideoFileWriter::worker_loop(const std::string& filepath,
+    uint32_t width,
+    uint32_t height,
+    double frame_rate,
+    AVPixelFormat src_fmt,
+    AVCodecID codec_id)
+{
+    FFmpegMuxContext mux;
+    VideoEncodeContext enc;
+
+    auto fail = [&](std::string msg) {
+        set_error(std::move(msg));
+        m_open.store(false, std::memory_order_release);
+        m_close_promise.set_value(false);
+    };
+
+    if (!mux.open(filepath)) {
+        fail(mux.last_error());
+        return;
+    }
+    if (!enc.open(mux, width, height, frame_rate, src_fmt, codec_id)) {
+        fail(enc.last_error());
+        return;
+    }
+    if (!mux.write_header()) {
+        fail(mux.last_error());
+        return;
+    }
+
+    m_open.store(true, std::memory_order_release);
+
+    MF_INFO(Journal::Component::IO, Journal::Context::FileIO,
+        "[VideoFileWriter] worker started: '{}' {}x{} @{:.3f}fps",
+        filepath, width, height, frame_rate);
+
+    while (true) {
+        auto item_opt = m_queue->pop();
+        if (!item_opt) {
+            std::this_thread::sleep_for(std::chrono::microseconds(100));
+            continue;
+        }
+
+        bool done = std::visit([&](auto& cmd) -> bool {
+            using T = std::decay_t<decltype(cmd)>;
+
+            if constexpr (std::is_same_v<T, RawFrame>) {
+                if (!enc.encode_frame(cmd.pixels.data(), cmd.pixels.size(),
+                        cmd.width, cmd.height, mux)) {
+                    set_error(enc.last_error());
+                    MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+                        "[VideoFileWriter] encode_frame failed: {}", enc.last_error());
+                }
+                return false;
+            }
+
+            if constexpr (std::is_same_v<T, DownloadCmd>) {
+                const auto img_fmt = cmd.buffer->get_format();
+                const AVPixelFormat av_fmt = image_format_to_avpixfmt(img_fmt);
+                if (av_fmt == AV_PIX_FMT_NONE) {
+                    MF_WARN(Journal::Component::IO, Journal::Context::FileIO,
+                        "[VideoFileWriter] DownloadCmd: unsupported ImageFormat {}",
+                        static_cast<int>(img_fmt));
+                    return false;
+                }
+
+                const auto& cpu = cmd.buffer->get_pixel_data();
+                if (!cpu.empty()) {
+                    if (!enc.encode_frame(cpu.data(), cpu.size(),
+                            cmd.buffer->get_width(), cmd.buffer->get_height(), mux)) {
+                        set_error(enc.last_error());
+                        MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+                            "[VideoFileWriter] encode_frame (cpu) failed: {}", enc.last_error());
+                    }
+                    return false;
+                }
+
+                auto tex = cmd.buffer->get_texture();
+                if (!tex) {
+                    MF_WARN(Journal::Component::IO, Journal::Context::FileIO,
+                        "[VideoFileWriter] DownloadCmd: no CPU pixels and no GPU texture");
+                    return false;
+                }
+
+                using Portal::Graphics::TextureLoom;
+                const size_t mip0_bytes = static_cast<size_t>(tex->get_width())
+                    * tex->get_height()
+                    * TextureLoom::get_bytes_per_pixel(img_fmt);
+
+                if (mip0_bytes == 0)
+                    return false;
+
+                std::vector<uint8_t> pixels(mip0_bytes);
+                TextureLoom::instance().download_data_async(tex, pixels.data(), mip0_bytes);
+
+                if (!enc.encode_frame(pixels.data(), pixels.size(),
+                        tex->get_width(), tex->get_height(), mux)) {
+                    set_error(enc.last_error());
+                    MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+                        "[VideoFileWriter] encode_frame (gpu) failed: {}", enc.last_error());
+                }
+                return false;
+            }
+
+            return static_cast<bool>(std::is_same_v<T, CloseCmd>);
+        },
+            *item_opt);
+
+        if (done)
+            break;
+    }
+
+    bool ok = enc.drain(mux);
+    if (!ok) {
+        set_error(enc.last_error());
+        MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+            "[VideoFileWriter] drain failed: {}", enc.last_error());
+    }
+
+    mux.close();
+    m_open.store(false, std::memory_order_release);
+    m_close_promise.set_value(ok);
+
+    MF_INFO(Journal::Component::IO, Journal::Context::FileIO,
+        "[VideoFileWriter] worker finished: '{}' status={}",
+        filepath, ok ? "ok" : "error");
+}
+
+} // namespace MayaFlux::IO

--- a/src/MayaFlux/IO/VideoFileWriter.cpp
+++ b/src/MayaFlux/IO/VideoFileWriter.cpp
@@ -148,7 +148,13 @@ bool VideoFileWriter::record(const std::shared_ptr<Core::Window>& window,
                 }
             }
 
-            write(buf->data(), buf->size());
+            if (!m_open.load(std::memory_order_acquire))
+                return;
+
+            post(RawFrame {
+                .pixels = std::vector<uint8_t>(buf->begin(), buf->end()),
+                .width = w,
+                .height = h });
         });
 
     if (obs_id == 0) {

--- a/src/MayaFlux/IO/VideoFileWriter.hpp
+++ b/src/MayaFlux/IO/VideoFileWriter.hpp
@@ -91,6 +91,8 @@ public:
         return m_observer_id.load(std::memory_order_acquire) != 0;
     }
 
+    [[nodiscard]] std::shared_ptr<Core::Window> capture_window() const { return m_capture_window; }
+
     // =========================================================================
     // Write
     // =========================================================================

--- a/src/MayaFlux/IO/VideoFileWriter.hpp
+++ b/src/MayaFlux/IO/VideoFileWriter.hpp
@@ -1,0 +1,164 @@
+#pragma once
+
+#include "MayaFlux/Transitive/Memory/RingBuffer.hpp"
+
+#include <future>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavutil/pixfmt.h>
+}
+
+namespace MayaFlux::Core {
+class Window;
+}
+
+namespace MayaFlux::Kakshya {
+class TextureContainer;
+class VideoStreamContainer;
+}
+
+namespace MayaFlux::Buffers {
+class TextureBuffer;
+}
+
+namespace MayaFlux::IO {
+
+/**
+ * @class VideoFileWriter
+ * @brief Asynchronous video file encoder with a lock-free work queue.
+ *
+ * Accepts pixel data from multiple source types and encodes it to a file on a
+ * dedicated worker thread. The public API is fully non-blocking: every write
+ * call copies the pixel data, posts a work item to an SPSC queue, and returns
+ * immediately. The worker thread owns all FFmpeg state and is the only thread
+ * that touches it.
+ *
+ * Supported input paths:
+ * - record() / stop_recording(): swapchain readback via DisplayService frame
+ *   observer; encoder opened lazily on first frame.
+ * - Raw packed uint8_t pixels (span): caller supplies dimensions matching open().
+ * - TextureContainer: reads pixel_bytes(layer); dimensions from container.
+ * - VideoStreamContainer / CameraContainer: reads get_frame_pixels(); always RGBA.
+ * - TextureBuffer: CPU pixels via get_pixel_data() when present, otherwise
+ *   GPU download via download_data_async() on the worker thread.
+ *
+ * Source dimensions may differ from the encoder output dimensions; SwsContext
+ * rescales automatically. The format passed to open() must match the source
+ * pixel layout for all write() calls on that instance.
+ *
+ * close() returns future<bool>; caller must .get() before process exit or the
+ * container trailer will not be written.
+ */
+class MAYAFLUX_API VideoFileWriter {
+public:
+    VideoFileWriter();
+    ~VideoFileWriter();
+
+    VideoFileWriter(const VideoFileWriter&) = delete;
+    VideoFileWriter& operator=(const VideoFileWriter&) = delete;
+    VideoFileWriter(VideoFileWriter&&) = delete;
+    VideoFileWriter& operator=(VideoFileWriter&&) = delete;
+
+    // =========================================================================
+    // Lifecycle
+    // =========================================================================
+
+    bool open(const std::string& filepath,
+        uint32_t width,
+        uint32_t height,
+        double frame_rate,
+        AVPixelFormat src_pixel_format,
+        AVCodecID explicit_codec = AV_CODEC_ID_NONE);
+
+    std::future<bool> close();
+
+    [[nodiscard]] bool is_open() const { return m_open.load(std::memory_order_acquire); }
+
+    // =========================================================================
+    // Screen capture
+    // =========================================================================
+
+    bool record(const std::shared_ptr<Core::Window>& window,
+        const std::string& filepath,
+        double frame_rate,
+        AVCodecID codec_id = AV_CODEC_ID_NONE);
+
+    std::future<bool> stop_recording();
+
+    [[nodiscard]] bool is_recording() const
+    {
+        return m_observer_id.load(std::memory_order_acquire) != 0;
+    }
+
+    // =========================================================================
+    // Write
+    // =========================================================================
+
+    void write(const uint8_t* pixels, size_t size);
+    void write(std::span<const uint8_t> pixels);
+
+    void write(const std::shared_ptr<Kakshya::TextureContainer>& container,
+        uint32_t layer = 0);
+
+    void write(const std::shared_ptr<Kakshya::VideoStreamContainer>& container,
+        uint64_t frame_index = 0);
+
+    void write(const std::shared_ptr<Buffers::TextureBuffer>& buffer);
+
+    // =========================================================================
+    // Error
+    // =========================================================================
+
+    [[nodiscard]] std::string last_error() const;
+
+private:
+    struct RawFrame {
+        std::vector<uint8_t> pixels;
+        uint32_t width {};
+        uint32_t height {};
+    };
+
+    struct DownloadCmd {
+        std::shared_ptr<Buffers::TextureBuffer> buffer;
+    };
+
+    struct CloseCmd { };
+
+    using WorkItem = std::variant<RawFrame, DownloadCmd, CloseCmd>;
+
+    static constexpr size_t k_queue_capacity = 512;
+    std::unique_ptr<Memory::LockFreeQueue<WorkItem, k_queue_capacity>> m_queue;
+
+    std::thread m_worker;
+    std::atomic<bool> m_open { false };
+    std::atomic<bool> m_closing { false };
+    std::promise<bool> m_close_promise;
+
+    mutable std::mutex m_error_mutex;
+    std::string m_last_error;
+
+    uint32_t m_width {};
+    uint32_t m_height {};
+    AVPixelFormat m_src_fmt { AV_PIX_FMT_BGRA };
+
+    std::shared_ptr<Core::Window> m_capture_window;
+    std::atomic<uint32_t> m_observer_id { 0 };
+    std::atomic<bool> m_capture_opened { false };
+    std::string m_capture_filepath;
+    double m_capture_frame_rate {};
+    AVCodecID m_capture_codec_id { AV_CODEC_ID_NONE };
+    bool m_capture_did_enable { false };
+
+    void worker_loop(const std::string& filepath,
+        uint32_t width,
+        uint32_t height,
+        double frame_rate,
+        AVPixelFormat src_fmt,
+        AVCodecID codec_id);
+
+    void set_error(std::string msg);
+    bool post(const WorkItem& item);
+};
+
+} // namespace MayaFlux::IO


### PR DESCRIPTION
The audio pipeline has had a full write path since 0.3: `SoundFileWriter`, `AudioEncodeContext`, `capture_output`. The graphics side had nothing equivalent. A rendered frame in host memory was not a writable event. This PR adds the video write path as a structural peer.

### The encode layer

`VideoEncodeContext` mirrors `AudioEncodeContext` on the encode side. It owns `AVCodecContext`, `SwsContext` (source pixel format to YUV420P via `sws_scale`), and a scratch `AVFrame`. Codec is inferred from the container when `AV_CODEC_ID_NONE` is passed: H.264 for MP4/MKV, VP9 for WebM. Source dimensions are passed per frame rather than assumed fixed, so `sws_scale` can rescale from any source size to the declared output dimensions without stride smear. `SwsContext` rebuilds on dimension change.

### VideoFileWriter

Same SPSC worker thread model as `SoundFileWriter`. All write calls are non-blocking: copy the source, post a work item, return. The worker thread owns all FFmpeg state.

Four write paths cover the full surface:

```cpp
// swapchain readback, from record() or a manual observer
writer->write(const uint8_t* pixels, size_t size);

// TextureContainer: Yantra workflow output, offline texture
writer->write(container, layer);

// VideoStreamContainer / CameraContainer: always RGBA, no GPU round-trip
writer->write(container, frame_index);

// TextureBuffer: CPU pixels when present, download_data_async fallback
writer->write(buffer);
```

`record(window)` is the primary capture path. It registers a `DisplayService` frame observer, enables swapchain capture on the window if needed, and opens the encoder lazily on the first delivered frame so pixel format and dimensions come from the live swapchain rather than a guess made at call time. Window resize is handled correctly: the observer delivers live `w`/`h` with every frame, which are carried into the `RawFrame` work item directly. `SwsContext` rebuilds when they change.

`stop_recording()` unregisters the observer, restores capture state if `record()` enabled it, and posts `CloseCmd`. Returns `future<bool>`; caller must `.get()` before process exit or the MP4 trailer will not be written.

### IOManager surface

```cpp
// untracked writer the caller drives manually
auto writer = get_io_manager()->create_writer("out.mp4", 1280, 720, 60.0, AV_PIX_FMT_RGBA);

// tracked capture keyed by window, stop by id or by window pointer
auto id = get_io_manager()->capture_window(window, "session.mp4", 60.0);
get_io_manager()->stop_capture(id);
get_io_manager()->stop_capture(window); // convenience overload

// inspection
get_io_manager()->get_video_capture_ids();
get_io_manager()->get_video_writers();
```

`stop_capture(uint32_t)` checks the audio capture map first then the video capture map, so a single call site handles both domains. Audio and video captures share `m_save_tasks` for future tracking, so `wait_for_pending_saves()` covers everything.

### Format

Format is determined by the filepath extension, same as the audio path:

```cpp
capture_window(window, "out.mp4",  60.0);  // MP4, H.264
capture_window(window, "out.mkv",  60.0);  // MKV, H.264
capture_window(window, "out.webm", 60.0);  // WebM, VP9
```

`AVCodecID` override is available on all entry points.