### PR TITLE
feat(config): JSON file-based engine configuration with override control

### DIFF
--- a/cmake/defines.cmake
+++ b/cmake/defines.cmake
@@ -82,6 +82,13 @@ option(MAYAFLUX_DEV
        "Build MayaFlux for development with debug symobls, rpath and tests" OFF)
 option(MAYAFLUX_BUILD_PROJECT "Build project_launcher binary" OFF)
 
+option(MAYAFLUX_CONFIG_OVERRIDE
+       "JSON config file takes precedence over settings()" OFF)
+
+if(MAYAFLUX_CONFIG_OVERRIDE)
+    add_compile_definitions(MAYAFLUX_CONFIG_OVERRIDE)
+endif()
+
 if(EXAMPLE_SHADER_DIR)
     include(examples_shaders)
 endif()

--- a/src/MayaFlux/API/Config.cpp
+++ b/src/MayaFlux/API/Config.cpp
@@ -12,11 +12,30 @@
 namespace MayaFlux {
 
 namespace {
+    struct JournalConfig {
+        std::string severity; // "TRACE" "DEBUG" "INFO" "WARN" "ERROR" "FATAL"
+        bool sink_to_console { false };
+        std::string log_file; // empty = no file sink
+        std::vector<std::string> disable_components; // names from Journal::Component enum
+        std::vector<std::string> disable_contexts; // names from Journal::Context enum
+
+        static constexpr auto describe()
+        {
+            return std::make_tuple(
+                IO::member("severity", &JournalConfig::severity),
+                IO::member("sink_to_console", &JournalConfig::sink_to_console),
+                IO::member("log_file", &JournalConfig::log_file),
+                IO::member("disable_components", &JournalConfig::disable_components),
+                IO::member("disable_contexts", &JournalConfig::disable_contexts));
+        }
+    };
+
     struct EngineConfig {
         Core::GlobalStreamInfo stream;
         Core::GlobalGraphicsConfig graphics;
         Core::GlobalInputConfig input;
         Core::GlobalNetworkConfig network;
+        JournalConfig journal;
 
         static constexpr auto describe()
         {
@@ -24,7 +43,8 @@ namespace {
                 IO::member("stream", &EngineConfig::stream),
                 IO::member("graphics", &EngineConfig::graphics),
                 IO::member("input", &EngineConfig::input),
-                IO::member("network", &EngineConfig::network));
+                IO::member("network", &EngineConfig::network),
+                IO::member("journal", &EngineConfig::journal));
         }
     };
 }
@@ -152,6 +172,42 @@ bool load_config_from_file(const std::string& path)
     get_global_graphics_config() = result->graphics;
     get_global_input_config() = result->input;
     get_global_network_config() = result->network;
+
+    const auto& j = result->journal;
+
+    if (!j.severity.empty()) {
+        auto sev = Reflect::string_to_enum_case_insensitive<Journal::Severity>(j.severity);
+        if (sev) {
+            Config::set_journal_severity(*sev);
+        } else {
+            MF_WARN(Journal::Component::API, Journal::Context::Configuration,
+                "Unknown journal severity: {}", j.severity);
+        }
+    }
+    if (j.sink_to_console)
+        Config::sink_journal_to_console();
+    if (!j.log_file.empty())
+        Config::store_journal_entries(j.log_file);
+    for (const auto& name : j.disable_components) {
+        auto comp = Reflect::string_to_enum_case_insensitive<Journal::Component>(name);
+        if (comp) {
+            Config::set_journal_component_filter({ *comp }, false);
+        } else {
+            MF_WARN(Journal::Component::API, Journal::Context::Configuration,
+                "Unknown journal component: {}", name);
+        }
+    }
+
+    for (const auto& name : j.disable_contexts) {
+        auto ctx = Reflect::string_to_enum_case_insensitive<Journal::Context>(name);
+        if (ctx) {
+            Config::set_journal_context_filter({ *ctx }, false);
+        } else {
+            MF_WARN(Journal::Component::API, Journal::Context::Configuration,
+                "Unknown journal context: {}", name);
+        }
+    }
+
     return true;
 }
 

--- a/src/MayaFlux/API/Config.cpp
+++ b/src/MayaFlux/API/Config.cpp
@@ -2,11 +2,33 @@
 #include "Core.hpp"
 
 #include "MayaFlux/Core/Engine.hpp"
+
 #include "MayaFlux/Journal/Archivist.hpp"
 #include "MayaFlux/Journal/ConsoleSink.hpp"
 #include "MayaFlux/Journal/FileSink.hpp"
 
+#include "MayaFlux/IO/JSONSerializer.hpp"
+
 namespace MayaFlux {
+
+namespace {
+    struct EngineConfig {
+        Core::GlobalStreamInfo stream;
+        Core::GlobalGraphicsConfig graphics;
+        Core::GlobalInputConfig input;
+        Core::GlobalNetworkConfig network;
+
+        static constexpr auto describe()
+        {
+            return std::make_tuple(
+                IO::member("stream", &EngineConfig::stream),
+                IO::member("graphics", &EngineConfig::graphics),
+                IO::member("input", &EngineConfig::input),
+                IO::member("network", &EngineConfig::network));
+        }
+    };
+}
+
 bool is_engine_configured()
 {
     return is_configured();
@@ -115,6 +137,22 @@ void store_journal_entries(const std::string& file_name)
 void sink_journal_to_console()
 {
     Journal::Archivist::instance().add_sink(std::make_unique<Journal::ConsoleSink>());
+}
+
+bool load_config_from_file(const std::string& path)
+{
+    IO::JSONSerializer ser;
+    auto result = ser.read<EngineConfig>(path);
+    if (!result) {
+        MF_ERROR(Journal::Component::API, Journal::Context::Configuration,
+            "Failed to load config from {}: {}", path, ser.last_error());
+        return false;
+    }
+    get_global_stream_info() = result->stream;
+    get_global_graphics_config() = result->graphics;
+    get_global_input_config() = result->input;
+    get_global_network_config() = result->network;
+    return true;
 }
 
 }

--- a/src/MayaFlux/API/Config.hpp
+++ b/src/MayaFlux/API/Config.hpp
@@ -109,6 +109,16 @@ namespace Config {
      * NOTE: This records thread safe entries and cannot unsink once called.
      */
     MAYAFLUX_API void sink_journal_to_console();
+
+    /**
+     * @brief Load engine configuration from a JSON file, applying any present fields
+     *        to the pre-Init config structs.
+     * @param path Path to a mayaflux.json file.
+     * @return True if the file was read and at least partially applied. False if the
+     *         file could not be opened or parsed; last_error() will be set.
+     * @note Must be called before Init(). Fields absent from the file retain defaults.
+     */
+    MAYAFLUX_API bool load_config_from_file(const std::string& path);
 }
 
 }

--- a/src/MayaFlux/Core/GlobalGraphicsInfo.hpp
+++ b/src/MayaFlux/Core/GlobalGraphicsInfo.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "MayaFlux/IO/Reflection.hpp"
+
 namespace MayaFlux::Core {
 
 //==============================================================================
@@ -66,6 +68,23 @@ struct MAYAFLUX_API GraphicsBackendInfo {
     /** @brief Backend-specific extensions to request */
     std::vector<std::string> required_extensions;
     std::vector<std::string> optional_extensions;
+
+    static constexpr auto describe()
+    {
+        return std::make_tuple(
+            IO::member("enable_validation", &GraphicsBackendInfo::enable_validation),
+            IO::member("enable_debug_markers", &GraphicsBackendInfo::enable_debug_markers),
+            // IO::member("required_features", &GraphicsBackendInfo::required_features),
+            IO::member("memory_strategy", &GraphicsBackendInfo::memory_strategy),
+            IO::member("command_pooling", &GraphicsBackendInfo::command_pooling),
+            IO::member("max_frames_in_flight", &GraphicsBackendInfo::max_frames_in_flight),
+            IO::member("enable_compute_queue", &GraphicsBackendInfo::enable_compute_queue),
+            IO::member("enable_transfer_queue", &GraphicsBackendInfo::enable_transfer_queue),
+            IO::member("shader_compilation", &GraphicsBackendInfo::shader_compilation),
+            IO::member("shader_cache_dir", &GraphicsBackendInfo::shader_cache_dir),
+            IO::member("required_extensions", &GraphicsBackendInfo::required_extensions),
+            IO::member("optional_extensions", &GraphicsBackendInfo::optional_extensions));
+    }
 };
 
 /**
@@ -92,6 +111,17 @@ struct MAYAFLUX_API GraphicsResourceLimits {
 
     /** @brief Maximum number of pipeline state objects */
     uint32_t max_pipelines = 256;
+
+    static constexpr auto describe()
+    {
+        return std::make_tuple(
+            IO::member("max_windows", &GraphicsResourceLimits::max_windows),
+            IO::member("max_staging_buffer_mb", &GraphicsResourceLimits::max_staging_buffer_mb),
+            IO::member("max_compute_buffer_mb", &GraphicsResourceLimits::max_compute_buffer_mb),
+            IO::member("max_texture_cache_mb", &GraphicsResourceLimits::max_texture_cache_mb),
+            IO::member("max_descriptor_sets", &GraphicsResourceLimits::max_descriptor_sets),
+            IO::member("max_pipelines", &GraphicsResourceLimits::max_pipelines));
+    }
 };
 
 //==============================================================================
@@ -170,6 +200,19 @@ struct MAYAFLUX_API GraphicsSurfaceInfo {
 
     /** @brief Backend-specific configuration parameters */
     std::unordered_map<std::string, std::any> backend_options;
+
+    static constexpr auto describe()
+    {
+        return std::make_tuple(
+            IO::member("format", &GraphicsSurfaceInfo::format),
+            IO::member("color_space", &GraphicsSurfaceInfo::color_space),
+            IO::member("present_mode", &GraphicsSurfaceInfo::present_mode),
+            IO::member("image_count", &GraphicsSurfaceInfo::image_count),
+            IO::member("enable_regions", &GraphicsSurfaceInfo::enable_regions),
+            IO::member("max_regions_per_window", &GraphicsSurfaceInfo::max_regions_per_window),
+            IO::member("enable_hdr", &GraphicsSurfaceInfo::enable_hdr),
+            IO::member("measure_frame_time", &GraphicsSurfaceInfo::measure_frame_time));
+    }
 };
 
 /**
@@ -204,6 +247,17 @@ struct GlfwPreInitConfig {
      *  Required for Vulkan capture and profiling layers that do not implement
      *  VK_KHR_wayland_surface.  XWayland must be present. */
     bool force_x11_on_wayland = false;
+
+    static constexpr auto describe()
+    {
+        return std::make_tuple(
+            IO::member("platform", &GlfwPreInitConfig::platform),
+            IO::member("disable_libdecor", &GlfwPreInitConfig::disable_libdecor),
+            IO::member("cocoa_chdir_resources", &GlfwPreInitConfig::cocoa_chdir_resources),
+            IO::member("cocoa_menubar", &GlfwPreInitConfig::cocoa_menubar),
+            IO::member("headless", &GlfwPreInitConfig::headless),
+            IO::member("force_x11_on_wayland", &GlfwPreInitConfig::force_x11_on_wayland));
+    }
 };
 
 /**
@@ -222,6 +276,14 @@ struct KeyRepeatConfig {
 
     /** @brief If true, compositor-reported repeat_info overrides these values. */
     bool allow_compositor_override { false };
+
+    static constexpr auto describe()
+    {
+        return std::make_tuple(
+            IO::member("initial_delay_ms", &KeyRepeatConfig::initial_delay_ms),
+            IO::member("interval_ms", &KeyRepeatConfig::interval_ms),
+            IO::member("allow_compositor_override", &KeyRepeatConfig::allow_compositor_override));
+    }
 };
 
 /**
@@ -249,6 +311,15 @@ struct TextConfig {
 
     /** @brief Atlas texture dimension (power of two). */
     uint32_t atlas_size { 512 };
+
+    static constexpr auto describe()
+    {
+        return std::make_tuple(
+            IO::member("family", &TextConfig::family),
+            IO::member("style", &TextConfig::style),
+            IO::member("pixel_size", &TextConfig::pixel_size),
+            IO::member("atlas_size", &TextConfig::atlas_size));
+    }
 };
 
 struct MAYAFLUX_API GlobalGraphicsConfig {
@@ -321,6 +392,20 @@ struct MAYAFLUX_API GlobalGraphicsConfig {
         "sans-serif", "", 24, 512
 #endif
     };
+
+    static constexpr auto describe()
+    {
+        return std::make_tuple(
+            IO::member("glfw_preinit_config", &GlobalGraphicsConfig::glfw_preinit_config),
+            IO::member("key_repeat_config", &GlobalGraphicsConfig::key_repeat_config),
+            IO::member("surface_info", &GlobalGraphicsConfig::surface_info),
+            IO::member("backend_info", &GlobalGraphicsConfig::backend_info),
+            IO::member("resource_limits", &GlobalGraphicsConfig::resource_limits),
+            IO::member("target_frame_rate", &GlobalGraphicsConfig::target_frame_rate),
+            IO::member("windowing_backend", &GlobalGraphicsConfig::windowing_backend),
+            IO::member("requested_api", &GlobalGraphicsConfig::requested_api),
+            IO::member("text_config", &GlobalGraphicsConfig::text_config));
+    }
 };
 
 //==============================================================================

--- a/src/MayaFlux/Core/GlobalInputConfig.hpp
+++ b/src/MayaFlux/Core/GlobalInputConfig.hpp
@@ -2,6 +2,8 @@
 
 #include "MayaFlux/Core/Input/InputBinding.hpp"
 
+#include "MayaFlux/IO/Reflection.hpp"
+
 namespace MayaFlux::Core {
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -97,6 +99,15 @@ struct MAYAFLUX_API HIDDeviceFilter {
             .usage = std::nullopt
         };
     }
+
+    static constexpr auto describe()
+    {
+        return std::make_tuple(
+            IO::opt_member("vendor_id", &HIDDeviceFilter::vendor_id),
+            IO::opt_member("product_id", &HIDDeviceFilter::product_id),
+            IO::opt_member("usage_page", &HIDDeviceFilter::usage_page),
+            IO::opt_member("usage", &HIDDeviceFilter::usage));
+    }
 };
 
 /**
@@ -110,6 +121,18 @@ struct MAYAFLUX_API HIDBackendInfo {
     int poll_timeout_ms { 10 }; ///< Polling timeout in milliseconds
     bool auto_reconnect { true }; ///< Auto-reconnect disconnected devices
     uint32_t reconnect_interval_ms { 1000 }; ///< Reconnection attempt interval
+
+    static constexpr auto describe()
+    {
+        return std::make_tuple(
+            IO::member("enabled", &HIDBackendInfo::enabled),
+            IO::member("filters", &HIDBackendInfo::filters),
+            IO::member("auto_open", &HIDBackendInfo::auto_open),
+            IO::member("read_buffer_size", &HIDBackendInfo::read_buffer_size),
+            IO::member("poll_timeout_ms", &HIDBackendInfo::poll_timeout_ms),
+            IO::member("auto_reconnect", &HIDBackendInfo::auto_reconnect),
+            IO::member("reconnect_interval_ms", &HIDBackendInfo::reconnect_interval_ms));
+    }
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -127,6 +150,19 @@ struct MAYAFLUX_API MIDIBackendInfo {
     std::vector<std::string> output_port_filters; ///< Filter output ports by name substring
     bool enable_virtual_port { false }; ///< Create a virtual MIDI port
     std::string virtual_port_name { "MayaFlux" }; ///< Name for virtual port
+
+    static constexpr auto describe()
+    {
+        return std::make_tuple(
+            IO::member("enabled", &MIDIBackendInfo::enabled),
+            IO::member("auto_open_inputs", &MIDIBackendInfo::auto_open_inputs),
+            IO::member("auto_open_outputs", &MIDIBackendInfo::auto_open_outputs),
+            IO::member("input_port_filters", &MIDIBackendInfo::input_port_filters),
+            IO::member("output_port_filters", &MIDIBackendInfo::output_port_filters),
+            IO::member("enable_virtual_port", &MIDIBackendInfo::enable_virtual_port),
+            IO::member("virtual_port_name", &MIDIBackendInfo::virtual_port_name),
+            IO::member("enabled", &MIDIBackendInfo::enabled));
+    }
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -144,6 +180,18 @@ struct MAYAFLUX_API OSCConfigInfo {
     bool enable_multicast { false }; ///< Enable multicast reception
     std::string multicast_group; ///< Multicast group address
     size_t receive_buffer_size { 65536 }; ///< UDP receive buffer size
+
+    static constexpr auto describe()
+    {
+        return std::make_tuple(
+            IO::member("enabled", &OSCConfigInfo::enabled),
+            IO::member("receive_port", &OSCConfigInfo::receive_port),
+            IO::member("send_port", &OSCConfigInfo::send_port),
+            IO::member("send_address", &OSCConfigInfo::send_address),
+            IO::member("enable_multicast", &OSCConfigInfo::enable_multicast),
+            IO::member("multicast_group", &OSCConfigInfo::multicast_group),
+            IO::member("receive_buffer_size", &OSCConfigInfo::receive_buffer_size));
+    }
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -160,6 +208,16 @@ struct MAYAFLUX_API SerialPortConfig {
     uint8_t stop_bits { 1 }; ///< Stop bits (1 or 2)
     char parity { 'N' }; ///< Parity: 'N'one, 'E'ven, 'O'dd
     bool flow_control { false }; ///< Hardware flow control
+
+    static constexpr auto describe()
+    {
+        return std::make_tuple(
+            IO::member("port_name", &SerialPortConfig::port_name),
+            IO::member("baud_rate", &SerialPortConfig::baud_rate),
+            IO::member("data_bits", &SerialPortConfig::data_bits),
+            IO::member("stop_bits", &SerialPortConfig::stop_bits),
+            IO::member("flow_control", &SerialPortConfig::flow_control));
+    }
 };
 
 /**
@@ -170,6 +228,15 @@ struct MAYAFLUX_API SerialBackendInfo {
     std::vector<SerialPortConfig> ports; ///< Ports to open
     bool auto_detect_arduino { false }; ///< Auto-detect Arduino devices
     uint32_t default_baud_rate { 115200 }; ///< Default baud for auto-detected devices
+
+    static constexpr auto describe()
+    {
+        return std::make_tuple(
+            IO::member("enabled", &SerialBackendInfo::enabled),
+            IO::member("ports", &SerialBackendInfo::ports),
+            IO::member("auto_detect_arduino", &SerialBackendInfo::auto_detect_arduino),
+            IO::member("default_baud_rate", &SerialBackendInfo::default_baud_rate));
+    }
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -259,6 +326,15 @@ struct MAYAFLUX_API GlobalInputConfig {
     [[nodiscard]] bool any_enabled() const
     {
         return hid.enabled || midi.enabled || osc.enabled || serial.enabled;
+    }
+
+    static constexpr auto describe()
+    {
+        return std::make_tuple(
+            IO::member("hid", &GlobalInputConfig::hid),
+            IO::member("midi", &GlobalInputConfig::midi),
+            IO::member("osc", &GlobalInputConfig::osc),
+            IO::member("serial", &GlobalInputConfig::serial));
     }
 };
 

--- a/src/MayaFlux/Core/GlobalNetworkConfig.hpp
+++ b/src/MayaFlux/Core/GlobalNetworkConfig.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "MayaFlux/IO/Reflection.hpp"
+
 namespace MayaFlux::Core {
 
 /**
@@ -87,6 +89,19 @@ struct MAYAFLUX_API UDPBackendInfo {
     bool enable_broadcast { false };
     bool enable_multicast { false };
     std::string multicast_group;
+
+    static constexpr auto describe()
+    {
+        return std::make_tuple(
+            IO::member("enabled", &UDPBackendInfo::enabled),
+            IO::member("default_receive_port", &UDPBackendInfo::default_receive_port),
+            IO::member("default_send_port", &UDPBackendInfo::default_send_port),
+            IO::member("default_send_address", &UDPBackendInfo::default_send_address),
+            IO::member("receive_buffer_size", &UDPBackendInfo::receive_buffer_size),
+            IO::member("enable_broadcast", &UDPBackendInfo::enable_broadcast),
+            IO::member("enable_multicast", &UDPBackendInfo::enable_multicast),
+            IO::member("multicast_group", &UDPBackendInfo::multicast_group));
+    }
 };
 
 /**
@@ -104,6 +119,17 @@ struct MAYAFLUX_API TCPBackendInfo {
     bool auto_reconnect { true };
     uint32_t reconnect_interval_ms { 2000 };
     uint32_t connect_timeout_ms { 5000 };
+
+    static constexpr auto describe()
+    {
+        return std::make_tuple(
+            IO::member("enabled", &TCPBackendInfo::enabled),
+            IO::member("listen_port", &TCPBackendInfo::listen_port),
+            IO::member("receive_buffer_size", &TCPBackendInfo::receive_buffer_size),
+            IO::member("auto_reconnect", &TCPBackendInfo::auto_reconnect),
+            IO::member("reconnect_interval_ms", &TCPBackendInfo::reconnect_interval_ms),
+            IO::member("connect_timeout_ms", &TCPBackendInfo::connect_timeout_ms));
+    }
 };
 
 /**
@@ -118,6 +144,14 @@ struct MAYAFLUX_API SharedMemoryBackendInfo {
     bool enabled { false };
     std::string segment_name { "mayaflux_shm" };
     size_t segment_size { 16 * 1024 * 1024 };
+
+    static constexpr auto describe()
+    {
+        return std::make_tuple(
+            IO::member("enabled", &SharedMemoryBackendInfo::enabled),
+            IO::member("segment_name", &SharedMemoryBackendInfo::segment_name),
+            IO::member("segment_size", &SharedMemoryBackendInfo::segment_size));
+    }
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -169,6 +203,14 @@ struct MAYAFLUX_API GlobalNetworkConfig {
     [[nodiscard]] bool any_enabled() const
     {
         return udp.enabled || tcp.enabled || shared_memory.enabled;
+    }
+
+    static constexpr auto describe()
+    {
+        return std::make_tuple(
+            IO::member("udp", &GlobalNetworkConfig::udp),
+            IO::member("tcp", &GlobalNetworkConfig::tcp),
+            IO::member("shared_memory", &GlobalNetworkConfig::shared_memory));
     }
 };
 

--- a/src/MayaFlux/Core/GlobalStreamInfo.hpp
+++ b/src/MayaFlux/Core/GlobalStreamInfo.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "MayaFlux/IO/Reflection.hpp"
+
 namespace MayaFlux::Core {
 
 enum AudioBackendType : uint8_t {
@@ -91,6 +93,15 @@ struct GlobalStreamInfo {
 
         /** @brief Human-readable identifier for the associated device */
         std::string device_name;
+
+        static constexpr auto describe()
+        {
+            return std::make_tuple(
+                IO::member("enabled", &ChannelConfig::enabled),
+                IO::member("channels", &ChannelConfig::channels),
+                IO::member("device_id", &ChannelConfig::device_id),
+                IO::member("device_name", &ChannelConfig::device_name));
+        }
     };
 
     /** @brief Configuration for output signal channels */
@@ -149,27 +160,6 @@ struct GlobalStreamInfo {
     /** @brief Dithering algorithm for format conversions */
     DitherMethod dither = DitherMethod::NONE;
 
-    /**
-     * @struct MidiConfig
-     * @brief Configuration for MIDI data channels
-     *
-     * Defines the parameters for digital musical instrument control
-     * data transmission and reception.
-     */
-    struct MidiConfig {
-        /** @brief Whether this MIDI channel is active */
-        bool enabled = false;
-
-        /** @brief System identifier for the associated MIDI device (-1 for default) */
-        int device_id = -1;
-    };
-
-    /** @brief Configuration for MIDI input data */
-    MidiConfig midi_input;
-
-    /** @brief Configuration for MIDI output data */
-    MidiConfig midi_output;
-
     /** @brief Whether to measure and report actual stream latency */
     bool measure_latency = false;
 
@@ -193,6 +183,21 @@ struct GlobalStreamInfo {
      * @return Number of output channels configured in the stream
      */
     uint32_t get_num_channels() const { return output.channels; }
-};
 
+    static constexpr auto describe()
+    {
+        return std::make_tuple(
+            IO::member("sample_rate", &GlobalStreamInfo::sample_rate),
+            IO::member("buffer_size", &GlobalStreamInfo::buffer_size),
+            IO::member("format", &GlobalStreamInfo::format),
+            IO::member("non_interleaved", &GlobalStreamInfo::non_interleaved),
+            IO::member("output", &GlobalStreamInfo::output),
+            IO::member("input", &GlobalStreamInfo::input),
+            IO::member("priority", &GlobalStreamInfo::priority),
+            IO::member("auto_convert_format", &GlobalStreamInfo::auto_convert_format),
+            IO::member("handle_xruns", &GlobalStreamInfo::handle_xruns),
+            IO::member("use_callback", &GlobalStreamInfo::use_callback),
+            IO::member("stream_latency_ms", &GlobalStreamInfo::stream_latency_ms));
+    }
+};
 }

--- a/src/MayaFlux/Journal/FileSink.hpp
+++ b/src/MayaFlux/Journal/FileSink.hpp
@@ -12,7 +12,7 @@ public:
         : writer_(std::make_unique<IO::TextFileWriter>())
     {
         writer_->set_max_file_size(max_file_size_mb * 1024 * 1024);
-        writer_->open(filepath,
+        writer_->open(IO::resolve_write_path(filepath),
             IO::FileWriteOptions::CREATE | IO::FileWriteOptions::APPEND);
     }
 

--- a/src/MayaFlux/Kakshya/Region/Region.hpp
+++ b/src/MayaFlux/Kakshya/Region/Region.hpp
@@ -2,6 +2,12 @@
 
 #include "MayaFlux/Kakshya/NDData/NDData.hpp"
 
+#ifdef MAYAFLUX_PLATFORM_WINDOWS
+#ifdef CALLBACK
+#undef CALLBACK
+#endif // CALLBACK
+#endif // MAYAFLUX_PLATFORM_WINDOWS
+
 namespace MayaFlux::Kakshya {
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,23 +38,38 @@ int main(int argc, char* argv[])
             "Version: {}.{}.{}", MAYAFLUX_VERSION_MAJOR, MAYAFLUX_VERSION_MINOR, MAYAFLUX_VERSION_PATCH);
         MF_LOG(MayaFlux::Journal::Component::USER, MayaFlux::Journal::Context::Init, "");
 
+        bool config_override = false;
+#ifdef MAYAFLUX_CONFIG_OVERRIDE
+        config_override = true;
+#endif
+
         std::string config_path;
-        for (int i = 1; i < argc - 1; ++i) {
-            if (std::string_view(argv[i]) == "--config") {
-                config_path = argv[i + 1];
-                break;
+        for (int i = 1; i < argc; ++i) {
+            if (std::string_view(argv[i]) == "--config" && i + 1 < argc) {
+                config_path = argv[++i];
+            } else if (std::string_view(argv[i]) == "--config-override") {
+                config_override = true;
             }
         }
+
         if (config_path.empty()) {
             namespace fs = std::filesystem;
             auto candidate = fs::path(Config::SOURCE_DIR) / "mayaflux.json";
             if (fs::exists(candidate))
                 config_path = candidate.string();
         }
-        if (!config_path.empty())
-            MayaFlux::Config::load_config_from_file(config_path);
 
-        initialize();
+        if (config_override) {
+            MF_LOG(MayaFlux::Journal::Component::USER, MayaFlux::Journal::Context::Init,
+                "Config override active: file loads after settings()");
+            initialize();
+            if (!config_path.empty())
+                MayaFlux::Config::load_config_from_file(config_path);
+        } else {
+            if (!config_path.empty())
+                MayaFlux::Config::load_config_from_file(config_path);
+            initialize();
+        }
 
         MayaFlux::Init();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,13 +30,29 @@ void run()
 #endif
 }
 
-int main()
+int main(int argc, char* argv[])
 {
     try {
         MF_LOG(MayaFlux::Journal::Component::USER, MayaFlux::Journal::Context::Init, "=== MayaFlux Creative Coding Framework ===");
         MF_LOG(MayaFlux::Journal::Component::USER, MayaFlux::Journal::Context::Init,
             "Version: {}.{}.{}", MAYAFLUX_VERSION_MAJOR, MAYAFLUX_VERSION_MINOR, MAYAFLUX_VERSION_PATCH);
         MF_LOG(MayaFlux::Journal::Component::USER, MayaFlux::Journal::Context::Init, "");
+
+        std::string config_path;
+        for (int i = 1; i < argc - 1; ++i) {
+            if (std::string_view(argv[i]) == "--config") {
+                config_path = argv[i + 1];
+                break;
+            }
+        }
+        if (config_path.empty()) {
+            namespace fs = std::filesystem;
+            auto candidate = fs::path(Config::SOURCE_DIR) / "mayaflux.json";
+            if (fs::exists(candidate))
+                config_path = candidate.string();
+        }
+        if (!config_path.empty())
+            MayaFlux::Config::load_config_from_file(config_path);
 
         initialize();
 


### PR DESCRIPTION
MayaFlux projects previously required a recompile to change audio buffer size, sample rate, input backend ports, or logging verbosity. This adds a JSON configuration layer that sits alongside the existing `settings()` function without replacing it.

The file is optional. When absent, nothing changes. When present, it applies only the fields it contains, leaving everything else at its default or at whatever `settings()` sets.

## Load order

By default `settings()` wins. The file loads first as a base, then `settings()` runs and overwrites. This means bad or stale JSON never silently breaks a project.

To make the file win instead, pass `--config-override` at runtime or set `-DMAYAFLUX_CONFIG_OVERRIDE=ON` at build time. In this mode `settings()` runs first as a base, then the file overwrites on top. Useful for deployed instruments where the operator tunes without recompiling.

## File location

The launcher probes for `mayaflux.json` at `SOURCE_DIR` automatically. A different path can be passed explicitly with `--config path/to/file.json`.

## Supported fields

All four engine config structs are supported: `GlobalStreamInfo`, `GlobalGraphicsConfig`, `GlobalInputConfig`, `GlobalNetworkConfig`. Journal configuration is also supported via a `journal` section.

## Example

```json
{
  "stream": {
    "sample_rate": 48000,
    "buffer_size": 256,
    "output": { "enabled": true, "channels": 2 },
    "input":  { "enabled": true, "channels": 2 }
  },
  "input": {
    "midi": { "enabled": true },
    "osc":  { "enabled": true, "receive_port": 9090 }
  },
  "journal": {
    "severity": "WARN",
    "sink_to_console": true,
    "log_file": "logs/session.log",
    "disable_components": ["Vruta", "Kriya"],
    "disable_contexts": ["AudioCallback", "GraphicsCallback"]
  }
}
```

Only the fields you include are applied. The rest retain their defaults or whatever `settings()` sets.
