### PR TITLE
FreeRoutine: condition-driven coroutine scheduling

### DIFF
--- a/src/MayaFlux/Core/ProcessingTokens.hpp
+++ b/src/MayaFlux/Core/ProcessingTokens.hpp
@@ -16,6 +16,17 @@ enum class ProcessingToken {
     EVENT_DRIVEN,
     MULTI_RATE, ///< Coroutine can handle multiple sample rates. Picks the frame-accurate processing token by default
     ON_DEMAND, ///< Coroutine is executed on demand, not scheduled
+    /**
+     * @brief Condition-driven execution - resume when a caller-supplied predicate returns true.
+     *
+     * FreeRoutine coroutines carry this token. The scheduler owns a dedicated
+     * thread for this domain that loops continuously, calling try_resume() on
+     * each CONDITIONAL task. try_resume() evaluates the condition stored in the
+     * promise by the most recent ConditionAwaiter; if it returns true the
+     * coroutine is resumed on the scheduler thread. No clock is created for
+     * this domain.
+     */
+    CONDITIONAL,
     CUSTOM
 };
 
@@ -28,7 +39,7 @@ enum class ProcessingToken {
  * temporal domains within the same processing token.
  */
 enum class DelayContext : uint8_t {
-    NONE, ///< No active delay, resume immediately
+    NONE, ///< No active delay, try resume immediately
     SAMPLE_BASED, ///< Sample-accurate delay (audio domain)
     BUFFER_BASED, ///< Buffer-cycle delay (audio hardware boundary)
     FRAME_BASED, ///< Frame-rate delay (Graphics domain)

--- a/src/MayaFlux/Kriya/Awaiters/ConditionAwaiter.hpp
+++ b/src/MayaFlux/Kriya/Awaiters/ConditionAwaiter.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "MayaFlux/Vruta/Promise.hpp"
+
+namespace MayaFlux::Kriya {
+
+/**
+ * @class ConditionAwaiter
+ * @brief Suspends a FreeRoutine until a caller-supplied predicate returns true.
+ *
+ * await_ready() evaluates the condition immediately; if already true the
+ * coroutine does not suspend. Otherwise await_suspend() arms the promise so
+ * the scheduler's CONDITIONAL thread will evaluate the condition on each pass
+ * and resume the handle when it returns true.
+ *
+ * The condition is moved into the promise on suspension and cleared on
+ * resumption. It must be safe to call from the scheduler thread.
+ *
+ * @code
+ * auto routine = [&]() -> Vruta::FreeRoutine {
+ *     while (true) {
+ *         co_await ConditionAwaiter{ [&]{ return flag.load(); } };
+ *         do_work();
+ *     }
+ * };
+ * @endcode
+ */
+class ConditionAwaiter {
+public:
+    /**
+     * @brief Construct with a condition predicate.
+     * @param condition Callable returning bool. Evaluated on the scheduler thread.
+     */
+    explicit ConditionAwaiter(std::function<bool()> condition)
+        : m_condition(std::move(condition))
+    {
+    }
+
+    /**
+     * @brief Evaluate the condition before suspending.
+     * @return true if the condition is already met; the coroutine will not suspend.
+     */
+    [[nodiscard]] bool await_ready() const
+    {
+        return m_condition && m_condition();
+    }
+
+    /**
+     * @brief Arm the promise with the condition and the coroutine handle.
+     * @param handle Handle to the suspended FreeRoutine coroutine frame.
+     *
+     * Requires that the coroutine type is FreeRoutine; the promise cast
+     * is asserted at compile time via the typed handle overload.
+     */
+    void await_suspend(std::coroutine_handle<Vruta::conditional_promise> handle)
+    {
+        auto& p = handle.promise();
+        p.condition = std::move(m_condition);
+        p.armed.store(true, std::memory_order_release);
+    }
+
+    /**
+     * @brief No value to return on resumption.
+     */
+    void await_resume() const { }
+
+private:
+    std::function<bool()> m_condition;
+};
+
+} // namespace MayaFlux::Kriya

--- a/src/MayaFlux/Vruta/Promise.hpp
+++ b/src/MayaFlux/Vruta/Promise.hpp
@@ -9,6 +9,7 @@ namespace MayaFlux::Vruta {
 class SoundRoutine;
 class GraphicsRoutine;
 class CrossRoutine;
+class FreeRoutine;
 class Event;
 class NetworkSource;
 
@@ -420,6 +421,46 @@ struct cross_promise : public routine_promise<CrossRoutine> {
      * suspension before any concurrent await_suspend can re-arm it.
      */
     std::atomic<bool> frame_satisfied { false };
+};
+
+/**
+ * @struct conditional_promise
+ * @brief Coroutine promise for routines suspended on an arbitrary boolean condition.
+ *
+ * FreeRoutine coroutines carry no clock. The scheduler's dedicated CONDITIONAL
+ * thread evaluates the stored condition on every iteration; when it returns true
+ * the handle is resumed. DelayContext stays NONE throughout because no delay is
+ * being modelled - the coroutine is simply waiting for a predicate to become
+ * satisfied.
+ *
+ * The condition is written by ConditionAwaiter::await_suspend and read by the
+ * scheduler thread. Both accesses are on different threads, so the condition
+ * field is protected by the same atomic flag pattern used in BroadcastSource:
+ * the awaiter stores condition + handle atomically before setting armed, and
+ * the scheduler thread reads only after observing armed == true.
+ */
+struct conditional_promise : public routine_promise<FreeRoutine> {
+    FreeRoutine get_return_object();
+
+    ProcessingToken processing_token { ProcessingToken::CONDITIONAL };
+
+    /**
+     * @brief Condition evaluated by the scheduler thread on each iteration.
+     *
+     * Written once per suspension by ConditionAwaiter::await_suspend.
+     * Read repeatedly by the scheduler thread until it returns true.
+     * Null when the coroutine is not suspended on a condition.
+     */
+    std::function<bool()> condition;
+
+    /**
+     * @brief True while the coroutine is suspended on a ConditionAwaiter.
+     *
+     * Set to true in await_suspend, cleared to false before handle.resume().
+     * The scheduler thread reads this to distinguish an active suspension
+     * from a running or completed coroutine.
+     */
+    std::atomic<bool> armed { false };
 };
 
 /**

--- a/src/MayaFlux/Vruta/Routine.cpp
+++ b/src/MayaFlux/Vruta/Routine.cpp
@@ -18,6 +18,11 @@ CrossRoutine cross_promise::get_return_object()
     return { std::coroutine_handle<cross_promise>::from_promise(*this) };
 }
 
+FreeRoutine conditional_promise::get_return_object()
+{
+    return FreeRoutine { std::coroutine_handle<conditional_promise>::from_promise(*this) };
+}
+
 SoundRoutine::SoundRoutine(std::coroutine_handle<promise_type> h)
     : m_handle(h)
 {
@@ -601,6 +606,120 @@ void* CrossRoutine::get_state_impl_raw(const std::string& key)
         return &it->second;
     }
     return nullptr;
+}
+
+FreeRoutine::FreeRoutine(std::coroutine_handle<promise_type> h)
+    : m_handle(h)
+{
+    if (!m_handle || !m_handle.address()) {
+        error<std::invalid_argument>(
+            Journal::Component::Vruta, Journal::Context::CoroutineScheduling,
+            std::source_location::current(),
+            "FreeRoutine: invalid coroutine handle");
+    }
+}
+
+FreeRoutine::FreeRoutine(FreeRoutine&& other) noexcept
+    : m_handle(std::exchange(other.m_handle, {}))
+{
+}
+
+FreeRoutine& FreeRoutine::operator=(FreeRoutine&& other) noexcept
+{
+    if (this != &other) {
+        if (m_handle && m_handle.address())
+            m_handle.destroy();
+        m_handle = std::exchange(other.m_handle, {});
+    }
+    return *this;
+}
+
+FreeRoutine::~FreeRoutine()
+{
+    if (m_handle && m_handle.address())
+        m_handle.destroy();
+}
+
+ProcessingToken FreeRoutine::get_processing_token() const
+{
+    return ProcessingToken::CONDITIONAL;
+}
+
+bool FreeRoutine::is_active() const
+{
+    return m_handle && m_handle.address() && !m_handle.done();
+}
+
+bool FreeRoutine::initialize_state(uint64_t /*current_context*/)
+{
+    if (!m_handle || m_handle.done())
+        return false;
+
+    m_handle.promise().auto_resume = true;
+    return true;
+}
+
+bool FreeRoutine::try_resume(uint64_t /*current_context*/)
+{
+    return try_resume_with_context(0, DelayContext::NONE);
+}
+
+bool FreeRoutine::try_resume_with_context(uint64_t /*current_value*/, DelayContext /*context*/)
+{
+    if (!is_active())
+        return false;
+
+    auto& p = m_handle.promise();
+
+    if (p.should_terminate || !p.auto_resume)
+        return false;
+
+    if (!p.armed.load(std::memory_order_acquire))
+        return false;
+
+    if (!p.condition || !p.condition())
+        return false;
+
+    p.armed.store(false, std::memory_order_release);
+    p.condition = nullptr;
+    m_handle.resume();
+    return true;
+}
+
+bool FreeRoutine::force_resume()
+{
+    if (!m_handle || m_handle.done())
+        return false;
+    m_handle.resume();
+    return true;
+}
+
+bool FreeRoutine::restart()
+{
+    if (!m_handle)
+        return false;
+    set_state<bool>("restart", true);
+    m_handle.promise().auto_resume = true;
+    if (is_active()) {
+        m_handle.resume();
+        return true;
+    }
+    return false;
+}
+
+void FreeRoutine::set_state_impl(const std::string& key, std::any value)
+{
+    if (m_handle)
+        m_handle.promise().state[key] = std::move(value);
+}
+
+void* FreeRoutine::get_state_impl_raw(const std::string& key)
+{
+    if (!m_handle)
+        return nullptr;
+    auto& s = m_handle.promise().state;
+    auto it = s.find(key);
+    return it != s.end() ? &it->second : nullptr;
 }
 
 }

--- a/src/MayaFlux/Vruta/Routine.hpp
+++ b/src/MayaFlux/Vruta/Routine.hpp
@@ -756,4 +756,89 @@ protected:
 private:
     std::coroutine_handle<promise_type> m_handle;
 };
+
+/**
+ * @class FreeRoutine
+ * @brief Coroutine resumed when a caller-supplied condition becomes true.
+ *
+ * FreeRoutine has no clock domain. It suspends on ConditionAwaiter, which
+ * stores a std::function<bool()> in the promise. The scheduler's dedicated
+ * CONDITIONAL thread evaluates that condition on every pass; the coroutine
+ * resumes on that thread the moment the condition returns true.
+ *
+ * Intended for compute loops that must run independently of both the audio
+ * sample clock and the graphics frame clock - cellular automata, physics
+ * integration, ML inference, any free-running iterative process.
+ *
+ * Usage:
+ * @code
+ * auto my_routine = [&state]() -> Vruta::FreeRoutine {
+ *     while (true) {
+ *         co_await ConditionAwaiter{ [&]{ return state.ready.load(); } };
+ *         state.evolve();
+ *     }
+ * };
+ * scheduler->add_task(std::make_shared<FreeRoutine>(my_routine()), "ca_evolve");
+ * @endcode
+ */
+class MAYAFLUX_API FreeRoutine : public Routine {
+public:
+    using promise_type = MayaFlux::Vruta::conditional_promise;
+
+    [[nodiscard]] ProcessingToken get_processing_token() const override;
+
+    explicit FreeRoutine(std::coroutine_handle<promise_type> h);
+
+    FreeRoutine(const FreeRoutine& other) = delete;
+    FreeRoutine& operator=(const FreeRoutine& other) = delete;
+    FreeRoutine(FreeRoutine&& other) noexcept;
+    FreeRoutine& operator=(FreeRoutine&& other) noexcept;
+    ~FreeRoutine() override;
+
+    [[nodiscard]] bool is_active() const override;
+    bool initialize_state(uint64_t current_context = 0U) override;
+    bool try_resume(uint64_t current_context) override;
+    bool try_resume_with_context(uint64_t current_value, DelayContext context) override;
+    bool force_resume() override;
+    bool restart() override;
+
+    [[nodiscard]] uint64_t next_execution() const override { return 0; }
+    [[nodiscard]] bool requires_clock_sync() const override { return false; }
+
+    [[nodiscard]] bool get_auto_resume() const override
+    {
+        return m_handle ? m_handle.promise().auto_resume : false;
+    }
+
+    void set_auto_resume(bool v) override
+    {
+        if (m_handle)
+            m_handle.promise().auto_resume = v;
+    }
+
+    [[nodiscard]] bool get_should_terminate() const override
+    {
+        return m_handle ? m_handle.promise().should_terminate : true;
+    }
+
+    void set_should_terminate(bool v) override
+    {
+        if (m_handle)
+            m_handle.promise().should_terminate = v;
+    }
+
+    [[nodiscard]] bool get_sync_to_clock() const override { return false; }
+
+    [[nodiscard]] uint64_t get_next_sample() const override { return 0; }
+    void set_next_sample(uint64_t) override { }
+    [[nodiscard]] uint64_t get_next_frame() const override { return 0; }
+    void set_next_frame(uint64_t) override { }
+
+protected:
+    void set_state_impl(const std::string& key, std::any value) override;
+    void* get_state_impl_raw(const std::string& key) override;
+
+private:
+    std::coroutine_handle<promise_type> m_handle;
+};
 }

--- a/src/MayaFlux/Vruta/Scheduler.cpp
+++ b/src/MayaFlux/Vruta/Scheduler.cpp
@@ -35,6 +35,24 @@ void TaskScheduler::add_task(const std::shared_ptr<Routine>& routine, const std:
     if (initialize)
         initialize_routine_state(routine, token);
 
+    if (token == ProcessingToken::CONDITIONAL) {
+        routine->set_auto_resume(true);
+        for (auto& op : m_conditional_pending_ops) {
+            bool expected = false;
+            if (op.active.compare_exchange_strong(expected, true,
+                    std::memory_order_relaxed, std::memory_order_relaxed)) {
+                op.is_addition = true;
+                op.entry = { routine, task_name };
+                m_conditional_pending_count.fetch_add(1, std::memory_order_release);
+                start_conditional_thread();
+                return;
+            }
+        }
+        MF_ERROR(Journal::Component::Vruta, Journal::Context::CoroutineScheduling,
+            "Conditional pending queue full, could not add task '{}'", task_name);
+        return;
+    }
+
     for (auto& op : m_pending_ops) {
         bool expected = false;
         if (op.active.compare_exchange_strong(expected, true,
@@ -52,6 +70,17 @@ void TaskScheduler::add_task(const std::shared_ptr<Routine>& routine, const std:
 
 bool TaskScheduler::cancel_task(const std::string& name)
 {
+    for (auto& op : m_conditional_pending_ops) {
+        bool expected = false;
+        if (op.active.compare_exchange_strong(expected, true,
+                std::memory_order_acquire, std::memory_order_relaxed)) {
+            op.entry = { nullptr, name };
+            op.is_addition = false;
+            m_conditional_pending_count.fetch_add(1, std::memory_order_relaxed);
+            return true;
+        }
+    }
+
     for (auto& op : m_pending_ops) {
         bool expected = false;
         if (op.active.compare_exchange_strong(expected, true,
@@ -74,6 +103,13 @@ bool TaskScheduler::cancel_task(const std::shared_ptr<Routine>& routine)
     if (!routine)
         return false;
 
+    if (routine && routine->get_processing_token() == ProcessingToken::CONDITIONAL) {
+        auto it = std::ranges::find_if(m_conditional_tasks,
+            [&routine](const TaskEntry& e) { return e.routine == routine; });
+        const std::string name = (it != m_conditional_tasks.end()) ? it->name : "";
+        return cancel_task(name);
+    }
+
     auto it = find_task_by_routine(routine);
     const std::string name = (it != m_tasks.end()) ? it->name : "";
 
@@ -95,6 +131,14 @@ bool TaskScheduler::cancel_task(const std::shared_ptr<Routine>& routine)
 
 bool TaskScheduler::restart_task(const std::string& name)
 {
+    auto cit = std::ranges::find_if(m_conditional_tasks,
+        [&name](const TaskEntry& e) { return e.name == name; });
+    if (cit != m_conditional_tasks.end()) {
+        if (cit->routine && cit->routine->is_active())
+            cit->routine->restart();
+        return true;
+    }
+
     auto it = find_task_by_name(name);
     if (it != m_tasks.end()) {
         if (it->routine && it->routine->is_active()) {
@@ -106,12 +150,26 @@ bool TaskScheduler::restart_task(const std::string& name)
 
 std::shared_ptr<Routine> TaskScheduler::get_task(const std::string& name) const
 {
+    auto cit = std::ranges::find_if(m_conditional_tasks,
+        [&name](const TaskEntry& e) { return e.name == name; });
+    if (cit != m_conditional_tasks.end())
+        return cit->routine;
+
     auto it = find_task_by_name(name);
     return (it != m_tasks.end()) ? it->routine : nullptr;
 }
 
 std::vector<std::shared_ptr<Routine>> TaskScheduler::get_tasks_for_token(ProcessingToken token) const
 {
+    if (token == ProcessingToken::CONDITIONAL) {
+        std::vector<std::shared_ptr<Routine>> result;
+        for (const auto& e : m_conditional_tasks) {
+            if (e.routine)
+                result.push_back(e.routine);
+        }
+        return result;
+    }
+
     std::vector<std::shared_ptr<Routine>> result;
     for (const auto& entry : m_tasks) {
         if (entry.routine && entry.routine->get_processing_token() == token) {
@@ -133,6 +191,15 @@ std::vector<std::string> TaskScheduler::get_task_names() const
 
 std::vector<std::string> TaskScheduler::get_task_names(ProcessingToken token) const
 {
+    if (token == ProcessingToken::CONDITIONAL) {
+        std::vector<std::string> names;
+        for (const auto& e : m_conditional_tasks) {
+            if (e.routine)
+                names.push_back(e.name);
+        }
+        return names;
+    }
+
     std::vector<std::string> names;
     for (const auto& entry : m_tasks) {
         if (entry.routine && entry.routine->get_processing_token() == token)
@@ -287,6 +354,8 @@ unsigned int TaskScheduler::get_default_rate(ProcessingToken token) const
         return 1;
     case ProcessingToken::CUSTOM:
         return 1000;
+    case ProcessingToken::CONDITIONAL:
+        return 0;
     default:
         return m_registered_sample_rate;
     }
@@ -294,6 +363,9 @@ unsigned int TaskScheduler::get_default_rate(ProcessingToken token) const
 
 void TaskScheduler::ensure_domain(ProcessingToken token, unsigned int rate)
 {
+    if (token == ProcessingToken::CONDITIONAL)
+        return;
+
     auto clock_it = m_token_clocks.find(token);
     if (clock_it == m_token_clocks.end()) {
         unsigned int domain_rate = (rate > 0) ? rate : get_default_rate(token);
@@ -368,8 +440,35 @@ bool TaskScheduler::initialize_routine_state(const std::shared_ptr<Routine>& rou
     return routine->initialize_state(current_context);
 }
 
+void TaskScheduler::start_conditional_thread()
+{
+    if (m_conditional_thread.joinable())
+        return;
+
+#if MAYAFLUX_USE_JTHREAD
+    m_conditional_thread = std::jthread([this](const std::stop_token& st) {
+        while (!st.stop_requested())
+            pump_conditional();
+    });
+#else
+    m_conditional_stop.store(false, std::memory_order_release);
+    m_conditional_thread = std::thread([this]() {
+        while (!m_conditional_stop.load(std::memory_order_acquire))
+            pump_conditional();
+    });
+#endif
+}
+
 void TaskScheduler::pause_all_tasks()
 {
+    for (auto& entry : m_conditional_tasks) {
+        if (entry.routine && entry.routine->is_active()) {
+            bool current_auto_resume = entry.routine->get_auto_resume();
+            entry.routine->set_state<bool>("was_auto_resume", current_auto_resume);
+            entry.routine->set_auto_resume(false);
+        }
+    }
+
     for (auto& entry : m_tasks) {
         if (entry.routine && entry.routine->is_active()) {
             bool current_auto_resume = entry.routine->get_auto_resume();
@@ -381,6 +480,17 @@ void TaskScheduler::pause_all_tasks()
 
 void TaskScheduler::resume_all_tasks()
 {
+    for (auto& entry : m_conditional_tasks) {
+        if (entry.routine && entry.routine->is_active()) {
+            auto was_auto_resume = entry.routine->get_state<bool>("was_auto_resume");
+            if (was_auto_resume) {
+                entry.routine->set_auto_resume(*was_auto_resume);
+            } else {
+                entry.routine->set_auto_resume(true);
+            }
+        }
+    }
+
     for (auto& entry : m_tasks) {
         if (entry.routine && entry.routine->is_active()) {
             auto was_auto_resume = entry.routine->get_state<bool>("was_auto_resume");
@@ -444,6 +554,17 @@ void TaskScheduler::terminate_all_tasks()
             "All coroutines terminated successfully");
     }
 
+    drain_conditional_pending();
+    for (auto& entry : m_conditional_tasks) {
+        if (entry.routine && entry.routine->is_active())
+            entry.routine->set_should_terminate(true);
+    }
+    for (auto& entry : m_conditional_tasks) {
+        if (entry.routine && entry.routine->is_active())
+            entry.routine->force_resume();
+    }
+    m_conditional_tasks.clear();
+
     m_tasks.clear();
 }
 
@@ -499,6 +620,40 @@ void TaskScheduler::drain_pending_tasks()
     }
 }
 
+void TaskScheduler::drain_conditional_pending()
+{
+    if (m_conditional_pending_count.load(std::memory_order_acquire) == 0)
+        return;
+
+    for (auto& op : m_conditional_pending_ops) {
+        if (!op.active.load(std::memory_order_acquire))
+            continue;
+
+        if (op.is_addition) {
+            auto it = std::ranges::find_if(m_conditional_tasks,
+                [&](const TaskEntry& e) { return e.name == op.entry.name; });
+            if (it != m_conditional_tasks.end()) {
+                if (it->routine && it->routine->is_active())
+                    it->routine->set_should_terminate(true);
+                m_conditional_tasks.erase(it);
+            }
+            m_conditional_tasks.push_back(std::move(op.entry));
+        } else {
+            auto it = std::ranges::find_if(m_conditional_tasks,
+                [&](const TaskEntry& e) { return e.name == op.entry.name; });
+            if (it != m_conditional_tasks.end()) {
+                if (it->routine && it->routine->is_active())
+                    it->routine->set_should_terminate(true);
+                m_conditional_tasks.erase(it);
+            }
+        }
+
+        op.entry = { nullptr, "" };
+        op.active.store(false, std::memory_order_release);
+        m_conditional_pending_count.fetch_sub(1, std::memory_order_relaxed);
+    }
+}
+
 void TaskScheduler::pump_cross(DelayContext context, ProcessingToken clock_token, uint64_t processing_units)
 {
     auto cross_tasks = get_tasks_for_token(ProcessingToken::MULTI_RATE);
@@ -524,6 +679,25 @@ void TaskScheduler::pump_cross(DelayContext context, ProcessingToken clock_token
                 routine->try_resume_with_context(pos, context);
             }
         }
+    }
+}
+
+void TaskScheduler::pump_conditional()
+{
+    drain_conditional_pending();
+
+    if (m_conditional_tasks.empty()) {
+        std::this_thread::yield();
+        return;
+    }
+
+    std::erase_if(m_conditional_tasks, [](const TaskEntry& e) {
+        return !e.routine || !e.routine->is_active();
+    });
+
+    for (auto& entry : m_conditional_tasks) {
+        if (entry.routine && entry.routine->is_active())
+            entry.routine->try_resume(0);
     }
 }
 

--- a/src/MayaFlux/Vruta/Scheduler.hpp
+++ b/src/MayaFlux/Vruta/Scheduler.hpp
@@ -430,11 +430,28 @@ private:
     void drain_pending_tasks();
 
     /**
+     * @brief Drain pending conditional task operations before processing
+     *
+     * Similar to drain_pending_tasks, but specifically for conditional tasks that may
+     * have been added or removed while the conditional processing thread is running.
+     */
+    void drain_conditional_pending();
+
+    /**
      * @brief Initialize a routine's state for a specific domain
      * @param routine Routine to initialize
      * @param token Processing domain
      */
     bool initialize_routine_state(const std::shared_ptr<Routine>& routine, ProcessingToken token);
+
+    /**
+     * @brief Start the conditional task processing thread if not already running
+     *
+     * This method ensures that the thread responsible for processing conditional tasks
+     * is started when the first conditional task is added. It checks if the thread is
+     * already running to avoid starting multiple threads.
+     */
+    void start_conditional_thread();
 
     /**
      * @brief Pump the MULTI_RATE list from one clock's context.
@@ -450,6 +467,15 @@ private:
      * @param processing_units Units to advance, matching the driving token's call.
      */
     void pump_cross(DelayContext context, ProcessingToken clock_token, uint64_t processing_units);
+
+    /**
+     * @brief Pump the conditional task list in a separate thread
+     *
+     * This method runs in a dedicated thread and continuously checks for conditional tasks
+     * that are ready to execute. It processes these tasks based on their conditions and
+     * ensures they are executed as soon as their conditions are met.
+     */
+    void pump_conditional();
 
     /**
      * @brief Clock instances for each processing domain
@@ -481,6 +507,8 @@ private:
     mutable std::atomic<uint64_t> m_next_task_id { 1 };
 
     std::vector<TaskEntry> m_tasks;
+
+    std::vector<TaskEntry> m_conditional_tasks;
 
     /**
      * @brief The master sample clock for the processing engine
@@ -514,6 +542,18 @@ private:
 
     std::atomic<uint32_t> m_pending_count { 0 };
     PendingTaskOp m_pending_ops[MAX_PENDING_TASKS];
+
+    static constexpr size_t MAX_PENDING_CONDITIONAL = 64;
+
+    std::atomic<uint32_t> m_conditional_pending_count { 0 };
+    PendingTaskOp m_conditional_pending_ops[MAX_PENDING_CONDITIONAL];
+
+#if MAYAFLUX_USE_JTHREAD
+    std::jthread m_conditional_thread;
+#else
+    std::thread m_conditional_thread;
+    std::atomic<bool> m_conditional_stop { false };
+#endif
 };
 
 }


### PR DESCRIPTION
**Brief**

A new coroutine type and scheduling domain that sits orthogonal to the existing sample and frame clocks. `FreeRoutine` suspends on an arbitrary boolean predicate and resumes the moment that predicate returns true, on a dedicated scheduler thread that has no relationship to audio callbacks or frame boundaries.

**Reasoning**

The existing scheduling vocabulary covers two cases: things that happen at sample rate (`SoundRoutine`) and things that happen at frame rate (`GraphicsRoutine`). A third class of computation exists that belongs to neither - iterative algorithms that must run as fast as possible at their own natural cadence, decoupled from both the audio thread and the render loop. Cellular automata, physics integrators, ML inference loops, state machine evaluators. Forcing these into a `SoundRoutine` pollutes the audio thread budget. Forcing them into a `GraphicsRoutine` ties frame rate to unrelated compute. A raw `std::thread` with a loop works but exits the coroutine model entirely, losing composability with the rest of the scheduling infrastructure.

**Scope**

- `ProcessingToken::CONDITIONAL` - new token, no clock created, no rate registered
- `conditional_promise` - promise with `std::function<bool()> condition` and `std::atomic<bool> armed`; no clock fields
- `FreeRoutine` - move-only `Routine` child; copy ctor/assign deleted; `try_resume_with_context` checks armed then evaluates condition, clears both before `handle.resume()`
- `ConditionAwaiter` - typed on `conditional_promise`, compile-time domain guard; moves condition into promise on suspend
- `TaskScheduler` CONDITIONAL domain - separate `m_conditional_tasks` list, separate 64-slot lock-free pending-op array with the same CAS slot-claim pattern as the existing `m_pending_ops`; `start_conditional_thread` lazy-starts a `jthread` (with `std::thread` fallback behind `MAYAFLUX_USE_JTHREAD`); `pump_conditional` drains pending, yields on empty, erases inactive, calls `try_resume` on each live entry
- All existing `TaskScheduler` management surface extended: `get_task`, `cancel_task`, `restart_task`, `get_tasks_for_token`, `has_active_tasks`, `get_task_names`, `pause_all_tasks`, `resume_all_tasks` all cover `m_conditional_tasks`

**Design decisions of note**

The condition lambda lives in the promise, not the awaiter. The awaiter moves it in on `await_suspend` and the scheduler thread reads it via `armed` (acquire) before evaluating. This closes the race between suspension and the first scheduler pass without any mutex. The same atomic flag pattern is already used in `BroadcastSource`.

`initial_suspend` returns `suspend_never` (inherited from `routine_promise`), so the coroutine body runs to its first `co_await ConditionAwaiter` on construction. `initialize_state` therefore only sets `auto_resume = true` - no bootstrap resume is needed or correct.

The scheduler thread is started lazily on the first `add_task` for a `CONDITIONAL` routine and runs until the scheduler destructs. The `jthread` destructor handles `request_stop` + join automatically, matching the pattern in `NetworkSubsystem`.

**Usage**

```cpp
auto ca_loop = [&state]() -> Vruta::FreeRoutine {
    while (true) {
        co_await Kriya::ConditionAwaiter {
            [&state] { return state.tick_ready.load(std::memory_order_acquire); }
        };
        state.evolve();
        state.tick_ready.store(false, std::memory_order_release);
    }
};

auto r = ca_loop();
get_scheduler()->add_task(
    std::make_shared<Vruta::FreeRoutine>(std::move(r)), "ca_evolve", false);
```

```cpp
// Evolve a CA grid every 50ms regardless of audio or frame rate.
// The wall clock condition is the entire scheduling mechanism.
auto ca_ticker = [&grid]() -> Vruta::FreeRoutine {
    auto last = std::chrono::steady_clock::now();
    while (true) {
        co_await Kriya::ConditionAwaiter { [&last] {
            auto now = std::chrono::steady_clock::now();
            if (now - last >= std::chrono::milliseconds(50)) {
                last = now;
                return true;
            }
            return false;
        }};
        grid.evolve();
    }
};
```

```cpp
// React to an OSC message from an external controller without
// touching the audio thread. The flag is set by the OSC receive callback.
std::atomic<bool> trigger { false };

auto osc_responder = [&trigger, &synth]() -> Vruta::FreeRoutine {
    while (true) {
        co_await Kriya::ConditionAwaiter {
            [&trigger] { return trigger.exchange(false, std::memory_order_acq_rel); }
        };
        synth.retrigger();
    }
};
```

The condition can be anything callable returning bool - a wall clock check, an atomic flag, a queue non-empty test. The body runs on the conditional thread each time the condition is satisfied. Audio and graphics threads are untouched.

**What is not in scope**

Fan-out (one condition waking multiple routines) is not addressed here. If needed, one `FreeRoutine` per consumer is the correct pattern, same as `BroadcastSource`. A typed condition carrier (analogous to `BroadcastSource<T>` for payload delivery) is a separate concern and has not earned three callers yet.
