### PR TITLE
 Portal::Forma - complete interaction layer

### DIFF
--- a/docs/Portal-Forma-Plot.md
+++ b/docs/Portal-Forma-Plot.md
@@ -247,6 +247,117 @@ auto buf = Portal::Forma::create_buffer(surface.window(), spec.capacity_for(N), 
 auto el  = Plot::place(surface, std::move(buf), std::move(spec), std::move(container));
 ```
 
+## Adornments
+
+Adornments are text labels, axis tick labels, and legends associated with a
+plot. They are described on the `Series` chain and materialized automatically
+when the plot is placed via `Portal::Forma::plot()`.
+
+### Bounds
+
+`.bounds()` declares the NDC region occupied by the data area. All adornment
+placement is relative to this. Required whenever ticks or legends are used.
+
+```cpp
+constexpr Kinesis::AABB2D plot_bounds { glm::vec2(-0.75F, -0.75F), glm::vec2(0.7F, 0.8F) };
+
+Plot::series()
+    .y(...)
+    .bounds(plot_bounds)
+    ...
+```
+
+### Tick labels
+
+`.x_ticks()` and `.y_ticks()` request evenly-spaced numeric labels along a
+plot edge. The range is derived from the axis mapping by default, or supplied
+explicitly.
+
+```cpp
+// Y ticks on the left, 5 labels, 2 decimal places, range from mapping
+.y_ticks(5, Plot::TickEdge::Left, 2)
+
+// X ticks on the bottom, explicit range, integer labels
+.x_ticks(Plot::AxisRange{}.range(0.F, 512.F), 5, Plot::TickEdge::Bottom, 0)
+```
+
+`.ticks()` places labels on any edge with an explicit range when neither X nor
+Y axis inference is appropriate:
+
+```cpp
+.ticks(Plot::TickEdge::Right, Plot::AxisRange{}.range(0.F, 1.F), 4)
+```
+
+### Legend
+
+`.legend()` adds a vertical legend. Pass an origin in NDC and a list of
+entries, each carrying a label string and a color matching the corresponding
+series palette entry.
+
+```cpp
+.legend(
+    glm::vec2(0.72F, 0.8F),
+    { Plot::LegendEntry { "sine_a", glm::vec3(0.2F, 0.6F, 1.0F) },
+      Plot::LegendEntry { "sine_b", glm::vec3(0.9F, 0.4F, 0.1F) } })
+```
+
+### Free text labels
+
+`.label()` places an arbitrary text string at a given NDC region:
+
+```cpp
+.label("Amplitude vs Sample",
+    Kinesis::AABB2D { .min = { -0.15F, 0.83F }, .max = { 0.5F, 0.95F } })
+```
+
+Color defaults to `{ 0.85, 0.85, 0.85, 1.0 }`. An optional fourth argument
+overrides it.
+
+### Complete example
+
+```cpp
+constexpr Kinesis::AABB2D bounds { glm::vec2(-0.75F, -0.75F), glm::vec2(0.7F, 0.8F) };
+constexpr uint64_t N = 512;
+
+auto [el, surface] = Portal::Forma::plot("Annotated Waveform", 1280, 720,
+    Plot::source()
+        .as("sine_a", N, Role::SPATIAL_Y, DataModality::AUDIO_1D)
+        .from([](std::vector<double>& s) {
+            for (size_t i = 0; i < s.size(); ++i)
+                s[i] = std::sin(static_cast<double>(i) / s.size() * 2.0 * M_PI);
+        })
+        .as("sine_b", N, Role::SPATIAL_Y, DataModality::AUDIO_1D)
+        .from([](std::vector<double>& s) {
+            for (size_t i = 0; i < s.size(); ++i)
+                s[i] = 0.5 * std::sin(static_cast<double>(i) / s.size() * 4.0 * M_PI);
+        })
+        .build(),
+    Plot::series()
+        .y(Role::SPATIAL_Y,
+            Plot::AxisRange{}.range(-1.F, 1.F),
+            { glm::vec3(0.2F, 0.6F, 1.0F), glm::vec3(0.9F, 0.4F, 0.1F) })
+        .background(bounds)
+        .bounds(bounds)
+        .y_ticks(5, Plot::TickEdge::Left, 2)
+        .x_ticks(Plot::AxisRange{}.range(0.F, static_cast<float>(N)), 5, Plot::TickEdge::Bottom, 0)
+        .legend(
+            glm::vec2(0.72F, 0.8F),
+            { Plot::LegendEntry { "sine_a", glm::vec3(0.2F, 0.6F, 1.0F) },
+              Plot::LegendEntry { "sine_b", glm::vec3(0.9F, 0.4F, 0.1F) } })
+        .label("Amplitude vs Sample",
+            Kinesis::AABB2D { .min = { -0.15F, 0.83F }, .max = { 0.5F, 0.95F } })
+        .as_filled_waveform()
+        .baseline(0.F)
+        .done());
+
+schedule_metro(1.0 / 60.0, [el = std::move(el)]() mutable { el.sync(); });
+```
+
+Adornments are only materialized automatically when using `Portal::Forma::plot()`.
+On the manual path (`Plot::place()` directly), adornment buffers must be
+constructed and placed explicitly via `Plot::place_label()` and
+`Plot::place_rect()`.
+
 ---
 
 ## Quick examples

--- a/docs/Portal-Forma-UI-Patterns.md
+++ b/docs/Portal-Forma-UI-Patterns.md
@@ -1,0 +1,381 @@
+# Portal::Forma - UI Patterns
+
+Forma has no widget hierarchy, no retained tree, no retained state beyond
+what you explicitly create. If you are coming from ImGui, that is the core
+difference: ImGui owns your layout and state management. Forma does not. You
+own layout, Forma owns rendering and hit testing.
+
+This guide maps common ImGui patterns to their Forma equivalents.
+
+---
+
+## Mental model shift
+
+ImGui:
+- Call `Begin` / `End` each frame.
+- Declare widgets inline. ImGui handles state, layout, and drawing.
+- Nothing persists. Everything is re-emitted every frame.
+
+Forma:
+- Construct elements once at startup. Register them on a `Layer`.
+- Write to `MappedState<T>` to change values. `sync()` redraws geometry.
+- Hit testing and event dispatch run continuously via `Context`.
+- Layout is your NDC arithmetic, done once at construction time.
+
+The frame loop runs invisibly. You do not call `Begin`, you do not loop over
+widgets. You write a value and the geometry function reacts.
+
+---
+
+## Layout
+
+ImGui handles cursor advancement internally. Forma uses `LayoutCursor`.
+
+`LayoutCursor` holds a shared `MappedState<float>` carrying the current NDC Y
+baseline. NDC Y runs +1 (top) to -1 (bottom). `advance(height)` subtracts
+height and returns the AABB just occupied.
+
+```cpp
+LayoutCursor cursor;             // starts at y = 1.0 (top)
+cursor.skip(0.02F);              // padding
+
+const auto row0 = cursor.advance(0.06F);  // AABB { -1, 0.92, 1, 1.0 } (approximately)
+const auto row1 = cursor.advance(0.06F);
+const auto row2 = cursor.advance(0.06F);
+```
+
+For columnar layouts, compute x ranges manually:
+
+```cpp
+constexpr float x_left  = -0.95F;
+constexpr float x_mid   =  0.0F;
+constexpr float x_right =  0.95F;
+
+// Two columns side by side at the same row y
+auto row = cursor.advance(0.06F);
+Kinesis::AABB2D left_cell  { { x_left, row.min.y }, { x_mid,   row.max.y } };
+Kinesis::AABB2D right_cell { { x_mid,  row.min.y }, { x_right, row.max.y } };
+```
+
+---
+
+## ImGui::Text / label
+
+ImGui:
+```cpp
+ImGui::Text("Cutoff: %.2f Hz", freq);
+```
+
+Forma: construct once, update via `set_text` or `repress`.
+
+```cpp
+// Construction
+auto text_buf = Portal::Forma::create_buffer(
+    window,
+    Portal::Graphics::PrimitiveTopology::TRIANGLE_LIST,
+    std::vector { std::pair { std::string("text"), std::shared_ptr<Core::VKImage>{} } });
+
+auto el = Portal::Forma::Element {}
+    .non_interactive()
+    .with_buffer(text_buf)
+    .with_text("Cutoff: 440.00 Hz",
+        Portal::Text::PressParams {
+            .color = { 0.85F, 0.85F, 0.85F, 1.F },
+            .render_bounds = { 512, 48 },
+        },
+        label_bounds);
+
+const uint32_t label_id = surface.layer().add(el);
+
+// Update from any graphics-thread callback
+el.set_text(std::format("Cutoff: {:.2f} Hz", freq),
+    Portal::Text::PressParams { .render_bounds = { 512, 48 } });
+```
+
+For live-updating readouts driven by a reader function, `make_value_row`
+(from `Inspect/QueryUtils.hpp`) does the repress loop for you:
+
+```cpp
+const glm::uvec2 dims = row_pixel_dims(window, x_min, x_max, row_h);
+auto row_buf = Inspector::make_row_buffer(window, "Cutoff", dims);
+
+auto row = make_value_row(
+    ValueSpec {
+        .label = "Cutoff",
+        .reader = [&freq] { return std::format("{:.2f} Hz", freq.load()); },
+    },
+    std::move(row_buf),
+    surface, cursor, x_min, x_max, row_h);
+
+// Each graphics tick:
+row.link.tap();
+```
+
+---
+
+## ImGui::Button
+
+ImGui:
+```cpp
+if (ImGui::Button("Trigger")) { fire(); }
+```
+
+Forma: element + `on_press` callback. State lives in your code, not in Forma.
+
+```cpp
+constexpr glm::vec3 k_rest  { 0.2F, 0.2F, 0.2F };
+constexpr glm::vec3 k_press { 0.7F, 0.3F, 0.2F };
+
+auto buf = Portal::Forma::create_buffer(
+    window,
+    Kinesis::filled_rect(box, k_rest),
+    Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP);
+
+const uint32_t id = surface.layer().add(
+    Portal::Forma::Element {}
+        .with_bounds(box)
+        .with_buffer(buf));
+
+surface.ctx().on_press  (id, IO::MouseButtons::Left,
+    [buf, box](uint32_t, glm::vec2) {
+        buf->submit(Kinesis::filled_rect(box, k_press));
+        fire();
+    });
+surface.ctx().on_release(id, IO::MouseButtons::Left,
+    [buf, box](uint32_t, glm::vec2) {
+        buf->submit(Kinesis::filled_rect(box, k_rest));
+    });
+surface.ctx().on_enter  (id, [buf, box](uint32_t) {
+    buf->submit(Kinesis::filled_rect(box, { 0.35F, 0.35F, 0.35F }));
+});
+surface.ctx().on_leave  (id, [buf, box](uint32_t) {
+    buf->submit(Kinesis::filled_rect(box, k_rest));
+});
+```
+
+---
+
+## ImGui::Checkbox / toggle
+
+ImGui:
+```cpp
+ImGui::Checkbox("Enable", &enabled);
+```
+
+Forma: `toggle` geometry function + `on_press` to flip state.
+
+```cpp
+auto el = Portal::Forma::create_element<bool>(
+    surface,
+    Portal::Forma::Geometry::toggle(box, { 0.2F, 0.2F, 0.2F }, { 0.2F, 0.7F, 0.4F }),
+    false,
+    Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP);
+
+surface.ctx().on_press(el.element.id, IO::MouseButtons::Left,
+    [state = el.state](uint32_t, glm::vec2) {
+        state->write(!state->value);
+    });
+
+// Read current value anywhere:
+const bool enabled = el.state->value;
+```
+
+---
+
+## ImGui::SliderFloat / horizontal fader
+
+ImGui:
+```cpp
+ImGui::SliderFloat("Gain", &gain, 0.0f, 1.0f);
+```
+
+Forma: `horizontal_fader` geometry function + drag callbacks.
+
+```cpp
+constexpr Kinesis::AABB2D track { { -0.8F, -0.05F }, { 0.8F, 0.05F } };
+
+auto el = Portal::Forma::create_element<float>(
+    surface,
+    Portal::Forma::Geometry::horizontal_fader(track, 0.04F),
+    0.5F,
+    Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP);
+
+auto pressed = make_persistent(false);
+surface.ctx().on_press  (el.element.id, IO::MouseButtons::Left,
+    [&pressed](uint32_t, glm::vec2) { pressed = true; });
+surface.ctx().on_release(el.element.id, IO::MouseButtons::Left,
+    [&pressed](uint32_t, glm::vec2) { pressed = false; });
+surface.ctx().on_move   (el.element.id,
+    [state = el.state, &pressed, track](uint32_t, glm::vec2 ndc) {
+        if (!pressed) return;
+        state->write(std::clamp((ndc.x - track.min.x) / track.width(), 0.F, 1.F));
+    });
+
+// Wire to a node:
+auto constant = vega.Constant(0.5) | Audio[0];
+Portal::Forma::bridge().at(el.state).write(constant);
+```
+
+For a knob (arc-based), use `stroke_slider` with an `arc_path`:
+
+```cpp
+auto path = Kinesis::arc_path({ 0.F, 0.F }, 0.3F, 0.3F,
+    glm::radians(215.F), glm::radians(-35.F), 64);
+
+auto handle_buf = Portal::Forma::create_buffer(
+    window, Portal::Graphics::PrimitiveTopology::POINT_LIST);
+
+auto el = Portal::Forma::create_element<float>(
+    surface,
+    Portal::Forma::Geometry::stroke_slider(path, handle_buf,
+        0.02F, { 0.2F, 0.2F, 0.25F }, { 0.3F, 0.6F, 1.0F }),
+    0.5F,
+    Portal::Graphics::PrimitiveTopology::LINE_LIST);
+```
+
+---
+
+## ImGui::CollapsingHeader / tree node
+
+ImGui:
+```cpp
+if (ImGui::CollapsingHeader("Oscillator")) {
+    ImGui::SliderFloat("Freq", ...);
+}
+```
+
+Forma: `Collapsible` + `attach` for each body element.
+
+```cpp
+constexpr float x_min = -0.95F, x_max = 0.95F, row_h = 0.055F;
+
+// Header buffer: plain color if no label image, textured if one is set
+auto hbuf = Portal::Forma::create_buffer(window,
+    Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP);
+
+auto col = Collapsible {}
+    .initially_open(true)
+    .closed_color({ 0.2F, 0.2F, 0.22F })
+    .open_color({ 0.28F, 0.28F, 0.32F })
+    .place(std::move(hbuf), surface, cursor, x_min, x_max, row_h);
+
+// Body elements - each must be created after place() so cursor is advanced
+auto fader_el = Portal::Forma::create_element<float>(
+    surface,
+    Portal::Forma::Geometry::horizontal_fader(
+        cursor.advance(row_h), 0.04F),
+    0.5F,
+    Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP);
+
+col.attach(surface.layer(), fader_el.element.id);
+```
+
+`attach` relates the body element to the header and syncs initial visibility
+to the header's open state. Any number of body elements can be attached.
+
+---
+
+## ImGui grouped value readout panel
+
+A scrollable inspector-style panel with live-updating labeled rows grouped
+under collapsible headers. This is the pattern the internal Inspector uses.
+
+```cpp
+constexpr float x_min = -0.95F, x_max = 0.95F, row_h = 0.05F;
+LayoutCursor cursor;
+
+const glm::uvec2 dims = row_pixel_dims(window, x_min, x_max, row_h);
+
+// Pre-create one RowBuffer per data field
+auto freq_buf  = Inspector::make_row_buffer(window, "Freq",  dims);
+auto amp_buf   = Inspector::make_row_buffer(window, "Amp",   dims);
+auto phase_buf = Inspector::make_row_buffer(window, "Phase", dims);
+auto hdr_buf   = Inspector::make_row_buffer(window, "Oscillator", dims);
+
+std::array<RowBuffer, 3> row_bufs {
+    std::move(freq_buf), std::move(amp_buf), std::move(phase_buf)
+};
+
+std::array<ValueSpec, 3> specs { {
+    { "Freq",  [&] { return std::format("{:.1f} Hz", freq.load()); } },
+    { "Amp",   [&] { return std::format("{:.3f}",    amp.load());  } },
+    { "Phase", [&] { return std::format("{:.2f} rad", ph.load());  } },
+} };
+
+auto group = make_value_group(
+    specs, std::move(hdr_buf), row_bufs,
+    surface, cursor, x_min, x_max, row_h, true);
+
+// Each graphics tick - tap all links to repress live values
+schedule_metro(1.0 / 30.0, [g = std::move(group)]() mutable {
+    for (auto& row : g.rows)
+        row.link.tap();
+});
+```
+
+For deeply nested trees (node graph inspection, buffer chains), use
+`InspectResult` which nests `ValueGroup` recursively and exposes `tap_all()`.
+
+---
+
+## Visibility and z-order
+
+ImGui visibility is implicit (don't call the widget). Forma is explicit.
+
+```cpp
+// Show / hide an element
+surface.layer().set_visible(id, false);
+surface.layer().set_visible(id, true);
+
+// Cascades to all related children automatically when using relate_to:
+surface.layer().set_visible(parent_id, false);  // hides all attached children
+
+// Z-order
+surface.layer().send_to_back(id);
+surface.layer().send_to_front(id);
+```
+
+---
+
+## Scrollable regions
+
+Forma has no built-in scroll container. The pattern is a `LayoutCursor` with a
+float offset applied to all bounds, driven by scroll events on a background
+hit region:
+
+```cpp
+auto scroll_offset = make_persistent(0.F);
+constexpr float scroll_speed = 0.04F;
+
+// Background hit region covers the panel area
+const uint32_t panel_id = surface.layer().add(
+    Portal::Forma::Element {}
+        .with_bounds(panel_bounds)
+        .non_interactive());    // non_interactive = no pointer grab, but scroll fires
+
+surface.ctx().on_scroll(panel_id,
+    [&scroll_offset](uint32_t, glm::vec2 delta) {
+        scroll_offset = std::clamp(
+            scroll_offset + delta.y * scroll_speed, -8.F, 0.F);
+        // re-run layout with new offset, or drive LayoutCursor state
+    });
+```
+
+Full scrollable panels require re-placing elements at new bounds when the
+offset changes, or using a LayoutCursor whose `state()` is closed over by
+all body geometry functions so they reflow on `state()->write(new_y)`.
+
+---
+
+## Key differences from ImGui
+
+| ImGui | Forma |
+|---|---|
+| Immediate: re-emit every frame | Retained: construct once, update on change |
+| Implicit layout engine | Explicit NDC arithmetic + LayoutCursor |
+| Internal widget state | Your state, written via `MappedState<T>::write` |
+| `if (Button(...))` inline action | `on_press` callback registered once |
+| Style stack | Per-element color/geometry at construction |
+| Docking, tables, scroll built-in | Build from primitives; no built-in containers |
+| Thread: main/render thread only | Callbacks on graphics thread; writes from any thread |
+| Immediate feedback | Geometry updates on next `sync()` after `write()` |

--- a/docs/Portal-Forma-UI-Patterns.md
+++ b/docs/Portal-Forma-UI-Patterns.md
@@ -189,7 +189,7 @@ ImGui:
 ImGui::SliderFloat("Gain", &gain, 0.0f, 1.0f);
 ```
 
-Forma: `horizontal_fader` geometry function + drag callbacks.
+Forma: `horizontal_fader` geometry function + `on_drag`. No press flag needed.
 
 ```cpp
 constexpr Kinesis::AABB2D track { { -0.8F, -0.05F }, { 0.8F, 0.05F } };
@@ -200,20 +200,29 @@ auto el = Portal::Forma::create_element<float>(
     0.5F,
     Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP);
 
-auto pressed = make_persistent(false);
-surface.ctx().on_press  (el.element.id, IO::MouseButtons::Left,
-    [&pressed](uint32_t, glm::vec2) { pressed = true; });
-surface.ctx().on_release(el.element.id, IO::MouseButtons::Left,
-    [&pressed](uint32_t, glm::vec2) { pressed = false; });
-surface.ctx().on_move   (el.element.id,
-    [state = el.state, &pressed, track](uint32_t, glm::vec2 ndc) {
-        if (!pressed) return;
-        state->write(std::clamp((ndc.x - track.min.x) / track.width(), 0.F, 1.F));
+surface.ctx().on_drag(el.element.id, IO::MouseButtons::Left,
+    [state = el.state, track](uint32_t, glm::vec2 ndc) {
+        state->write(std::clamp(
+            (ndc.x - track.min.x) / track.width(), 0.F, 1.F));
     });
 
 // Wire to a node:
 auto constant = vega.Constant(0.5) | Audio[0];
 Portal::Forma::bridge().at(el.state).write(constant);
+```
+
+Arrow-key fine adjustment wires directly to the same state once the element
+has keyboard focus (transferred automatically on click):
+
+```cpp
+surface.ctx().on_held(el.element.id, IO::Keys::ArrowRight,
+    [state = el.state](uint32_t) {
+        state->write(std::clamp(state->value + 0.005F, 0.F, 1.F));
+    });
+surface.ctx().on_held(el.element.id, IO::Keys::ArrowLeft,
+    [state = el.state](uint32_t) {
+        state->write(std::clamp(state->value - 0.005F, 0.F, 1.F));
+    });
 ```
 
 For a knob (arc-based), use `stroke_slider` with an `arc_path`:
@@ -231,6 +240,11 @@ auto el = Portal::Forma::create_element<float>(
         0.02F, { 0.2F, 0.2F, 0.25F }, { 0.3F, 0.6F, 1.0F }),
     0.5F,
     Portal::Graphics::PrimitiveTopology::LINE_LIST);
+
+surface.ctx().on_drag(el.element.id, IO::MouseButtons::Left,
+    [state = el.state, path](uint32_t, glm::vec2 ndc) {
+        // project ndc onto path arc-length, write [0,1]
+    });
 ```
 
 ---
@@ -318,6 +332,79 @@ For deeply nested trees (node graph inspection, buffer chains), use
 
 ---
 
+## Drawable canvas / array editor
+
+ImGui has no direct equivalent. The closest approximation - a sequence of
+`SliderFloat` calls - gives N discrete sliders with no drawn curve, no drag
+interpolation, and no direct routing to an audio buffer.
+
+Forma's `drawable_canvas` renders a `vector<float>` of N samples as a
+continuous polyline. `wire_canvas_drag` handles all interaction: NDC to
+sample index, amplitude mapping, gap interpolation under fast drag, and
+version increment to trigger `sync()`. The state vector routes directly to
+any bulk float consumer.
+
+```cpp
+constexpr Kinesis::AABB2D bounds { glm::vec2(-0.8F, -0.6F), glm::vec2(0.8F, 0.6F) };
+constexpr uint32_t k_n = 256;
+
+auto el = Portal::Forma::create_element<std::vector<float>>(
+    surface,
+    Portal::Forma::Geometry::drawable_canvas(bounds),
+    std::vector<float>(k_n, 0.5F),
+    Portal::Graphics::PrimitiveTopology::LINE_LIST);
+
+Portal::Forma::Geometry::wire_canvas_drag(surface.ctx(), el.element.id, el.state, bounds);
+```
+
+Routing to consumers:
+
+```cpp
+// Wavetable or envelope written directly to audio output
+auto writer = std::make_shared<Buffers::AudioWriteProcessor>();
+auto audio_buf = std::make_shared<Buffers::AudioBuffer>(0, k_n);
+audio_buf->set_default_processor(writer);
+register_audio_buffer(audio_buf, 0);
+Portal::Forma::bridge().at(el.state).write(writer);
+
+// IIR feedforward coefficients
+auto iir = vega.IIR(rand, a_coefs, b_coefs) | Audio[0];
+Portal::Forma::bridge().at(el.state).write(
+    [iir](std::span<const float> s) {
+        iir->setBCoefficients({ s.begin(), s.end() });
+    });
+
+// Any N-element float consumer
+Portal::Forma::bridge().at(el.state).write(
+    [](std::span<const float> s) { /* s.data(), s.size() */ });
+```
+
+Two canvases on one surface give independent control over separate arrays -
+for example IIR a-coefs and b-coefs simultaneously:
+
+```cpp
+auto b_el = Portal::Forma::create_element<std::vector<float>>(surface,
+    Portal::Forma::Geometry::drawable_canvas(b_bounds, { 0.3F, 0.8F, 0.4F }),
+    b_init, Portal::Graphics::PrimitiveTopology::LINE_LIST);
+
+auto a_el = Portal::Forma::create_element<std::vector<float>>(surface,
+    Portal::Forma::Geometry::drawable_canvas(a_bounds, { 0.8F, 0.4F, 0.3F }),
+    a_init, Portal::Graphics::PrimitiveTopology::LINE_LIST);
+
+Portal::Forma::Geometry::wire_canvas_drag(surface.ctx(), b_el.element.id, b_el.state, b_bounds);
+Portal::Forma::Geometry::wire_canvas_drag(surface.ctx(), a_el.element.id, a_el.state, a_bounds);
+
+Portal::Forma::bridge().at(b_el.state).write([iir](std::span<const float> s) {
+    iir->setBCoefficients({ s.begin(), s.end() });
+});
+Portal::Forma::bridge().at(a_el.state).write([iir](std::span<const float> s) {
+    if (!s.empty() && s[0] != 0.F)
+        iir->setACoefficients({ s.begin(), s.end() });
+});
+```
+
+---
+
 ## Visibility and z-order
 
 ImGui visibility is implicit (don't call the widget). Forma is explicit.
@@ -375,7 +462,11 @@ all body geometry functions so they reflow on `state()->write(new_y)`.
 | Implicit layout engine | Explicit NDC arithmetic + LayoutCursor |
 | Internal widget state | Your state, written via `MappedState<T>::write` |
 | `if (Button(...))` inline action | `on_press` callback registered once |
+| `SliderFloat` with press+drag implicit | `on_drag` callback - no press flag |
+| No keyboard routing to widgets | Per-element key focus: `on_press(key)`, `on_held(key)`, `on_release(key)` |
 | Style stack | Per-element color/geometry at construction |
 | Docking, tables, scroll built-in | Build from primitives; no built-in containers |
 | Thread: main/render thread only | Callbacks on graphics thread; writes from any thread |
 | Immediate feedback | Geometry updates on next `sync()` after `write()` |
+| No curve/array editor primitive | `drawable_canvas` + `wire_canvas_drag`: drawn curve routes directly to audio or any N-element consumer |
+| No audio graph wiring | `Bridge::write` routes element value to nodes, shaders, audio processors, or arbitrary span sinks |

--- a/docs/Portal-Forma.md
+++ b/docs/Portal-Forma.md
@@ -162,9 +162,7 @@ auto el = Portal::Forma::create_element<float>(
 
 ## Geometry functions for Mapped\<T\>
 
-`Portal::Forma::Geometry` (in `Primitives/Geometry.hpp`) provides ready-made
-geometry functions for `create_element<T>`. Each produces a closure over its
-configuration parameters; pass the result directly as the `geom` argument.
+`Portal::Forma::Geometry` provides ready-made geometry functions for `create_element<T>`. Each produces a closure over its configuration parameters; pass the result directly as the `geom` argument.
 
 ### Controls
 
@@ -174,6 +172,7 @@ configuration parameters; pass the result directly as the `geom` argument.
 | `vertical_fader(bounds, handle_h)` | `float [0,1]` | TRIANGLE_STRIP | Same, vertical orientation. |
 | `stroke_slider(path, handle_buf, ...)` | `float [0,1]` | LINE_LIST | Arc-length scrubber along any polyline. Requires a separate POINT_LIST handle buffer. |
 | `toggle(region, color_off, color_on)` | `bool` | TRIANGLE_STRIP | Color switches on write. Wire `on_press` to flip state. |
+| `drawable_canvas(bounds, color, thickness)` | `vector<float>` | LINE_LIST | N samples rendered as a polyline. Use `wire_canvas_drag` to wire interaction. |
 
 ### Readouts
 
@@ -190,31 +189,45 @@ configuration parameters; pass the result directly as the `geom` argument.
 | `crosshair(arm_len, color, thickness, hit_radius)` | `glm::vec2` (NDC) | LINE_LIST | Two crossing segments. |
 | `position_picker(bounds, color, size)` | `glm::vec2 [0,1]²` | POINT_LIST | Maps unit square to NDC bounds. |
 
+### Drawable canvas
+
+`drawable_canvas` renders a `vector<float>` of N samples as a LINE_LIST polyline across the canvas bounds. Sample values are in [0, 1] mapped to the Y axis.
+
+`wire_canvas_drag` registers the drag interaction in one call: it maps NDC cursor position to sample index and amplitude, interpolates between the previous and current index to fill gaps under fast drag, and increments `state->version` to trigger `sync()`.
+
 ```cpp
-// Boolean toggle with on_press wiring
-auto el = Portal::Forma::create_element<bool>(
+constexpr Kinesis::AABB2D bounds { glm::vec2(-0.8F, -0.6F), glm::vec2(0.8F, 0.6F) };
+constexpr uint32_t k_n = 256;
+
+auto el = Portal::Forma::create_element<std::vector<float>>(
     surface,
-    Portal::Forma::Geometry::toggle(box, { 0.2F, 0.2F, 0.2F }, { 0.2F, 0.7F, 0.4F }),
-    false,
-    Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP);
+    Portal::Forma::Geometry::drawable_canvas(bounds),
+    std::vector<float>(k_n, 0.5F),
+    Portal::Graphics::PrimitiveTopology::LINE_LIST);
 
-surface.ctx().on_press(el.element.id, IO::MouseButtons::Left,
-    [state = el.state](uint32_t, glm::vec2) {
-        state->write(!state->value);
-    });
-
-// Audio level meter driven from a node
-auto el = Portal::Forma::create_element<float>(
-    surface,
-    Portal::Forma::Geometry::level_meter(
-        Kinesis::AABB2D { { -0.8F, -0.05F }, { 0.8F, 0.05F } },
-        true, { 0.2F, 0.8F, 0.3F }, { 0.1F, 0.1F, 0.12F }),
-    0.F,
-    Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP);
-
-Portal::Forma::bridge().at(el.state).bind(rms_node,
-    [](double x) { return static_cast<float>(std::clamp(x, 0.0, 1.0)); });
+Portal::Forma::Geometry::wire_canvas_drag(surface.ctx(), el.element.id, el.state, bounds);
 ```
+
+The state vector routes to any bulk float consumer via Bridge:
+
+```cpp
+// Wavetable / envelope - direct to AudioWriteProcessor
+auto writer = std::make_shared<Buffers::AudioWriteProcessor>();
+auto audio_buf = std::make_shared<Buffers::AudioBuffer>(0, k_n);
+audio_buf->set_default_processor(writer);
+register_audio_buffer(audio_buf, 0);
+Portal::Forma::bridge().at(el.state).write(writer);
+
+// IIR coefficient array
+auto iir = vega.IIR(rand, a_coefs, b_coefs) | Audio[0];
+Portal::Forma::bridge().at(el.state).write(
+    [iir](std::span<const float> s) {
+        std::vector<double> coefs(s.begin(), s.end());
+        iir->setBCoefficients(coefs);
+    });
+```
+
+---
 
 ## Element spatial description
 
@@ -255,28 +268,67 @@ suitable for direct assignment to `contains`.
 ## Pointer events
 
 ```cpp
-surface.ctx().on_press  (id, IO::MouseButtons::Left, [](uint32_t id, glm::vec2 ndc) { });
-surface.ctx().on_release(id, IO::MouseButtons::Left, [](uint32_t id, glm::vec2 ndc) { });
+surface.ctx().on_press  (id, IO::MouseButtons::Left,  [](uint32_t id, glm::vec2 ndc) { });
+surface.ctx().on_release(id, IO::MouseButtons::Left,  [](uint32_t id, glm::vec2 ndc) { });
+surface.ctx().on_drag   (id, IO::MouseButtons::Left,  [](uint32_t id, glm::vec2 ndc) { });
 surface.ctx().on_enter  (id, [](uint32_t id) { });
 surface.ctx().on_leave  (id, [](uint32_t id) { });
 surface.ctx().on_move   (id, [](uint32_t id, glm::vec2 ndc) { });
-surface.ctx().on_scroll (id, [](uint32_t id, glm::vec2 delta) { });
+surface.ctx().on_scroll (id, [](uint32_t id, glm::vec2 ndc, double dx, double dy) { });
 ```
 
-`ndc` is the cursor position in NDC space at the time of the event.
-Callbacks run on the graphics thread.
+`ndc` is the cursor position in NDC space at the time of the event. Callbacks run on the graphics thread.
 
-Hover tint pattern using `Kinesis::filled_rect`:
+`on_drag` is the preferred callback for continuous gestures (sliders, faders, canvas drawing). It tracks the originating element even when the cursor leaves its bounds, and fires on every motion event while the button is held. It does not require a separate press flag. Use `on_press`/`on_release` only when you need to detect the transition itself.
 
 ```cpp
-constexpr glm::vec3 k_rest  { 0.3F, 0.3F, 0.3F };
-constexpr glm::vec3 k_hover { 0.5F, 0.5F, 0.5F };
+// Fader using on_drag - no pressed flag needed
+surface.ctx().on_drag(el.element.id, IO::MouseButtons::Left,
+    [state = el.state, track](uint32_t, glm::vec2 ndc) {
+        state->write(std::clamp(
+            (ndc.x - track.min.x) / track.width(), 0.F, 1.F));
+    });
+```
 
-auto buf = Portal::Forma::create_buffer(window, Kinesis::filled_rect(box, k_rest),
-    Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP);
+---
 
-surface.ctx().on_enter(id, [buf, box](uint32_t) { buf->submit(Kinesis::filled_rect(box, k_hover)); });
-surface.ctx().on_leave(id, [buf, box](uint32_t) { buf->submit(Kinesis::filled_rect(box, k_rest)); });
+## Keyboard focus and key events
+
+Keyboard focus transfers to an element on mouse press. Key events route only to the focused element.
+
+```cpp
+// Key pressed once (fires on initial press, not on repeat)
+surface.ctx().on_press(id, IO::Keys::Enter, [](uint32_t id) { });
+
+// Key released
+surface.ctx().on_release(id, IO::Keys::Escape, [](uint32_t id) { });
+
+// Key held - fires on initial press and each OS repeat tick
+// Useful for continuous adjustment (arrow key nudge, value increment)
+surface.ctx().on_held(id, IO::Keys::ArrowUp, [](uint32_t id) { });
+
+// Focus lifecycle
+surface.ctx().on_focus_gained(id, [](uint32_t id) { /* highlight */ });
+surface.ctx().on_focus_lost  (id, [](uint32_t id) { /* unhighlight */ });
+
+// Query and clear focus
+auto focused_id = surface.ctx().focused(); // std::optional<uint32_t>
+surface.ctx().clear_focus();
+```
+
+Focus transfers automatically on mouse press. `unbind(id)` clears focus if that element holds it. Multiple key codes can be registered on the same element; each is a separate `on_press`/`on_held`/`on_release` call.
+
+Arrow-key nudge on a fader:
+
+```cpp
+surface.ctx().on_held(el.element.id, IO::Keys::ArrowRight,
+    [state = el.state](uint32_t) {
+        state->write(std::clamp(state->value + 0.01F, 0.F, 1.F));
+    });
+surface.ctx().on_held(el.element.id, IO::Keys::ArrowLeft,
+    [state = el.state](uint32_t) {
+        state->write(std::clamp(state->value - 0.01F, 0.F, 1.F));
+    });
 ```
 
 ---
@@ -445,7 +497,19 @@ Portal::Forma::bridge().at(el.state)
     .write(std::static_pointer_cast<Buffers::VKBuffer>(quad),
         "forma_ctl.frag", "intensity", 0, 1,
         Portal::Graphics::DescriptorRole::UNIFORM);
+
+// Route to an AudioWriteProcessor (scalar state: single-sample span)
+Portal::Forma::bridge().at(el.state).write(audio_write_processor);
+
+// Route vector<float> state to any bulk float consumer
+Portal::Forma::bridge().at(el.state).write(
+    [](std::span<const float> s) {
+        // s.data(), s.size() - full vector for vector<float> state,
+        // single element for scalar state
+    });
 ```
+
+The `write(span sink)` overload is the general bulk outbound path. For `MappedState<vector<float>>` or `MappedState<vector<double>>` the full vector is forwarded each frame. For scalar state a single-element span is constructed. The conversion from `float` to whatever the consumer needs is the caller's responsibility.
 
 ### Chaining both directions
 
@@ -470,14 +534,8 @@ auto el = Portal::Forma::create_element<float>(
     0.5F,
     Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP);
 
-auto pressed = make_persistent(false);
-
-surface.ctx().on_press  (el.element.id, IO::MouseButtons::Left, [&pressed](uint32_t, glm::vec2) { pressed = true;  });
-surface.ctx().on_release(el.element.id, IO::MouseButtons::Left, [&pressed](uint32_t, glm::vec2) { pressed = false; });
-surface.ctx().on_move   (el.element.id,
-    [state = el.state, &pressed, track](uint32_t, glm::vec2 ndc) {
-        if (!pressed)
-            return;
+surface.ctx().on_drag(el.element.id, IO::MouseButtons::Left,
+    [state = el.state, track](uint32_t, glm::vec2 ndc) {
         state->write(std::clamp(
             (ndc.x - track.min.x) / track.width(), 0.F, 1.F));
     });
@@ -540,15 +598,12 @@ auto el = Portal::Forma::create_element<glm::vec2>(
     glm::vec2 { 0.5F, 0.5F },
     Portal::Graphics::PrimitiveTopology::POINT_LIST);
 
-auto pressed = make_persistent(false);
-surface.ctx().on_press  (el.element.id, IO::MouseButtons::Left, [&pressed](uint32_t, glm::vec2) { pressed = true;  });
-surface.ctx().on_release(el.element.id, IO::MouseButtons::Left, [&pressed](uint32_t, glm::vec2) { pressed = false; });
-surface.ctx().on_move   (el.element.id, [state = el.state, &pressed, area](uint32_t, glm::vec2 ndc) {
-    if (!pressed) return;
-    state->write(glm::clamp(
-        (ndc - area.min) / glm::vec2(area.width(), area.height()),
-        glm::vec2(0.F), glm::vec2(1.F)));
-});
+surface.ctx().on_drag(el.element.id, IO::MouseButtons::Left,
+    [state = el.state, area](uint32_t, glm::vec2 ndc) {
+        state->write(glm::clamp(
+            (ndc - area.min) / glm::vec2(area.width(), area.height()),
+            glm::vec2(0.F), glm::vec2(1.F)));
+    });
 ```
 
 ### Labeled interactive button

--- a/docs/Portal-Forma.md
+++ b/docs/Portal-Forma.md
@@ -80,6 +80,142 @@ buffer that you fill via `buf->submit(...)` yourself.
 
 ---
 
+## Kinesis::Geometry2D - static vertex data
+
+`Kinesis::Geometry2D.hpp` produces raw vertex arrays. Pass the result directly
+to `create_buffer`, `buf->submit()`, or `write_verts` inside a geometry
+function. All coordinates are NDC (z = 0).
+
+### Filled shapes - `Kakshya::Vertex`, TRIANGLE_LIST
+
+| Function | Description |
+|---|---|
+| `filled_rect(region, color)` | 4-vertex TRIANGLE_STRIP rect. Also in `GeometryPrimitives.hpp`. |
+| `filled_rect_gradient(region, bl, br, tl, tr)` | Same shape, per-corner colors. |
+| `filled_rounded_rect(region, corner_r, segments, color)` | Rounded rect decomposed into body rects + corner fans. |
+| `filled_circle(center, radius, segments, color)` | Triangle fan. |
+| `filled_ring(center, inner_r, outer_r, segments, color)` | Annulus as quad strip. |
+| `filled_polygon(center, radius, sides, rotation, color)` | Regular n-gon fan. |
+| `filled_arc(center, radius, start, end, segments, color)` | Pie-slice sector fan. |
+
+```cpp
+// Rounded panel background
+auto buf = Portal::Forma::create_buffer(
+    window,
+    Kinesis::filled_rounded_rect(box, 0.02F, 6, { 0.15F, 0.15F, 0.17F }),
+    Portal::Graphics::PrimitiveTopology::TRIANGLE_LIST);
+
+// Ring indicator (e.g. dial surround)
+auto buf = Portal::Forma::create_buffer(
+    window,
+    Kinesis::filled_ring({ 0.F, 0.F }, 0.25F, 0.3F, 48, { 0.2F, 0.2F, 0.25F }),
+    Portal::Graphics::PrimitiveTopology::TRIANGLE_LIST);
+```
+
+### Outlines - `Kakshya::LineVertex`, LINE_LIST
+
+| Function | Description |
+|---|---|
+| `rect_outline(region, color, thickness)` | 4 edges, 8 vertices. |
+| `circle_outline(center, radius, segments, color, thickness)` | Closed loop. |
+| `arc_outline(center, radius, start, end, segments, color, thickness)` | Open arc. |
+| `polygon_outline(center, radius, sides, rotation, color, thickness)` | Closed n-gon. |
+| `polyline(pts, color, thickness)` | Open path from a span of `glm::vec2`. |
+| `polyline_colored(pts, colors, thickness)` | Same, per-vertex colors. |
+
+```cpp
+// Border around a panel
+auto buf = Portal::Forma::create_buffer(
+    window,
+    Kinesis::rect_outline(box, { 0.4F, 0.4F, 0.5F }, 1.F),
+    Portal::Graphics::PrimitiveTopology::LINE_LIST);
+
+// Cable route between two points
+const std::array<glm::vec2, 4> pts { { { -0.5F, -0.3F }, { -0.2F, 0.1F }, { 0.2F, -0.1F }, { 0.5F, 0.3F } } };
+auto buf = Portal::Forma::create_buffer(
+    window,
+    Kinesis::polyline(pts, { 0.6F, 0.9F, 0.3F }, 1.5F),
+    Portal::Graphics::PrimitiveTopology::LINE_LIST);
+```
+
+### Path sampling
+
+`arc_path(center, rx, ry, start, end, segments)` returns `vector<glm::vec2>`,
+useful as input to `polyline` or `stroke_slider`:
+
+```cpp
+// Semicircular arc path for a stroke_slider
+auto path = Kinesis::arc_path({ 0.F, 0.F }, 0.4F, 0.4F,
+    glm::radians(200.F), glm::radians(-20.F), 64);
+
+auto handle_buf = Portal::Forma::create_buffer(
+    window, Portal::Graphics::PrimitiveTopology::POINT_LIST);
+
+auto el = Portal::Forma::create_element<float>(
+    surface,
+    Portal::Forma::Geometry::stroke_slider(path, handle_buf),
+    0.5F,
+    Portal::Graphics::PrimitiveTopology::LINE_LIST);
+```
+
+---
+
+## Geometry functions for Mapped\<T\>
+
+`Portal::Forma::Geometry` (in `Primitives/Geometry.hpp`) provides ready-made
+geometry functions for `create_element<T>`. Each produces a closure over its
+configuration parameters; pass the result directly as the `geom` argument.
+
+### Controls
+
+| Function | T | Topology | Notes |
+|---|---|---|---|
+| `horizontal_fader(bounds, handle_w)` | `float [0,1]` | TRIANGLE_STRIP | Track + handle quads. Hit region follows handle. |
+| `vertical_fader(bounds, handle_h)` | `float [0,1]` | TRIANGLE_STRIP | Same, vertical orientation. |
+| `stroke_slider(path, handle_buf, ...)` | `float [0,1]` | LINE_LIST | Arc-length scrubber along any polyline. Requires a separate POINT_LIST handle buffer. |
+| `toggle(region, color_off, color_on)` | `bool` | TRIANGLE_STRIP | Color switches on write. Wire `on_press` to flip state. |
+
+### Readouts
+
+| Function | T | Topology | Notes |
+|---|---|---|---|
+| `level_meter(bounds, horizontal, fill, track)` | `float [0,1]` | TRIANGLE_STRIP | Fills proportional bar. No hit region. |
+| `radial(center, radius, start, end, color)` | `float [0,1]` | LINE_LIST | Sweeping indicator line. |
+
+### Positional
+
+| Function | T | Topology | Notes |
+|---|---|---|---|
+| `point(color, size, hit_radius)` | `glm::vec2` (NDC) | POINT_LIST | Single point. Hit region is a circle. |
+| `crosshair(arm_len, color, thickness, hit_radius)` | `glm::vec2` (NDC) | LINE_LIST | Two crossing segments. |
+| `position_picker(bounds, color, size)` | `glm::vec2 [0,1]²` | POINT_LIST | Maps unit square to NDC bounds. |
+
+```cpp
+// Boolean toggle with on_press wiring
+auto el = Portal::Forma::create_element<bool>(
+    surface,
+    Portal::Forma::Geometry::toggle(box, { 0.2F, 0.2F, 0.2F }, { 0.2F, 0.7F, 0.4F }),
+    false,
+    Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP);
+
+surface.ctx().on_press(el.element.id, IO::MouseButtons::Left,
+    [state = el.state](uint32_t, glm::vec2) {
+        state->write(!state->value);
+    });
+
+// Audio level meter driven from a node
+auto el = Portal::Forma::create_element<float>(
+    surface,
+    Portal::Forma::Geometry::level_meter(
+        Kinesis::AABB2D { { -0.8F, -0.05F }, { 0.8F, 0.05F } },
+        true, { 0.2F, 0.8F, 0.3F }, { 0.1F, 0.1F, 0.12F }),
+    0.F,
+    Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP);
+
+Portal::Forma::bridge().at(el.state).bind(rms_node,
+    [](double x) { return static_cast<float>(std::clamp(x, 0.0, 1.0)); });
+```
+
 ## Element spatial description
 
 Every `Element` has two independent spatial fields:

--- a/src/MayaFlux/Kinesis/Geometry2D.cpp
+++ b/src/MayaFlux/Kinesis/Geometry2D.cpp
@@ -1,0 +1,342 @@
+#include "Geometry2D.hpp"
+
+namespace MayaFlux::Kinesis {
+
+namespace {
+
+    constexpr uint32_t k_min_segments = 3;
+    constexpr uint32_t k_min_sides = 3;
+
+    [[nodiscard]] Kakshya::Vertex vert2(glm::vec2 p, glm::vec3 c) noexcept
+    {
+        return Kakshya::Vertex {
+            .position = { p.x, p.y, 0.F },
+            .color = c,
+        };
+    }
+
+    [[nodiscard]] Kakshya::LineVertex lvert2(glm::vec2 p, glm::vec3 c, float t) noexcept
+    {
+        return Kakshya::LineVertex {
+            .position = { p.x, p.y, 0.F },
+            .color = c,
+            .thickness = t,
+        };
+    }
+
+    [[nodiscard]] glm::vec2 ring_point(glm::vec2 center, float r, float angle) noexcept
+    {
+        return center + r * glm::vec2(std::cos(angle), std::sin(angle));
+    }
+
+} // namespace
+
+// =============================================================================
+// Filled shapes
+// =============================================================================
+
+std::vector<Kakshya::Vertex> filled_circle(
+    glm::vec2 center, float radius, uint32_t segments, glm::vec3 color)
+{
+    segments = std::max<uint32_t>(segments, k_min_segments);
+    const float step = glm::two_pi<float>() / static_cast<float>(segments);
+
+    std::vector<Kakshya::Vertex> out;
+    out.reserve(static_cast<size_t>(segments) * 3);
+
+    for (uint32_t i = 0; i < segments; ++i) {
+        const float a0 = static_cast<float>(i) * step;
+        const float a1 = static_cast<float>(i + 1) * step;
+        out.push_back(vert2(center, color));
+        out.push_back(vert2(ring_point(center, radius, a0), color));
+        out.push_back(vert2(ring_point(center, radius, a1), color));
+    }
+
+    return out;
+}
+
+std::vector<Kakshya::Vertex> filled_ring(
+    glm::vec2 center, float inner_r, float outer_r,
+    uint32_t segments, glm::vec3 color)
+{
+    segments = std::max<uint32_t>(segments, k_min_segments);
+    const float step = glm::two_pi<float>() / static_cast<float>(segments);
+
+    std::vector<Kakshya::Vertex> out;
+    out.reserve(static_cast<size_t>(segments) * 6);
+
+    for (uint32_t i = 0; i < segments; ++i) {
+        const float a0 = static_cast<float>(i) * step;
+        const float a1 = static_cast<float>(i + 1) * step;
+
+        const glm::vec2 oi0 = ring_point(center, inner_r, a0);
+        const glm::vec2 oo0 = ring_point(center, outer_r, a0);
+        const glm::vec2 oi1 = ring_point(center, inner_r, a1);
+        const glm::vec2 oo1 = ring_point(center, outer_r, a1);
+
+        out.push_back(vert2(oi0, color));
+        out.push_back(vert2(oo0, color));
+        out.push_back(vert2(oo1, color));
+
+        out.push_back(vert2(oi0, color));
+        out.push_back(vert2(oo1, color));
+        out.push_back(vert2(oi1, color));
+    }
+
+    return out;
+}
+
+std::vector<Kakshya::Vertex> filled_polygon(
+    glm::vec2 center, float radius, uint32_t sides,
+    float rotation_rad, glm::vec3 color)
+{
+    sides = std::max<uint32_t>(sides, k_min_sides);
+    const float step = glm::two_pi<float>() / static_cast<float>(sides);
+
+    std::vector<Kakshya::Vertex> out;
+    out.reserve((size_t)sides * 3);
+
+    for (uint32_t i = 0; i < sides; ++i) {
+        const float a0 = rotation_rad + static_cast<float>(i) * step;
+        const float a1 = rotation_rad + static_cast<float>(i + 1) * step;
+        out.push_back(vert2(center, color));
+        out.push_back(vert2(ring_point(center, radius, a0), color));
+        out.push_back(vert2(ring_point(center, radius, a1), color));
+    }
+
+    return out;
+}
+
+std::array<Kakshya::Vertex, 4> filled_rect_gradient(
+    AABB2D region,
+    glm::vec3 color_bl, glm::vec3 color_br,
+    glm::vec3 color_tl, glm::vec3 color_tr)
+{
+    return { {
+        { .position = { region.min.x, region.min.y, 0.F }, .color = color_bl },
+        { .position = { region.min.x, region.max.y, 0.F }, .color = color_tl },
+        { .position = { region.max.x, region.min.y, 0.F }, .color = color_br },
+        { .position = { region.max.x, region.max.y, 0.F }, .color = color_tr },
+    } };
+}
+
+std::vector<Kakshya::Vertex> filled_rounded_rect(
+    AABB2D region, float corner_radius,
+    uint32_t corner_segments, glm::vec3 color)
+{
+    corner_segments = std::max<uint32_t>(corner_segments, 1U);
+    const float max_r = std::min(region.width(), region.height()) * 0.5F;
+    const float r = std::min(corner_radius, max_r);
+
+    const glm::vec2 bl { region.min.x + r, region.min.y + r };
+    const glm::vec2 br { region.max.x - r, region.min.y + r };
+    const glm::vec2 tl { region.min.x + r, region.max.y - r };
+    const glm::vec2 tr { region.max.x - r, region.max.y - r };
+
+    std::vector<Kakshya::Vertex> out;
+    // 3 body rects (6 tris each) + 4 corner fans (corner_segments tris each)
+    out.reserve(18 + 4 * (size_t)corner_segments * 3);
+
+    // center rect
+    auto push_quad = [&](glm::vec2 a, glm::vec2 b, glm::vec2 c, glm::vec2 d) {
+        out.push_back(vert2(a, color));
+        out.push_back(vert2(b, color));
+        out.push_back(vert2(c, color));
+        out.push_back(vert2(b, color));
+        out.push_back(vert2(d, color));
+        out.push_back(vert2(c, color));
+    };
+
+    push_quad({ bl.x, region.min.y }, { tl.x, region.max.y }, { tr.x, region.min.y }, { tr.x, region.max.y });
+    push_quad({ region.min.x, bl.y }, { region.min.x, tl.y }, { bl.x, bl.y }, { bl.x, tl.y });
+    push_quad({ tr.x, br.y }, { tr.x, tr.y }, { region.max.x, br.y }, { region.max.x, tr.y });
+
+    // corner fans: BL, BR, TL, TR
+    struct Corner {
+        glm::vec2 c;
+        float a0;
+    };
+    const auto half_pi = glm::half_pi<float>();
+    const Corner corners[4] = {
+        { .c = bl, .a0 = glm::pi<float>() },
+        { .c = br, .a0 = -half_pi },
+        { .c = tl, .a0 = half_pi },
+        { .c = tr, .a0 = 0.F },
+    };
+
+    const float step = half_pi / static_cast<float>(corner_segments);
+    for (const auto& [c, a0] : corners) {
+        for (uint32_t i = 0; i < corner_segments; ++i) {
+            const float a1 = a0 + static_cast<float>(i) * step;
+            const float a2 = a0 + static_cast<float>(i + 1) * step;
+            out.push_back(vert2(c, color));
+            out.push_back(vert2(ring_point(c, r, a1), color));
+            out.push_back(vert2(ring_point(c, r, a2), color));
+        }
+    }
+
+    return out;
+}
+
+std::vector<Kakshya::Vertex> filled_arc(
+    glm::vec2 center, float radius,
+    float angle_start, float angle_end,
+    uint32_t segments, glm::vec3 color)
+{
+    segments = std::max<uint32_t>(segments, 1U);
+    const float step = (angle_end - angle_start) / static_cast<float>(segments);
+
+    std::vector<Kakshya::Vertex> out;
+    out.reserve(static_cast<size_t>(segments) * 3);
+
+    for (uint32_t i = 0; i < segments; ++i) {
+        const float a0 = angle_start + static_cast<float>(i) * step;
+        const float a1 = angle_start + static_cast<float>(i + 1) * step;
+        out.push_back(vert2(center, color));
+        out.push_back(vert2(ring_point(center, radius, a0), color));
+        out.push_back(vert2(ring_point(center, radius, a1), color));
+    }
+
+    return out;
+}
+
+std::vector<glm::vec2> arc_path(
+    glm::vec2 center,
+    float radius_x, float radius_y,
+    float angle_start, float angle_end,
+    uint32_t segments)
+{
+    segments = std::max<uint32_t>(segments, 1U);
+    const float step = (angle_end - angle_start) / static_cast<float>(segments);
+
+    std::vector<glm::vec2> out;
+    out.reserve(static_cast<size_t>(segments) + 1);
+    for (uint32_t i = 0; i <= segments; ++i) {
+        const float a = angle_start + static_cast<float>(i) * step;
+        out.push_back(center + glm::vec2(radius_x * std::cos(a), radius_y * std::sin(a)));
+    }
+    return out;
+}
+
+// =============================================================================
+// Outlines
+// =============================================================================
+
+std::vector<Kakshya::LineVertex> circle_outline(
+    glm::vec2 center, float radius, uint32_t segments,
+    glm::vec3 color, float thickness)
+{
+    segments = std::max<uint32_t>(segments, k_min_segments);
+    const float step = glm::two_pi<float>() / static_cast<float>(segments);
+
+    std::vector<Kakshya::LineVertex> out;
+    out.reserve(static_cast<size_t>(segments) * 2);
+
+    for (uint32_t i = 0; i < segments; ++i) {
+        const float a0 = static_cast<float>(i) * step;
+        const float a1 = static_cast<float>((i + 1) % segments) * step;
+        out.push_back(lvert2(ring_point(center, radius, a0), color, thickness));
+        out.push_back(lvert2(ring_point(center, radius, a1), color, thickness));
+    }
+
+    return out;
+}
+
+std::vector<Kakshya::LineVertex> arc_outline(
+    glm::vec2 center, float radius,
+    float angle_start, float angle_end,
+    uint32_t segments, glm::vec3 color, float thickness)
+{
+    segments = std::max<uint32_t>(segments, 1U);
+    const float step = (angle_end - angle_start) / static_cast<float>(segments);
+
+    std::vector<Kakshya::LineVertex> out;
+    out.reserve(static_cast<size_t>(segments) * 2);
+
+    for (uint32_t i = 0; i < segments; ++i) {
+        const float a0 = angle_start + static_cast<float>(i) * step;
+        const float a1 = angle_start + static_cast<float>(i + 1) * step;
+        out.push_back(lvert2(ring_point(center, radius, a0), color, thickness));
+        out.push_back(lvert2(ring_point(center, radius, a1), color, thickness));
+    }
+
+    return out;
+}
+
+std::array<Kakshya::LineVertex, 8> rect_outline(
+    AABB2D region, glm::vec3 color, float thickness)
+{
+    const glm::vec2 bl { region.min.x, region.min.y };
+    const glm::vec2 br { region.max.x, region.min.y };
+    const glm::vec2 tl { region.min.x, region.max.y };
+    const glm::vec2 tr { region.max.x, region.max.y };
+
+    return { {
+        lvert2(bl, color, thickness),
+        lvert2(br, color, thickness),
+        lvert2(br, color, thickness),
+        lvert2(tr, color, thickness),
+        lvert2(tr, color, thickness),
+        lvert2(tl, color, thickness),
+        lvert2(tl, color, thickness),
+        lvert2(bl, color, thickness),
+    } };
+}
+
+std::vector<Kakshya::LineVertex> polyline(
+    std::span<const glm::vec2> pts, glm::vec3 color, float thickness)
+{
+    if (pts.size() < 2)
+        return {};
+
+    std::vector<Kakshya::LineVertex> out;
+    out.reserve((pts.size() - 1) * 2);
+
+    for (size_t i = 0; i + 1 < pts.size(); ++i) {
+        out.push_back(lvert2(pts[i], color, thickness));
+        out.push_back(lvert2(pts[i + 1], color, thickness));
+    }
+
+    return out;
+}
+
+std::vector<Kakshya::LineVertex> polyline_colored(
+    std::span<const glm::vec2> pts,
+    std::span<const glm::vec3> colors,
+    float thickness)
+{
+    if (pts.size() < 2 || colors.size() != pts.size())
+        return {};
+
+    std::vector<Kakshya::LineVertex> out;
+    out.reserve((pts.size() - 1) * 2);
+
+    for (size_t i = 0; i + 1 < pts.size(); ++i) {
+        out.push_back(lvert2(pts[i], colors[i], thickness));
+        out.push_back(lvert2(pts[i + 1], colors[i + 1], thickness));
+    }
+
+    return out;
+}
+
+std::vector<Kakshya::LineVertex> polygon_outline(
+    glm::vec2 center, float radius, uint32_t sides,
+    float rotation_rad, glm::vec3 color, float thickness)
+{
+    sides = std::max<uint32_t>(sides, k_min_sides);
+    const float step = glm::two_pi<float>() / static_cast<float>(sides);
+
+    std::vector<Kakshya::LineVertex> out;
+    out.reserve((size_t)sides * 2);
+
+    for (uint32_t i = 0; i < sides; ++i) {
+        const float a0 = rotation_rad + static_cast<float>(i) * step;
+        const float a1 = rotation_rad + static_cast<float>((i + 1) % sides) * step;
+        out.push_back(lvert2(ring_point(center, radius, a0), color, thickness));
+        out.push_back(lvert2(ring_point(center, radius, a1), color, thickness));
+    }
+
+    return out;
+}
+
+} // namespace MayaFlux::Kinesis

--- a/src/MayaFlux/Kinesis/Geometry2D.hpp
+++ b/src/MayaFlux/Kinesis/Geometry2D.hpp
@@ -1,0 +1,262 @@
+#pragma once
+
+#include "MayaFlux/Kakshya/NDData/VertexFormats.hpp"
+#include "MayaFlux/Kinesis/Spatial/Bounds.hpp"
+
+namespace MayaFlux::Kinesis {
+
+// =============================================================================
+// Filled shapes — Kakshya::Vertex, TRIANGLE_LIST topology
+//
+// All coordinates are 2D NDC (z = 0). These produce vertex arrays suitable
+// for direct use with write_verts / FormaBuffer::submit / create_buffer.
+// No index buffer is required; triangle fan decomposition is inlined.
+// =============================================================================
+
+/**
+ * @brief Filled circle as a TRIANGLE_LIST triangle fan.
+ *
+ * Decomposes into (segments) triangles sharing a common center vertex.
+ * Minimum @p segments is 3; values below are clamped.
+ *
+ * @param center   Circle center in NDC.
+ * @param radius   Radius in NDC units.
+ * @param segments Triangle count around the circumference.
+ * @param color    Uniform fill color.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<Kakshya::Vertex> filled_circle(
+    glm::vec2 center,
+    float radius,
+    uint32_t segments,
+    glm::vec3 color = glm::vec3(1.F));
+
+/**
+ * @brief Filled annulus (ring) as a TRIANGLE_LIST quad strip.
+ *
+ * Produces two triangles per angular segment between @p inner_r and
+ * @p outer_r. Minimum @p segments is 3.
+ *
+ * @param center   Ring center in NDC.
+ * @param inner_r  Inner radius in NDC units.
+ * @param outer_r  Outer radius in NDC units.
+ * @param segments Quad count around the circumference.
+ * @param color    Uniform fill color.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<Kakshya::Vertex> filled_ring(
+    glm::vec2 center,
+    float inner_r,
+    float outer_r,
+    uint32_t segments,
+    glm::vec3 color = glm::vec3(1.F));
+
+/**
+ * @brief Filled regular n-gon as a TRIANGLE_LIST triangle fan.
+ *
+ * Vertices are placed on a circle of @p radius, starting at
+ * @p rotation_rad from +X, CCW. Minimum @p sides is 3.
+ *
+ * @param center       Polygon center in NDC.
+ * @param radius       Circumradius in NDC units.
+ * @param sides        Number of sides. Clamped to minimum 3.
+ * @param rotation_rad Starting angle in radians from +X axis.
+ * @param color        Uniform fill color.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<Kakshya::Vertex> filled_polygon(
+    glm::vec2 center,
+    float radius,
+    uint32_t sides,
+    float rotation_rad = 0.F,
+    glm::vec3 color = glm::vec3(1.F));
+
+/**
+ * @brief Filled rect with per-corner colors, TRIANGLE_STRIP (4 vertices).
+ *
+ * Vertex order matches filled_rect: BL, BL-top, BR, BR-top (TRIANGLE_STRIP).
+ * Drop-in replacement for filled_rect when a gradient fill is needed.
+ *
+ * @param region   NDC axis-aligned bounds.
+ * @param color_bl Bottom-left corner color.
+ * @param color_br Bottom-right corner color.
+ * @param color_tl Top-left corner color.
+ * @param color_tr Top-right corner color.
+ */
+[[nodiscard]] MAYAFLUX_API std::array<Kakshya::Vertex, 4> filled_rect_gradient(
+    AABB2D region,
+    glm::vec3 color_bl,
+    glm::vec3 color_br,
+    glm::vec3 color_tl,
+    glm::vec3 color_tr);
+
+/**
+ * @brief Filled rounded rectangle as a TRIANGLE_LIST mesh.
+ *
+ * Composed of a center rect, four edge rects, and four corner fans.
+ * @p corner_radius is clamped to half the shorter axis to prevent overlap.
+ * Minimum @p corner_segments is 1.
+ *
+ * @param region          NDC axis-aligned bounds.
+ * @param corner_radius   Radius of each rounded corner in NDC units.
+ * @param corner_segments Triangle count per quarter-circle corner arc.
+ * @param color           Uniform fill color.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<Kakshya::Vertex> filled_rounded_rect(
+    AABB2D region,
+    float corner_radius,
+    uint32_t corner_segments,
+    glm::vec3 color = glm::vec3(1.F));
+
+/**
+ * @brief Filled circular arc sector (pie slice) as a TRIANGLE_LIST fan.
+ *
+ * @p angle_start and @p angle_end are in radians, measured from +X CCW.
+ * Minimum @p segments is 1.
+ *
+ * @param center      Arc center in NDC.
+ * @param radius      Radius in NDC units.
+ * @param angle_start Start angle in radians.
+ * @param angle_end   End angle in radians.
+ * @param segments    Triangle count over the arc span.
+ * @param color       Uniform fill color.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<Kakshya::Vertex> filled_arc(
+    glm::vec2 center,
+    float radius,
+    float angle_start,
+    float angle_end,
+    uint32_t segments,
+    glm::vec3 color = glm::vec3(1.F));
+
+/**
+ * @brief Sample a circular arc as ordered NDC positions.
+ *
+ * Produces @p segments + 1 points along the arc from @p angle_start to
+ * @p angle_end, suitable as path input to stroke_slider or any other
+ * function consuming a @c span<const glm::vec2> path.
+ *
+ * @param center      Arc center in NDC.
+ * @param radius_x    Horizontal radius in NDC units.
+ * @param radius_y    Vertical radius in NDC units (use == radius_x for a circle).
+ * @param angle_start Start angle in radians from +X, CCW.
+ * @param angle_end   End angle in radians from +X, CCW.
+ * @param segments    Number of segments; produces segments+1 points.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<glm::vec2> arc_path(
+    glm::vec2 center,
+    float radius_x,
+    float radius_y,
+    float angle_start,
+    float angle_end,
+    uint32_t segments);
+
+// =============================================================================
+// Outlines — Kakshya::LineVertex, LINE_LIST topology
+//
+// Each function produces adjacent vertex pairs for LINE_LIST draw.
+// LINE_STRIP callers can use every other vertex as the strip is equivalent
+// for these closed/open forms, but LINE_LIST is the canonical output to
+// match the existing Forma pipeline (radial, stroke_slider precedent).
+// =============================================================================
+
+/**
+ * @brief Circle outline as a LINE_LIST (closed loop, 2 * segments vertices).
+ *
+ * Each segment is one line: [ring[i], ring[(i+1) % segments]].
+ * Minimum @p segments is 3.
+ *
+ * @param center    Circle center in NDC.
+ * @param radius    Radius in NDC units.
+ * @param segments  Edge count around the circumference.
+ * @param color     Uniform line color.
+ * @param thickness Line thickness (maps to LineVertex::thickness).
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<Kakshya::LineVertex> circle_outline(
+    glm::vec2 center,
+    float radius,
+    uint32_t segments,
+    glm::vec3 color = glm::vec3(1.F),
+    float thickness = 1.F);
+
+/**
+ * @brief Arc outline as a LINE_LIST (open curve, 2 * segments vertices).
+ *
+ * @p angle_start and @p angle_end are in radians from +X, CCW.
+ * Minimum @p segments is 1.
+ *
+ * @param center      Arc center in NDC.
+ * @param radius      Radius in NDC units.
+ * @param angle_start Start angle in radians.
+ * @param angle_end   End angle in radians.
+ * @param segments    Edge count over the arc span.
+ * @param color       Uniform line color.
+ * @param thickness   Line thickness.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<Kakshya::LineVertex> arc_outline(
+    glm::vec2 center,
+    float radius,
+    float angle_start,
+    float angle_end,
+    uint32_t segments,
+    glm::vec3 color = glm::vec3(1.F),
+    float thickness = 1.F);
+
+/**
+ * @brief Rectangle outline as a LINE_LIST (4 edges, 8 vertices).
+ *
+ * @param region    NDC axis-aligned bounds.
+ * @param color     Uniform line color.
+ * @param thickness Line thickness.
+ */
+[[nodiscard]] MAYAFLUX_API std::array<Kakshya::LineVertex, 8> rect_outline(
+    AABB2D region,
+    glm::vec3 color = glm::vec3(1.F),
+    float thickness = 1.F);
+
+/**
+ * @brief Polyline as a LINE_LIST (open path, 2 * (pts.size() - 1) vertices).
+ *
+ * Converts a span of NDC vec2 positions into adjacent LineVertex pairs.
+ * Suitable for waveform traces, cable routes, and arbitrary open curves.
+ *
+ * @param pts       Ordered path vertices in NDC.
+ * @param color     Uniform line color.
+ * @param thickness Line thickness.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<Kakshya::LineVertex> polyline(
+    std::span<const glm::vec2> pts,
+    glm::vec3 color = glm::vec3(1.F),
+    float thickness = 1.F);
+
+/**
+ * @brief Polyline with per-vertex colors as a LINE_LIST.
+ *
+ * @p pts and @p colors must have equal length. Each line segment blends
+ * from the color at its start vertex to the color at its end vertex.
+ *
+ * @param pts    Ordered path vertices in NDC.
+ * @param colors Per-vertex colors. Must match @p pts in size.
+ * @param thickness Line thickness applied uniformly.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<Kakshya::LineVertex> polyline_colored(
+    std::span<const glm::vec2> pts,
+    std::span<const glm::vec3> colors,
+    float thickness = 1.F);
+
+/**
+ * @brief Regular n-gon outline as a LINE_LIST (closed loop, 2 * sides vertices).
+ *
+ * @param center       Polygon center in NDC.
+ * @param radius       Circumradius in NDC units.
+ * @param sides        Side count. Clamped to minimum 3.
+ * @param rotation_rad Starting angle in radians from +X axis.
+ * @param color        Uniform line color.
+ * @param thickness    Line thickness.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<Kakshya::LineVertex> polygon_outline(
+    glm::vec2 center,
+    float radius,
+    uint32_t sides,
+    float rotation_rad = 0.F,
+    glm::vec3 color = glm::vec3(1.F),
+    float thickness = 1.F);
+
+} // namespace MayaFlux::Kinesis

--- a/src/MayaFlux/Kinesis/Scalar.hpp
+++ b/src/MayaFlux/Kinesis/Scalar.hpp
@@ -1,0 +1,264 @@
+#pragma once
+
+namespace MayaFlux::Kinesis {
+
+// =============================================================================
+// Range mapping
+// =============================================================================
+
+/**
+ * @brief Map @p x from [in_lo, in_hi] to [out_lo, out_hi], unclamped.
+ *
+ * Values outside [in_lo, in_hi] extrapolate linearly. Use map_clamped()
+ * when the output must stay within [out_lo, out_hi].
+ *
+ * Degenerate input range (in_lo == in_hi) returns out_lo.
+ */
+template <typename T>
+[[nodiscard]] constexpr T map(T x, T in_lo, T in_hi, T out_lo, T out_hi) noexcept
+{
+    const T in_range = in_hi - in_lo;
+    if (in_range == T { 0 })
+        return out_lo;
+    return out_lo + (x - in_lo) / in_range * (out_hi - out_lo);
+}
+
+/**
+ * @brief Map @p x from [in_lo, in_hi] to [out_lo, out_hi], clamped to
+ *        [out_lo, out_hi].
+ */
+template <typename T>
+[[nodiscard]] constexpr T map_clamped(T x, T in_lo, T in_hi, T out_lo, T out_hi) noexcept
+{
+    const T v = map(x, in_lo, in_hi, out_lo, out_hi);
+    return std::clamp(v, std::min(out_lo, out_hi), std::max(out_lo, out_hi));
+}
+
+/**
+ * @brief Normalize @p x in [lo, hi] to [0, 1], unclamped.
+ *
+ * Distinct from Kinesis::Discrete::normalize, which operates in-place on
+ * a span and computes its own min/max. This is the scalar equivalent.
+ *
+ * Degenerate range (lo == hi) returns 0.
+ */
+template <typename T>
+[[nodiscard]] constexpr T normalize(T x, T lo, T hi) noexcept
+{
+    const T range = hi - lo;
+    if (range == T { 0 })
+        return T { 0 };
+    return (x - lo) / range;
+}
+
+/**
+ * @brief Denormalize @p t from [0, 1] to [lo, hi].
+ *
+ * Equivalent to glm::mix(lo, hi, t) but named for legibility at call sites
+ * where the intent is range reconstruction rather than interpolation.
+ */
+template <typename T>
+[[nodiscard]] constexpr T denormalize(T t, T lo, T hi) noexcept
+{
+    return lo + t * (hi - lo);
+}
+
+// =============================================================================
+// Smoothing
+// =============================================================================
+
+/**
+ * @brief GLSL smoothstep: Hermite interpolation in [lo, hi].
+ *
+ * Returns 0 when x <= lo, 1 when x >= hi, and a smooth cubic curve
+ * in between. Equivalent to GLSL smoothstep(lo, hi, x).
+ *
+ * GLM provides this as glm::smoothstep but requires glm/gtx/compatibility.hpp
+ * and a vector type. This overload accepts any scalar T.
+ */
+template <typename T>
+[[nodiscard]] constexpr T smoothstep(T lo, T hi, T x) noexcept
+{
+    const T t = std::clamp((x - lo) / (hi - lo), T { 0 }, T { 1 });
+    return t * t * (T { 3 } - T { 2 } * t);
+}
+
+/**
+ * @brief Ken Perlin's quintic smootherstep: C2-continuous in [lo, hi].
+ *
+ * Derivative is zero at both endpoints (unlike smoothstep which has zero
+ * first derivative only). Use when second-derivative continuity matters:
+ * camera motion, envelope transitions, SDF blending weights.
+ */
+template <typename T>
+[[nodiscard]] constexpr T smootherstep(T lo, T hi, T x) noexcept
+{
+    const T t = std::clamp((x - lo) / (hi - lo), T { 0 }, T { 1 });
+    return t * t * t * (t * (t * T { 6 } - T { 15 }) + T { 10 });
+}
+
+/**
+ * @brief Exponential smoothing: move @p current toward @p target at rate
+ *        @p smoothing over time step @p dt.
+ *
+ * @p smoothing is a half-life in seconds: the distance to target halves
+ * every @p smoothing seconds. At smoothing = 0.1 the value tracks quickly;
+ * at smoothing = 2.0 it lags heavily.
+ *
+ * Framerate-independent. Equivalent to the "lerp every frame" pattern
+ * done correctly:
+ *   current = lerp(current, target, 1 - exp(-dt / smoothing))
+ *
+ * Degenerate case (smoothing <= 0) snaps to target immediately.
+ */
+template <typename T>
+[[nodiscard]] inline T damp(T current, T target, T smoothing, T dt) noexcept
+{
+    if (smoothing <= T { 0 })
+        return target;
+    return current + (target - current) * (T { 1 } - std::exp(-dt / smoothing));
+}
+
+// =============================================================================
+// Wrapping and folding
+// =============================================================================
+
+/**
+ * @brief Wrap @p x into [lo, hi) with modulo semantics.
+ *
+ * Unlike std::fmod, handles negative values and arbitrary lo correctly.
+ * Equivalent to the GLSL mod() applied after shifting by lo.
+ *
+ * Example: wrap(-0.1F, 0.F, 1.F) -> 0.9F
+ */
+template <typename T>
+[[nodiscard]] inline T wrap(T x, T lo, T hi) noexcept
+{
+    const T range = hi - lo;
+    if (range <= T { 0 })
+        return lo;
+    return x - range * std::floor((x - lo) / range);
+}
+
+/**
+ * @brief Ping-pong (triangle wave): fold @p x back and forth in [lo, hi].
+ *
+ * At x = lo the value is lo. It increases to hi then folds back toward lo.
+ * Period is 2 * (hi - lo). Use for oscillating parameters, bounce animations,
+ * or any signal that should reverse at the boundary instead of wrapping.
+ *
+ * Example: ping_pong(1.3F, 0.F, 1.F) -> 0.7F
+ */
+template <typename T>
+[[nodiscard]] inline T ping_pong(T x, T lo, T hi) noexcept
+{
+    const T range = hi - lo;
+    if (range <= T { 0 })
+        return lo;
+    const T shifted = x - lo;
+    const T period = T { 2 } * range;
+    const T t = shifted - period * std::floor(shifted / period);
+    return lo + (t < range ? t : period - t);
+}
+
+// =============================================================================
+// Snapping
+// =============================================================================
+
+/**
+ * @brief Round @p x to the nearest multiple of @p step.
+ *
+ * std::round(x / step) * step but named. step must be > 0.
+ *
+ * Example: snap(0.73F, 0.25F) -> 0.75F
+ */
+template <typename T>
+[[nodiscard]] inline T snap(T x, T step) noexcept
+{
+    if (step <= T { 0 })
+        return x;
+    return std::round(x / step) * step;
+}
+
+/**
+ * @brief Snap @p x to the nearest multiple of @p step within [lo, hi].
+ */
+template <typename T>
+[[nodiscard]] inline T snap(T x, T lo, T hi, T step) noexcept
+{
+    return std::clamp(snap(x, step), lo, hi);
+}
+
+// =============================================================================
+// Easing
+// =============================================================================
+
+/**
+ * @brief Cubic ease-in: slow start, fast end.
+ * @param t Normalized time in [0, 1].
+ */
+template <typename T>
+[[nodiscard]] constexpr T ease_in(T t) noexcept
+{
+    return t * t * t;
+}
+
+/**
+ * @brief Cubic ease-out: fast start, slow end.
+ * @param t Normalized time in [0, 1].
+ */
+template <typename T>
+[[nodiscard]] constexpr T ease_out(T t) noexcept
+{
+    const T u = T { 1 } - t;
+    return T { 1 } - u * u * u;
+}
+
+/**
+ * @brief Cubic ease-in-out: slow start, fast middle, slow end.
+ * @param t Normalized time in [0, 1].
+ */
+template <typename T>
+[[nodiscard]] constexpr T ease_in_out(T t) noexcept
+{
+    return t < T { 0.5 }
+        ? T { 4 } * t * t * t
+        : T { 1 } - T { 4 } * (T { 1 } - t) * (T { 1 } - t) * (T { 1 } - t) * T { 0.5 };
+}
+
+// =============================================================================
+// Deadzone and sign
+// =============================================================================
+
+/**
+ * @brief Zero values within [-threshold, threshold] and rescale the remainder
+ *        to fill [0, 1] (or [-1, 1] for negative inputs).
+ *
+ * Standard controller/HID deadzone. Input and output are in [-1, 1].
+ * threshold must be in [0, 1).
+ *
+ * Example: deadzone(0.1F, 0.2F) -> 0.0F  (inside dead zone)
+ *          deadzone(0.6F, 0.2F) -> 0.5F  (rescaled from [0.2, 1.0] to [0, 1])
+ */
+template <typename T>
+[[nodiscard]] constexpr T deadzone(T x, T threshold) noexcept
+{
+    if (std::abs(x) <= threshold)
+        return T { 0 };
+    const T sign = x > T { 0 } ? T { 1 } : T { -1 };
+    return sign * (std::abs(x) - threshold) / (T { 1 } - threshold);
+}
+
+/**
+ * @brief Sign of @p x, returning -1 or +1, never 0.
+ *
+ * std::copysign(1, x) but readable. Useful when zero must be treated as
+ * positive (e.g. initial state of a direction accumulator).
+ */
+template <typename T>
+[[nodiscard]] constexpr T sign_nonzero(T x) noexcept
+{
+    return x < T { 0 } ? T { -1 } : T { 1 };
+}
+
+} // namespace MayaFlux::Kinesis

--- a/src/MayaFlux/Portal/Forma/Bridge.cpp
+++ b/src/MayaFlux/Portal/Forma/Bridge.cpp
@@ -159,23 +159,40 @@ void Bridge::write(uint32_t id, std::shared_ptr<Buffers::AudioWriteProcessor> ta
     auto name = make_task_name(id, "audio");
     it->second.outbound_tasks.push_back(name);
 
+    auto bulk = it->second.bulk_reader;
     auto reader = it->second.reader;
 
-    auto routine = [](Vruta::TaskScheduler&,
-                       std::function<float()> r,
-                       std::shared_ptr<Buffers::AudioWriteProcessor> proc)
-        -> Vruta::GraphicsRoutine {
-        auto& p = co_await Kriya::GetGraphicsPromise {};
-        while (!p.should_terminate) {
-            proc->set_data(std::vector<double> { static_cast<double>(r()) });
-            co_await Kriya::FrameDelay { .frames_to_wait = 1 };
-        }
-    };
-
-    m_scheduler.add_task(
-        std::make_shared<Vruta::GraphicsRoutine>(
-            routine(m_scheduler, std::move(reader), std::move(target))),
-        name, false);
+    if (bulk) {
+        auto routine = [](Vruta::TaskScheduler&,
+                           std::function<std::vector<float>()> b,
+                           std::shared_ptr<Buffers::AudioWriteProcessor> proc)
+            -> Vruta::GraphicsRoutine {
+            auto& p = co_await Kriya::GetGraphicsPromise {};
+            while (!p.should_terminate) {
+                proc->set_data(std::span<const float>(b()));
+                co_await Kriya::FrameDelay { .frames_to_wait = 1 };
+            }
+        };
+        m_scheduler.add_task(
+            std::make_shared<Vruta::GraphicsRoutine>(
+                routine(m_scheduler, std::move(bulk), std::move(target))),
+            name, false);
+    } else {
+        auto routine = [](Vruta::TaskScheduler&,
+                           std::function<float()> r,
+                           std::shared_ptr<Buffers::AudioWriteProcessor> proc)
+            -> Vruta::GraphicsRoutine {
+            auto& p = co_await Kriya::GetGraphicsPromise {};
+            while (!p.should_terminate) {
+                proc->set_data(std::vector<double> { static_cast<double>(r()) });
+                co_await Kriya::FrameDelay { .frames_to_wait = 1 };
+            }
+        };
+        m_scheduler.add_task(
+            std::make_shared<Vruta::GraphicsRoutine>(
+                routine(m_scheduler, std::move(reader), std::move(target))),
+            name, false);
+    }
 }
 
 void Bridge::write(uint32_t id, std::shared_ptr<Buffers::DataWriteProcessor> target)
@@ -190,23 +207,40 @@ void Bridge::write(uint32_t id, std::shared_ptr<Buffers::DataWriteProcessor> tar
     auto name = make_task_name(id, "geometry");
     it->second.outbound_tasks.push_back(name);
 
+    auto bulk = it->second.bulk_reader;
     auto reader = it->second.reader;
 
-    auto routine = [](Vruta::TaskScheduler&,
-                       std::function<float()> r,
-                       std::shared_ptr<Buffers::DataWriteProcessor> proc)
-        -> Vruta::GraphicsRoutine {
-        auto& p = co_await Kriya::GetGraphicsPromise {};
-        while (!p.should_terminate) {
-            proc->set_data(std::vector<Kakshya::DataVariant> { Kakshya::DataVariant { std::vector<float> { r() } } });
-            co_await Kriya::FrameDelay { .frames_to_wait = 1 };
-        }
-    };
-
-    m_scheduler.add_task(
-        std::make_shared<Vruta::GraphicsRoutine>(
-            routine(m_scheduler, std::move(reader), std::move(target))),
-        name, false);
+    if (bulk) {
+        auto routine = [](Vruta::TaskScheduler&,
+                           std::function<std::vector<float>()> b,
+                           std::shared_ptr<Buffers::DataWriteProcessor> proc)
+            -> Vruta::GraphicsRoutine {
+            auto& p = co_await Kriya::GetGraphicsPromise {};
+            while (!p.should_terminate) {
+                proc->set_data(Kakshya::DataVariant { b() });
+                co_await Kriya::FrameDelay { .frames_to_wait = 1 };
+            }
+        };
+        m_scheduler.add_task(
+            std::make_shared<Vruta::GraphicsRoutine>(
+                routine(m_scheduler, std::move(bulk), std::move(target))),
+            name, false);
+    } else {
+        auto routine = [](Vruta::TaskScheduler&,
+                           std::function<float()> r,
+                           std::shared_ptr<Buffers::DataWriteProcessor> proc)
+            -> Vruta::GraphicsRoutine {
+            auto& p = co_await Kriya::GetGraphicsPromise {};
+            while (!p.should_terminate) {
+                proc->set_data(std::vector<Kakshya::DataVariant> { Kakshya::DataVariant { std::vector<float> { r() } } });
+                co_await Kriya::FrameDelay { .frames_to_wait = 1 };
+            }
+        };
+        m_scheduler.add_task(
+            std::make_shared<Vruta::GraphicsRoutine>(
+                routine(m_scheduler, std::move(reader), std::move(target))),
+            name, false);
+    }
 }
 
 void Bridge::write(uint32_t id, std::shared_ptr<Nodes::Constant> node)

--- a/src/MayaFlux/Portal/Forma/Bridge.cpp
+++ b/src/MayaFlux/Portal/Forma/Bridge.cpp
@@ -274,6 +274,57 @@ void Bridge::write(uint32_t id, std::shared_ptr<Nodes::Constant> node)
         name, false);
 }
 
+void Bridge::write(uint32_t id, std::function<void(std::span<const float>)> sink)
+{
+    auto it = m_records.find(id);
+    if (it == m_records.end()) {
+        MF_ERROR(Journal::Component::Portal, Journal::Context::Init,
+            "Bridge::write: unknown element id {}", id);
+        return;
+    }
+
+    auto name = make_task_name(id, "bulk_sink");
+    it->second.outbound_tasks.push_back(name);
+
+    auto bulk = it->second.bulk_reader;
+    auto reader = it->second.reader;
+
+    if (bulk) {
+        auto routine = [](Vruta::TaskScheduler&,
+                           std::function<std::vector<float>()> b,
+                           std::function<void(std::span<const float>)> s)
+            -> Vruta::GraphicsRoutine {
+            auto& p = co_await Kriya::GetGraphicsPromise {};
+            while (!p.should_terminate) {
+                const auto v = b();
+                s(v);
+                co_await Kriya::FrameDelay { .frames_to_wait = 1 };
+            }
+        };
+        m_scheduler.add_task(
+            std::make_shared<Vruta::GraphicsRoutine>(
+                routine(m_scheduler, std::move(bulk), std::move(sink))),
+            name, false);
+    } else {
+        auto routine = [](Vruta::TaskScheduler&,
+                           std::function<float()> r,
+                           std::function<void(std::span<const float>)> s)
+            -> Vruta::GraphicsRoutine {
+            auto& p = co_await Kriya::GetGraphicsPromise {};
+            float val {};
+            while (!p.should_terminate) {
+                val = r();
+                s(std::span<const float> { &val, 1 });
+                co_await Kriya::FrameDelay { .frames_to_wait = 1 };
+            }
+        };
+        m_scheduler.add_task(
+            std::make_shared<Vruta::GraphicsRoutine>(
+                routine(m_scheduler, std::move(reader), std::move(sink))),
+            name, false);
+    }
+}
+
 // =============================================================================
 // Lifecycle
 // =============================================================================

--- a/src/MayaFlux/Portal/Forma/Bridge.hpp
+++ b/src/MayaFlux/Portal/Forma/Bridge.hpp
@@ -125,6 +125,13 @@ public:
         bind(state->id, std::move(source));
     }
 
+    template <typename T>
+    void write(std::shared_ptr<MappedState<T>> state,
+        std::function<void(std::span<const float>)> sink)
+    {
+        write(state->id, std::move(sink));
+    }
+
     // =========================================================================
     // Outbound — id overloads (primary implementation)
     // =========================================================================
@@ -187,6 +194,22 @@ public:
      * @param node Constant node updated each frame.
      */
     void write(uint32_t id, std::shared_ptr<Nodes::Constant> node);
+
+    /**
+     * @brief Route element bulk value to a caller-supplied sink each frame.
+     *
+     * When the element's MappedState<T> has a bulk_reader (T is vector<float>
+     * or vector<double>), the full vector is forwarded as a span. For scalar
+     * T the sink receives a single-element span of the scalar value.
+     *
+     * Intended for consumers that operate on coefficient arrays or other
+     * N-element state: FIR/IIR coefficient vectors, Random node bounds,
+     * any function accepting a contiguous float range.
+     *
+     * @param id   Element id.
+     * @param sink Callable invoked each frame with the current value span.
+     */
+    void write(uint32_t id, std::function<void(std::span<const float>)> sink);
 
     // =========================================================================
     // Outbound — MappedState overloads
@@ -428,6 +451,12 @@ public:
         Binding& write(std::shared_ptr<Nodes::Constant> node)
         {
             m_bridge.write(m_id, std::move(node));
+            return *this;
+        }
+
+        Binding& write(std::function<void(std::span<const float>)> sink)
+        {
+            m_bridge.write(m_id, std::move(sink));
             return *this;
         }
 

--- a/src/MayaFlux/Portal/Forma/Bridge.hpp
+++ b/src/MayaFlux/Portal/Forma/Bridge.hpp
@@ -273,6 +273,19 @@ public:
             reader = [] { return 0.F; };
         }
 
+        std::function<std::vector<float>()> bulk_reader;
+        if constexpr (std::is_same_v<T, std::vector<float>>) {
+            bulk_reader = [s = state] { return s->value; };
+        } else if constexpr (std::is_same_v<T, std::vector<double>>) {
+            bulk_reader = [s = state] {
+                std::vector<float> out;
+                out.reserve(s->value.size());
+                for (double v : s->value)
+                    out.push_back(static_cast<float>(v));
+                return out;
+            };
+        }
+
         std::function<void(float)> writer;
         if constexpr (std::is_convertible_v<float, T>) {
             writer = [s = state](float v) {
@@ -287,6 +300,7 @@ public:
             .buffer = std::move(buffer),
             .bindings = nullptr,
             .reader = std::move(reader),
+            .bulk_reader = std::move(bulk_reader),
             .writer = std::move(writer),
             .inbound_task = {},
             .outbound_tasks = {},
@@ -470,6 +484,7 @@ private:
         std::shared_ptr<Buffers::FormaBuffer> buffer;
         std::shared_ptr<Buffers::FormaBindingsProcessor> bindings;
         std::function<float()> reader; ///< reads current value from MappedState (outbound)
+        std::function<std::vector<float>()> bulk_reader; ///< populated for vector<float>/vector<double> T
         std::function<void(float)> writer; ///< writes new value into MappedState (inbound)
         std::string inbound_task;
         std::vector<std::string> outbound_tasks;

--- a/src/MayaFlux/Portal/Forma/Context.cpp
+++ b/src/MayaFlux/Portal/Forma/Context.cpp
@@ -43,6 +43,11 @@ void Context::on_move(uint32_t id, MoveFn fn)
     m_callbacks[id].move = std::move(fn);
 }
 
+void Context::on_drag(uint32_t id, IO::MouseButtons btn, MoveFn fn)
+{
+    m_callbacks[id].drag[static_cast<int>(btn)] = std::move(fn);
+}
+
 void Context::on_enter(uint32_t id, EnterFn fn)
 {
     m_callbacks[id].enter = std::move(fn);
@@ -106,6 +111,18 @@ void Context::register_handlers()
 
     m_event_manager.add_event(
         std::make_shared<Vruta::Event>(
+            Kriya::mouse_dragged(m_window, IO::MouseButtons::Left,
+                [this](double px, double py) { handle_drag(px, py, IO::MouseButtons::Left); })),
+        m_name + "_drag_left");
+
+    m_event_manager.add_event(
+        std::make_shared<Vruta::Event>(
+            Kriya::mouse_dragged(m_window, IO::MouseButtons::Right,
+                [this](double px, double py) { handle_drag(px, py, IO::MouseButtons::Right); })),
+        m_name + "_drag_right");
+
+    m_event_manager.add_event(
+        std::make_shared<Vruta::Event>(
             Kriya::mouse_scrolled(m_window,
                 [this](double dx, double dy) { handle_scroll(dx, dy); })),
         m_name + "_scroll");
@@ -117,7 +134,8 @@ void Context::cancel_handlers()
              "_move",
              "_press_left", "_release_left",
              "_press_right", "_release_right",
-             "_scroll" }) {
+             "_scroll",
+             "_drag_left", "_drag_right" }) {
         m_event_manager.cancel_event(m_name + suffix);
     }
 }
@@ -191,6 +209,20 @@ void Context::handle_release(double px, double py, IO::MouseButtons btn)
     auto btn_it = it->second.release.find(static_cast<int>(btn));
     if (btn_it != it->second.release.end() && btn_it->second)
         btn_it->second(*hit, ndc);
+}
+
+void Context::handle_drag(double px, double py, IO::MouseButtons btn)
+{
+    const glm::vec2 ndc = to_ndc(px, py);
+    const auto hit = m_layer->hit_test(ndc);
+    if (!hit)
+        return;
+    auto it = m_callbacks.find(*hit);
+    if (it == m_callbacks.end())
+        return;
+    auto drag_it = it->second.drag.find(static_cast<int>(btn));
+    if (drag_it != it->second.drag.end() && drag_it->second)
+        drag_it->second(*hit, ndc);
 }
 
 void Context::handle_scroll(double dx, double dy)

--- a/src/MayaFlux/Portal/Forma/Context.cpp
+++ b/src/MayaFlux/Portal/Forma/Context.cpp
@@ -1,5 +1,7 @@
 #include "Context.hpp"
 
+#include "Primitives/Mapped.hpp"
+
 #include "MayaFlux/Core/Backends/Windowing/Window.hpp"
 #include "MayaFlux/Kriya/InputEvents.hpp"
 #include "MayaFlux/Vruta/EventManager.hpp"
@@ -147,6 +149,26 @@ const Vruta::WindowEventSource& Context::event_source() const
 {
     return m_window->get_event_source();
 }
+
+Context& Context::key_step(
+    uint32_t id,
+    std::shared_ptr<MappedState<float>> state,
+    IO::Keys decrease,
+    IO::Keys increase,
+    float delta,
+    float clamp_min,
+    float clamp_max)
+{
+    on_held(id, decrease, [state, delta, clamp_min, clamp_max](uint32_t) {
+        state->write(std::clamp(state->value - delta, clamp_min, clamp_max));
+    });
+
+    on_held(id, increase, [state, delta, clamp_min, clamp_max](uint32_t) {
+        state->write(std::clamp(state->value + delta, clamp_min, clamp_max));
+    });
+
+    return *this;
+} 
 
 // =============================================================================
 // Handler registration / cancellation

--- a/src/MayaFlux/Portal/Forma/Context.cpp
+++ b/src/MayaFlux/Portal/Forma/Context.cpp
@@ -63,8 +63,83 @@ void Context::on_scroll(uint32_t id, ScrollFn fn)
     m_callbacks[id].scroll = std::move(fn);
 }
 
+void Context::on_press(uint32_t id, IO::Keys key, KeyFn fn)
+{
+    const int key_code = static_cast<int>(key);
+    m_callbacks[id].key_press[key_code] = std::move(fn);
+
+    if (!m_registered_keys[key_code].has_press) {
+        const std::string key_name = std::to_string(key_code);
+        m_event_manager.add_event(
+            std::make_shared<Vruta::Event>(
+                Kriya::key_pressed(m_window, key,
+                    [this, key]() { handle_key_press(key); })),
+            m_name + "_key_press_" + key_name);
+        m_registered_keys[key_code].has_press = true;
+    }
+}
+
+void Context::on_release(uint32_t id, IO::Keys key, KeyFn fn)
+{
+    const int key_code = static_cast<int>(key);
+    m_callbacks[id].key_release[key_code] = std::move(fn);
+
+    if (!m_registered_keys[key_code].has_release) {
+        const std::string key_name = std::to_string(key_code);
+        m_event_manager.add_event(
+            std::make_shared<Vruta::Event>(
+                Kriya::key_released(m_window, key,
+                    [this, key]() { handle_key_release(key); })),
+            m_name + "_key_release_" + key_name);
+        m_registered_keys[key_code].has_release = true;
+    }
+}
+
+void Context::on_held(uint32_t id, IO::Keys key, KeyFn fn)
+{
+    const int key_code = static_cast<int>(key);
+    m_callbacks[id].key_held[key_code] = std::move(fn);
+
+    if (!m_registered_keys[key_code].has_held) {
+        const std::string key_name = std::to_string(key_code);
+        m_event_manager.add_event(
+            std::make_shared<Vruta::Event>(
+                Kriya::key_held(m_window, key,
+                    [this, key]() { handle_key_held(key); })),
+            m_name + "_key_held_" + key_name);
+        m_registered_keys[key_code].has_held = true;
+    }
+}
+
+void Context::on_focus_gained(uint32_t id, EnterFn fn)
+{
+    m_callbacks[id].focus_gained = std::move(fn);
+}
+
+void Context::on_focus_lost(uint32_t id, LeaveFn fn)
+{
+    m_callbacks[id].focus_lost = std::move(fn);
+}
+
+void Context::clear_focus()
+{
+    if (m_focused) {
+        auto it = m_callbacks.find(*m_focused);
+        if (it != m_callbacks.end() && it->second.focus_lost)
+            it->second.focus_lost(*m_focused);
+        m_focused = std::nullopt;
+    }
+}
+
 void Context::unbind(uint32_t id)
 {
+    if (m_focused && *m_focused == id) {
+        auto it = m_callbacks.find(id);
+        if (it != m_callbacks.end() && it->second.focus_lost)
+            it->second.focus_lost(id);
+        m_focused = std::nullopt;
+    }
+
     m_callbacks.erase(id);
 }
 
@@ -138,6 +213,16 @@ void Context::cancel_handlers()
              "_drag_left", "_drag_right" }) {
         m_event_manager.cancel_event(m_name + suffix);
     }
+
+    for (const auto& [key_code, handlers] : m_registered_keys) {
+        const std::string key_name = std::to_string(key_code);
+        if (handlers.has_press)
+            m_event_manager.cancel_event(m_name + "_key_press_" + key_name);
+        if (handlers.has_release)
+            m_event_manager.cancel_event(m_name + "_key_release_" + key_name);
+        if (handlers.has_held)
+            m_event_manager.cancel_event(m_name + "_key_held_" + key_name);
+    }
 }
 
 // =============================================================================
@@ -186,6 +271,22 @@ void Context::handle_press(double px, double py, IO::MouseButtons btn)
 
     const int btn_idx = static_cast<int>(btn);
 
+    if (hit != m_focused) {
+        if (m_focused) {
+            auto it = m_callbacks.find(*m_focused);
+            if (it != m_callbacks.end() && it->second.focus_lost)
+                it->second.focus_lost(*m_focused);
+        }
+
+        m_focused = hit;
+
+        if (hit) {
+            auto it = m_callbacks.find(*hit);
+            if (it != m_callbacks.end() && it->second.focus_gained)
+                it->second.focus_gained(*hit);
+        }
+    }
+
     if (hit && m_callbacks.contains(*hit) && m_callbacks[*hit].drag.contains(btn_idx)) {
         m_dragging[btn_idx] = hit;
     }
@@ -199,6 +300,9 @@ void Context::handle_press(double px, double py, IO::MouseButtons btn)
 
 void Context::handle_release(double px, double py, IO::MouseButtons btn)
 {
+    const int btn_idx = static_cast<int>(btn);
+    m_dragging[btn_idx] = std::nullopt;
+
     const glm::vec2 ndc = to_ndc(px, py);
     const auto hit = m_layer->hit_test(ndc);
     if (!hit)
@@ -242,6 +346,55 @@ void Context::handle_scroll(double dx, double dy)
 
     const auto [px, py] = m_window->get_event_source().get_mouse_position();
     it->second.scroll(*m_hovered, to_ndc(px, py), dx, dy);
+}
+
+// =============================================================================
+// Keyboard event dispatch
+// =============================================================================
+
+void Context::handle_key_press(IO::Keys key)
+{
+    if (!m_focused)
+        return;
+
+    auto it = m_callbacks.find(*m_focused);
+    if (it == m_callbacks.end())
+        return;
+
+    const int key_code = static_cast<int>(key);
+    auto key_it = it->second.key_press.find(key_code);
+    if (key_it != it->second.key_press.end())
+        key_it->second(*m_focused);
+}
+
+void Context::handle_key_release(IO::Keys key)
+{
+    if (!m_focused)
+        return;
+
+    auto it = m_callbacks.find(*m_focused);
+    if (it == m_callbacks.end())
+        return;
+
+    const int key_code = static_cast<int>(key);
+    auto key_it = it->second.key_release.find(key_code);
+    if (key_it != it->second.key_release.end())
+        key_it->second(*m_focused);
+}
+
+void Context::handle_key_held(IO::Keys key)
+{
+    if (!m_focused)
+        return;
+
+    auto it = m_callbacks.find(*m_focused);
+    if (it == m_callbacks.end())
+        return;
+
+    const int key_code = static_cast<int>(key);
+    auto key_it = it->second.key_held.find(key_code);
+    if (key_it != it->second.key_held.end())
+        key_it->second(*m_focused);
 }
 
 } // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Context.cpp
+++ b/src/MayaFlux/Portal/Forma/Context.cpp
@@ -183,16 +183,18 @@ void Context::handle_press(double px, double py, IO::MouseButtons btn)
 {
     const glm::vec2 ndc = to_ndc(px, py);
     const auto hit = m_layer->hit_test(ndc);
-    if (!hit)
-        return;
 
-    auto it = m_callbacks.find(*hit);
-    if (it == m_callbacks.end())
-        return;
+    const int btn_idx = static_cast<int>(btn);
 
-    auto btn_it = it->second.press.find(static_cast<int>(btn));
-    if (btn_it != it->second.press.end() && btn_it->second)
-        btn_it->second(*hit, ndc);
+    if (hit && m_callbacks.contains(*hit) && m_callbacks[*hit].drag.contains(btn_idx)) {
+        m_dragging[btn_idx] = hit;
+    }
+
+    if (hit) {
+        auto it = m_callbacks.find(*hit);
+        if (it != m_callbacks.end() && it->second.press.count(btn_idx))
+            it->second.press[btn_idx](*hit, ndc);
+    }
 }
 
 void Context::handle_release(double px, double py, IO::MouseButtons btn)
@@ -214,15 +216,19 @@ void Context::handle_release(double px, double py, IO::MouseButtons btn)
 void Context::handle_drag(double px, double py, IO::MouseButtons btn)
 {
     const glm::vec2 ndc = to_ndc(px, py);
-    const auto hit = m_layer->hit_test(ndc);
-    if (!hit)
-        return;
-    auto it = m_callbacks.find(*hit);
-    if (it == m_callbacks.end())
-        return;
-    auto drag_it = it->second.drag.find(static_cast<int>(btn));
-    if (drag_it != it->second.drag.end() && drag_it->second)
-        drag_it->second(*hit, ndc);
+    const int btn_idx = static_cast<int>(btn);
+
+    if (!m_dragging[btn_idx]) {
+        const auto hit = m_layer->hit_test(ndc);
+        if (hit)
+            m_dragging[btn_idx] = hit;
+        else
+            return;
+    }
+
+    auto it = m_callbacks.find(*m_dragging[btn_idx]);
+    if (it != m_callbacks.end() && it->second.drag.count(btn_idx))
+        it->second.drag[btn_idx](*m_dragging[btn_idx], ndc);
 }
 
 void Context::handle_scroll(double dx, double dy)

--- a/src/MayaFlux/Portal/Forma/Context.hpp
+++ b/src/MayaFlux/Portal/Forma/Context.hpp
@@ -41,6 +41,7 @@ public:
     using EnterFn = std::function<void(uint32_t id)>;
     using LeaveFn = std::function<void(uint32_t id)>;
     using ScrollFn = std::function<void(uint32_t id, glm::vec2 ndc, double dx, double dy)>;
+    using KeyFn = std::function<void(uint32_t id)>;
 
     /**
      * @brief Construct and immediately register event coroutines.
@@ -128,6 +129,60 @@ public:
      */
     void unbind(uint32_t id);
 
+    /**
+     * @brief Called when a key is pressed while the element has focus.
+     *
+     * Focus is transferred on mouse press. The callback fires only once per
+     * key press, even if the key is held.
+     *
+     * @param id  Element id to bind to.
+     * @param key The key to listen for.
+     * @param fn  Callback receiving element id.
+     */
+    void on_press(uint32_t id, IO::Keys key, KeyFn fn);
+
+    /**
+     * @brief Called when a key is released while the element has focus.
+     *
+     * @param id  Element id to bind to.
+     * @param key The key to listen for.
+     * @param fn  Callback receiving element id.
+     */
+    void on_release(uint32_t id, IO::Keys key, KeyFn fn);
+
+    /**
+     * @brief Called repeatedly while a key is held and the element has focus.
+     *
+     * Fires on initial press and continues on each repeat tick until the key
+     * is released. Useful for continuous adjustments (arrow key nudging,
+     * value increments) without requiring the user to repeatedly press.
+     *
+     * @param id  Element id to bind to.
+     * @param key The key to listen for.
+     * @param fn  Callback receiving element id, fired on press and each repeat.
+     */
+    void on_held(uint32_t id, IO::Keys key, KeyFn fn);
+
+    /**
+     * @brief Called once when an element gains keyboard focus (via click).
+     */
+    void on_focus_gained(uint32_t id, EnterFn fn);
+
+    /**
+     * @brief Called once when an element loses keyboard focus.
+     */
+    void on_focus_lost(uint32_t id, LeaveFn fn);
+
+    /**
+     * @brief Clear keyboard focus (no element focused).
+     */
+    void clear_focus();
+
+    /**
+     * @brief Get currently focused element, if any.
+     */
+    [[nodiscard]] std::optional<uint32_t> focused() const { return m_focused; }
+
     // =========================================================================
     // State query
     // =========================================================================
@@ -141,11 +196,25 @@ private:
         std::unordered_map<int, PressFn> press;
         std::unordered_map<int, PressFn> release;
         std::unordered_map<int, MoveFn> drag;
+        std::unordered_map<int, KeyFn> key_press;
+        std::unordered_map<int, KeyFn> key_release;
+        std::unordered_map<int, KeyFn> key_held;
+
         MoveFn move;
         EnterFn enter;
         LeaveFn leave;
         ScrollFn scroll;
+
+        EnterFn focus_gained;
+        LeaveFn focus_lost;
     };
+
+    struct KeyHandlerState {
+        bool has_press = false;
+        bool has_release = false;
+        bool has_held = false;
+    };
+    std::unordered_map<int, KeyHandlerState> m_registered_keys;
 
     std::shared_ptr<Layer> m_layer;
     std::shared_ptr<Core::Window> m_window;
@@ -165,8 +234,12 @@ private:
     void handle_release(double px, double py, IO::MouseButtons btn);
     void handle_scroll(double dx, double dy);
     void handle_drag(double px, double py, IO::MouseButtons btn);
+    void handle_key_press(IO::Keys key);
+    void handle_key_release(IO::Keys key);
+    void handle_key_held(IO::Keys key);
 
     std::optional<uint32_t> m_dragging[3];
+    std::optional<uint32_t> m_focused;
 };
 
 } // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Context.hpp
+++ b/src/MayaFlux/Portal/Forma/Context.hpp
@@ -88,16 +88,23 @@ public:
     void on_move(uint32_t id, MoveFn fn);
 
     /**
-     * @brief Called on each mouse-move event while @p btn is held, if the
-     *        cursor is over @p id at the time of the event.
+     * @brief Called on each mouse-move event while @p btn is held, tracking
+     *        the element where the drag began even when the cursor leaves its bounds.
+     *
+     * Drag tracking begins when the element is first hit (either at initial press
+     * or first drag motion while button is held). Once tracking starts, the callback
+     * continues to fire with the current cursor position until the button is released,
+     * regardless of whether the cursor remains over the element.
+     *
+     * This matches standard UI expectations for sliders, scrollbars, resize handles,
+     * and other controls that must respond continuously during a drag gesture.
      *
      * Backed by Kriya::mouse_dragged, which gates on button state natively.
-     * For controls that must respond to drag after the cursor leaves the
-     * element, use on_press + on_move with a captured flag instead.
      *
      * @param id  Element id to bind to.
      * @param btn Mouse button that must be held.
-     * @param fn  Callback receiving element id and current NDC cursor position.
+     * @param fn  Callback receiving element id and current NDC cursor position
+     *            (which may be outside the element's bounds during drag).
      */
     void on_drag(uint32_t id, IO::MouseButtons btn, MoveFn fn);
 
@@ -158,6 +165,8 @@ private:
     void handle_release(double px, double py, IO::MouseButtons btn);
     void handle_scroll(double dx, double dy);
     void handle_drag(double px, double py, IO::MouseButtons btn);
+
+    std::optional<uint32_t> m_dragging[3];
 };
 
 } // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Context.hpp
+++ b/src/MayaFlux/Portal/Forma/Context.hpp
@@ -88,6 +88,20 @@ public:
     void on_move(uint32_t id, MoveFn fn);
 
     /**
+     * @brief Called on each mouse-move event while @p btn is held, if the
+     *        cursor is over @p id at the time of the event.
+     *
+     * Backed by Kriya::mouse_dragged, which gates on button state natively.
+     * For controls that must respond to drag after the cursor leaves the
+     * element, use on_press + on_move with a captured flag instead.
+     *
+     * @param id  Element id to bind to.
+     * @param btn Mouse button that must be held.
+     * @param fn  Callback receiving element id and current NDC cursor position.
+     */
+    void on_drag(uint32_t id, IO::MouseButtons btn, MoveFn fn);
+
+    /**
      * @brief Called once when the cursor enters an element's region.
      */
     void on_enter(uint32_t id, EnterFn fn);
@@ -119,6 +133,7 @@ private:
     struct ElementCallbacks {
         std::unordered_map<int, PressFn> press;
         std::unordered_map<int, PressFn> release;
+        std::unordered_map<int, MoveFn> drag;
         MoveFn move;
         EnterFn enter;
         LeaveFn leave;
@@ -142,6 +157,7 @@ private:
     void handle_press(double px, double py, IO::MouseButtons btn);
     void handle_release(double px, double py, IO::MouseButtons btn);
     void handle_scroll(double dx, double dy);
+    void handle_drag(double px, double py, IO::MouseButtons btn);
 };
 
 } // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Context.hpp
+++ b/src/MayaFlux/Portal/Forma/Context.hpp
@@ -15,6 +15,9 @@ class WindowEventSource;
 
 namespace MayaFlux::Portal::Forma {
 
+template <typename T>
+struct MappedState;
+
 /**
  * @class Context
  * @brief Event wiring between a Layer and a window surface.
@@ -182,6 +185,30 @@ public:
      * @brief Get currently focused element, if any.
      */
     [[nodiscard]] std::optional<uint32_t> focused() const { return m_focused; }
+
+    /**
+     * @brief Attach key-delta handlers to a Mapped<float> element.
+     *
+     * Binds key handlers that adjust the element's state by a delta on each
+     * press/hold. The element must be focused (via mouse click) for keys to fire.
+     *
+     * @param id          Element id.
+     * @param state       MappedState to adjust.
+     * @param decrease    Key that decreases the value.
+     * @param increase    Key that increases the value.
+     * @param delta       Step size per key event.
+     * @param clamp_min   Minimum clamped value (default 0.0F).
+     * @param clamp_max   Maximum clamped value (default 1.0F).
+     * @return *this for chaining.
+     */
+    Context& key_step(
+        uint32_t id,
+        std::shared_ptr<MappedState<float>> state,
+        IO::Keys decrease,
+        IO::Keys increase,
+        float delta,
+        float clamp_min = 0.0F,
+        float clamp_max = 1.0F);
 
     // =========================================================================
     // State query

--- a/src/MayaFlux/Portal/Forma/Forma.cpp
+++ b/src/MayaFlux/Portal/Forma/Forma.cpp
@@ -35,6 +35,65 @@ namespace {
     constexpr uint32_t k_inspect_w = 480;
     constexpr uint32_t k_inspect_h = 900;
 
+    constexpr size_t k_text_label_capacity = static_cast<size_t>(6) * sizeof(Kakshya::MeshVertex);
+    constexpr size_t k_rect_capacity = static_cast<size_t>(4) * sizeof(Kakshya::Vertex);
+
+    void place_plot_adornments(
+        Surface& surface,
+        const Plot::SeriesSpec& spec,
+        uint32_t relate_to)
+    {
+        const auto& win = surface.window();
+
+        for (const auto& label : spec.labels) {
+            auto buf = internal::create_buffer_impl(
+                win,
+                k_text_label_capacity,
+                Graphics::PrimitiveTopology::TRIANGLE_LIST,
+                {},
+                { { "text", nullptr } });
+
+            (void)Plot::place_label(surface, std::move(buf), label, relate_to);
+        }
+
+        for (const auto& ticks : spec.tick_labels) {
+            for (const auto& label : Plot::plot_tick_labels(ticks)) {
+                auto buf = internal::create_buffer_impl(
+                    win,
+                    k_text_label_capacity,
+                    Graphics::PrimitiveTopology::TRIANGLE_LIST,
+                    {},
+                    { { "text", nullptr } });
+
+                (void)Plot::place_label(surface, std::move(buf), label, relate_to);
+            }
+        }
+
+        if (spec.legend) {
+            auto layout = Plot::layout_legend(*spec.legend);
+
+            for (const auto& swatch : layout.swatches) {
+                auto buf = internal::create_buffer_impl(
+                    win,
+                    k_rect_capacity,
+                    Graphics::PrimitiveTopology::TRIANGLE_STRIP);
+
+                (void)Plot::place_rect(surface, std::move(buf), swatch, relate_to);
+            }
+
+            for (const auto& label : layout.labels) {
+                auto buf = internal::create_buffer_impl(
+                    win,
+                    k_text_label_capacity,
+                    Graphics::PrimitiveTopology::TRIANGLE_LIST,
+                    {},
+                    { { "text", nullptr } });
+
+                (void)Plot::place_label(surface, std::move(buf), label, relate_to);
+            }
+        }
+    }
+
 } // namespace
 
 namespace internal {
@@ -210,17 +269,23 @@ plot(
             Graphics::PrimitiveTopology::TRIANGLE_STRIP,
             static_cast<size_t>(4) * Kakshya::VertexLayout::for_meshes().stride_bytes);
 
-        auto bg_id = bg.element.id;
+        const auto bg_id = bg.element.id;
         auto buf = internal::create_buffer_impl(window, spec.capacity_for(N), spec.topology);
-        auto mapped = Plot::place(surface, std::move(buf), std::move(spec), std::move(container));
+        auto mapped = Plot::place(surface, std::move(buf), spec, std::move(container));
         surface.layer().relate(mapped.element.id, bg_id);
         surface.layer().send_to_back(bg_id);
+
+        place_plot_adornments(surface, spec, mapped.element.id);
+
         return { std::move(mapped), std::move(surface) };
     }
 
     auto buf = internal::create_buffer_impl(window, spec.capacity_for(N), spec.topology);
+    auto mapped = Plot::place(surface, std::move(buf), spec, std::move(container));
 
-    return { Plot::place(surface, std::move(buf), std::move(spec), std::move(container)), std::move(surface) };
+    place_plot_adornments(surface, spec, mapped.element.id);
+
+    return { std::move(mapped), std::move(surface) };
 }
 
 // =============================================================================

--- a/src/MayaFlux/Portal/Forma/Layer.cpp
+++ b/src/MayaFlux/Portal/Forma/Layer.cpp
@@ -210,13 +210,10 @@ Element* Layer::get(uint32_t id)
 // Internal
 // =============================================================================
 
-glm::vec2 Layer::to_ndc(
-    double px, double py, uint32_t win_w, uint32_t win_h) noexcept
+glm::vec2 Layer::to_ndc(double px, double py, uint32_t w, uint32_t h) noexcept
 {
-    return {
-        (static_cast<float>(px) / static_cast<float>(win_w)) * 2.0F - 1.0F,
-        1.0F - (static_cast<float>(py) / static_cast<float>(win_h)) * 2.0F
-    };
+    auto ndc3 = Kinesis::to_ndc(px, py, w, h);
+    return { ndc3.x, ndc3.y };
 }
 
 bool Layer::test_element(const Element& el, glm::vec2 ndc) noexcept

--- a/src/MayaFlux/Portal/Forma/Plot/Plot.cpp
+++ b/src/MayaFlux/Portal/Forma/Plot/Plot.cpp
@@ -8,26 +8,6 @@
 
 namespace MayaFlux::Portal::Forma::Plot {
 
-namespace {
-
-    glm::uvec2 bounds_to_pixels(
-        const std::shared_ptr<Core::Window>& window,
-        Kinesis::AABB2D bounds)
-    {
-        const auto& ws = window->get_state();
-        const auto w = static_cast<uint32_t>(
-            std::max(bounds.width(), 0.001F)
-            * 0.5F
-            * static_cast<float>(ws.current_width));
-        const auto h = static_cast<uint32_t>(
-            std::max(bounds.height(), 0.001F)
-            * 0.5F
-            * static_cast<float>(ws.current_height));
-        return { std::max(w, 1U), std::max(h, 1U) };
-    }
-
-} // namespace
-
 // =============================================================================
 // place_label
 // =============================================================================
@@ -40,7 +20,10 @@ uint32_t place_label(
 {
     const auto render_bounds = spec.render_bounds.x > 0 && spec.render_bounds.y > 0
         ? spec.render_bounds
-        : bounds_to_pixels(surface.window(), spec.bounds);
+        : Kinesis::ndc_size_to_pixels(
+              { spec.bounds.width(), spec.bounds.height() },
+              surface.window()->get_state().current_width,
+              surface.window()->get_state().current_height);
 
     Element el;
     el.with_buffer(std::move(buf))

--- a/src/MayaFlux/Portal/Forma/Plot/Plot.cpp
+++ b/src/MayaFlux/Portal/Forma/Plot/Plot.cpp
@@ -1,10 +1,99 @@
 #include "Plot.hpp"
 
+#include "MayaFlux/Core/Backends/Windowing/Window.hpp"
+#include "MayaFlux/Kinesis/GeometryPrimitives.hpp"
 #include "MayaFlux/Portal/Forma/Plot/SeriesBuilder.hpp"
-
 #include "MayaFlux/Portal/Forma/Surface.hpp"
+#include "MayaFlux/Portal/Text/InkPress.hpp"
 
 namespace MayaFlux::Portal::Forma::Plot {
+
+namespace {
+
+    glm::uvec2 bounds_to_pixels(
+        const std::shared_ptr<Core::Window>& window,
+        Kinesis::AABB2D bounds)
+    {
+        const auto& ws = window->get_state();
+        const auto w = static_cast<uint32_t>(
+            std::max(bounds.width(), 0.001F)
+            * 0.5F
+            * static_cast<float>(ws.current_width));
+        const auto h = static_cast<uint32_t>(
+            std::max(bounds.height(), 0.001F)
+            * 0.5F
+            * static_cast<float>(ws.current_height));
+        return { std::max(w, 1U), std::max(h, 1U) };
+    }
+
+} // namespace
+
+// =============================================================================
+// place_label
+// =============================================================================
+
+uint32_t place_label(
+    Surface& surface,
+    std::shared_ptr<Buffers::FormaBuffer> buf,
+    const LabelSpec& spec,
+    uint32_t relate_to)
+{
+    const auto render_bounds = spec.render_bounds.x > 0 && spec.render_bounds.y > 0
+        ? spec.render_bounds
+        : bounds_to_pixels(surface.window(), spec.bounds);
+
+    Element el;
+    el.with_buffer(std::move(buf))
+        .with_bounds(spec.bounds)
+        .with_name(spec.name)
+        .with_text(spec.text,
+            Portal::Text::PressParams {
+                .color = spec.color,
+                .render_bounds = render_bounds,
+            },
+            spec.bounds);
+
+    if (!spec.interactive)
+        el.non_interactive();
+
+    const uint32_t id = surface.layer().add(std::move(el));
+    if (relate_to != 0)
+        surface.layer().relate(relate_to, id);
+
+    return id;
+}
+
+// =============================================================================
+// place_rect
+// =============================================================================
+
+uint32_t place_rect(
+    Surface& surface,
+    std::shared_ptr<Buffers::FormaBuffer> buf,
+    const RectSpec& spec,
+    uint32_t relate_to)
+{
+    const auto verts = Kinesis::filled_rect(spec.bounds, spec.color);
+    buf->submit(verts);
+
+    Element el;
+    el.with_buffer(std::move(buf))
+        .with_bounds(spec.bounds)
+        .with_name(spec.name);
+
+    if (!spec.interactive)
+        el.non_interactive();
+
+    const uint32_t id = surface.layer().add(std::move(el));
+    if (relate_to != 0)
+        surface.layer().relate(relate_to, id);
+
+    return id;
+}
+
+// =============================================================================
+// place
+// =============================================================================
 
 Mapped<std::shared_ptr<Kakshya::PlotContainer>> place(
     Surface& surface,
@@ -13,12 +102,13 @@ Mapped<std::shared_ptr<Kakshya::PlotContainer>> place(
     std::shared_ptr<Kakshya::PlotContainer> container)
 {
     auto mapped = make_mapped<std::shared_ptr<Kakshya::PlotContainer>>(
-        container, std::move(spec.fn), std::move(buf));
+        std::move(container), std::move(spec.fn), std::move(buf));
 
     mapped.element.id = surface.layer().add(mapped.element);
     mapped.state->id = mapped.element.id;
     mapped.force_redraw_on_sync = true;
     mapped.sync();
+
     return mapped;
 }
 

--- a/src/MayaFlux/Portal/Forma/Plot/Plot.hpp
+++ b/src/MayaFlux/Portal/Forma/Plot/Plot.hpp
@@ -46,6 +46,43 @@ namespace MayaFlux::Portal::Forma::Plot {
         std::shared_ptr<Kakshya::PlotContainer> container);
 
 /**
+ * @brief Place a text label element onto @p surface using a pre-built buffer.
+ *
+ * @p buf must have been created with an additional_textures slot named "text"
+ * (or equivalent). Buffer construction is the caller's responsibility;
+ * Portal::Forma::plot() handles this automatically.
+ *
+ * @param surface    Target surface.
+ * @param buf        FormaBuffer with a texture slot. One buffer per label.
+ * @param spec       Label geometry and style.
+ * @param relate_to  If non-zero, the produced element is related to this id.
+ * @return           Element id of the produced label element.
+ */
+[[nodiscard]] MAYAFLUX_API uint32_t place_label(
+    Surface& surface,
+    std::shared_ptr<Buffers::FormaBuffer> buf,
+    const LabelSpec& spec,
+    uint32_t relate_to = 0);
+
+/**
+ * @brief Place a filled rectangle element onto @p surface using a pre-built buffer.
+ *
+ * @p buf must be a plain TRIANGLE_STRIP FormaBuffer with no texture slot.
+ * Buffer construction is the caller's responsibility.
+ *
+ * @param surface    Target surface.
+ * @param buf        FormaBuffer sized for 4 vertices.
+ * @param spec       Rectangle geometry and color.
+ * @param relate_to  If non-zero, the produced element is related to this id.
+ * @return           Element id of the produced rect element.
+ */
+[[nodiscard]] MAYAFLUX_API uint32_t place_rect(
+    Surface& surface,
+    std::shared_ptr<Buffers::FormaBuffer> buf,
+    const RectSpec& spec,
+    uint32_t relate_to = 0);
+
+/**
  * @brief Begin a Series chain.
  *
  * Convenience constructor for GeometryFn<shared_ptr<PlotContainer>>.

--- a/src/MayaFlux/Portal/Forma/Plot/PlotSpec.cpp
+++ b/src/MayaFlux/Portal/Forma/Plot/PlotSpec.cpp
@@ -1,6 +1,7 @@
 #include "PlotSpec.hpp"
 
 #include "MayaFlux/Kakshya/Source/PlotContainer.hpp"
+#include "MayaFlux/Portal/Forma/Primitives/Geometry.hpp"
 
 namespace MayaFlux::Portal::Forma::Plot {
 
@@ -136,6 +137,81 @@ GeometryFn<float> background(
         }
 
         el.bounds_hint = bounds;
+    };
+}
+
+std::vector<Kakshya::LineVertex> plot_grid(
+    Kinesis::AABB2D bounds,
+    uint32_t x_divisions,
+    uint32_t y_divisions,
+    glm::vec3 color,
+    float thickness)
+{
+    std::vector<Kakshya::LineVertex> out;
+    out.reserve((static_cast<size_t>(x_divisions + y_divisions)) * 2);
+
+    auto lv = [&](glm::vec2 p) {
+        return Kakshya::LineVertex {
+            .position = { p.x, p.y, 0.F },
+            .color = color,
+            .thickness = thickness,
+        };
+    };
+
+    for (uint32_t i = 0; i < x_divisions; ++i) {
+        const float t = (x_divisions > 1)
+            ? static_cast<float>(i) / static_cast<float>(x_divisions - 1)
+            : 0.5F;
+        const float x = bounds.min.x + t * bounds.width();
+        out.push_back(lv({ x, bounds.min.y }));
+        out.push_back(lv({ x, bounds.max.y }));
+    }
+
+    for (uint32_t i = 0; i < y_divisions; ++i) {
+        const float t = (y_divisions > 1)
+            ? static_cast<float>(i) / static_cast<float>(y_divisions - 1)
+            : 0.5F;
+        const float y = bounds.min.y + t * bounds.height();
+        out.push_back(lv({ bounds.min.x, y }));
+        out.push_back(lv({ bounds.max.x, y }));
+    }
+
+    return out;
+}
+
+GeometryFn<float> plot_cursor(
+    Kinesis::AABB2D bounds,
+    bool vertical,
+    glm::vec3 color,
+    float thickness)
+{
+    return [bounds, vertical, color, thickness](
+               float v, std::vector<uint8_t>& out, Element& el) {
+        const float t = std::clamp(v, 0.F, 1.F);
+        using V = Kakshya::LineVertex;
+        std::array<V, 2> verts;
+        if (vertical) {
+            const float x = bounds.min.x + t * bounds.width();
+            verts = { {
+                { .position = { x, bounds.min.y, 0.F }, .color = color, .thickness = thickness },
+                { .position = { x, bounds.max.y, 0.F }, .color = color, .thickness = thickness },
+            } };
+            el.bounds_hint = Kinesis::AABB2D {
+                .min = { x - 0.01F, bounds.min.y },
+                .max = { x + 0.01F, bounds.max.y },
+            };
+        } else {
+            const float y = bounds.min.y + t * bounds.height();
+            verts = { {
+                { .position = { bounds.min.x, y, 0.F }, .color = color, .thickness = thickness },
+                { .position = { bounds.max.x, y, 0.F }, .color = color, .thickness = thickness },
+            } };
+            el.bounds_hint = Kinesis::AABB2D {
+                .min = { bounds.min.x, y - 0.01F },
+                .max = { bounds.max.x, y + 0.01F },
+            };
+        }
+        Geometry::write_verts(out, verts);
     };
 }
 

--- a/src/MayaFlux/Portal/Forma/Plot/PlotSpec.cpp
+++ b/src/MayaFlux/Portal/Forma/Plot/PlotSpec.cpp
@@ -215,4 +215,172 @@ GeometryFn<float> plot_cursor(
     };
 }
 
+// =============================================================================
+// Label / tick / legend spec helpers
+// =============================================================================
+
+LabelSpec plot_label(
+    std::string text,
+    Kinesis::AABB2D bounds,
+    glm::vec4 color,
+    std::string name)
+{
+    return LabelSpec {
+        .text = std::move(text),
+        .bounds = bounds,
+        .color = color,
+        .name = std::move(name),
+        .interactive = false,
+    };
+}
+
+std::vector<LabelSpec> plot_tick_labels(const TickLabelsSpec& spec)
+{
+    const uint32_t count = std::max(spec.count, 2U);
+    const bool horizontal = spec.edge == TickEdge::Bottom || spec.edge == TickEdge::Top;
+
+    std::vector<LabelSpec> labels;
+    labels.reserve(count);
+
+    for (uint32_t i = 0; i < count; ++i) {
+        const float t = static_cast<float>(i) / static_cast<float>(count - 1);
+        const float value = spec.range.min + t * (spec.range.max - spec.range.min);
+        const std::string text = std::format("{:.{}f}", value,
+            static_cast<int>(spec.decimal_places));
+
+        Kinesis::AABB2D label_bounds {};
+        if (horizontal) {
+            const float cx = spec.plot_bounds.min.x + t * spec.plot_bounds.width();
+            const float half_w = spec.plot_bounds.width() / static_cast<float>(count) * 0.5F;
+
+            if (spec.edge == TickEdge::Bottom) {
+                label_bounds = Kinesis::AABB2D {
+                    .min = { cx - half_w, spec.plot_bounds.min.y - spec.label_h },
+                    .max = { cx + half_w, spec.plot_bounds.min.y },
+                };
+            } else {
+                label_bounds = Kinesis::AABB2D {
+                    .min = { cx - half_w, spec.plot_bounds.max.y },
+                    .max = { cx + half_w, spec.plot_bounds.max.y + spec.label_h },
+                };
+            }
+        } else {
+            const float cy = spec.plot_bounds.min.y + t * spec.plot_bounds.height();
+            const float half_h = spec.plot_bounds.height() / static_cast<float>(count) * 0.5F;
+
+            if (spec.edge == TickEdge::Left) {
+                label_bounds = Kinesis::AABB2D {
+                    .min = { spec.plot_bounds.min.x - spec.label_w, cy - half_h },
+                    .max = { spec.plot_bounds.min.x, cy + half_h },
+                };
+            } else {
+                label_bounds = Kinesis::AABB2D {
+                    .min = { spec.plot_bounds.max.x, cy - half_h },
+                    .max = { spec.plot_bounds.max.x + spec.label_w, cy + half_h },
+                };
+            }
+        }
+
+        labels.push_back(LabelSpec {
+            .text = text,
+            .bounds = label_bounds,
+            .color = spec.color,
+            .name = spec.name_prefix + "_" + std::to_string(i),
+            .interactive = false,
+        });
+    }
+
+    return labels;
+}
+
+std::vector<LabelSpec> plot_tick_labels(
+    Kinesis::AABB2D bounds,
+    const AxisRange& range,
+    uint32_t count,
+    TickEdge edge,
+    glm::vec4 color,
+    uint8_t decimal_places,
+    float label_h,
+    float label_w)
+{
+    return plot_tick_labels(TickLabelsSpec {
+        .plot_bounds = bounds,
+        .range = range,
+        .count = count,
+        .edge = edge,
+        .color = color,
+        .decimal_places = decimal_places,
+        .label_h = label_h,
+        .label_w = label_w,
+    });
+}
+
+LegendSpec plot_legend(
+    glm::vec2 origin,
+    std::span<const std::string> labels,
+    std::span<const glm::vec3> colors,
+    float row_h,
+    float swatch_w,
+    glm::vec4 text_color)
+{
+    const size_t n = std::min(labels.size(), colors.size());
+
+    LegendSpec spec {
+        .origin = origin,
+        .row_h = row_h,
+        .swatch_w = swatch_w,
+        .text_color = text_color,
+    };
+    spec.entries.reserve(n);
+
+    for (size_t i = 0; i < n; ++i) {
+        spec.entries.push_back(LegendEntry {
+            .label = labels[i],
+            .color = colors[i],
+        });
+    }
+
+    return spec;
+}
+
+LegendLayout layout_legend(const LegendSpec& spec)
+{
+    LegendLayout layout;
+    layout.swatches.reserve(spec.entries.size());
+    layout.labels.reserve(spec.entries.size());
+
+    for (size_t i = 0; i < spec.entries.size(); ++i) {
+        const float y_top = spec.origin.y
+            - static_cast<float>(i) * (spec.row_h + spec.gap);
+        const float y_bot = y_top - spec.row_h;
+
+        const Kinesis::AABB2D swatch_bounds {
+            .min = { spec.origin.x, y_bot },
+            .max = { spec.origin.x + spec.swatch_w, y_top },
+        };
+
+        const Kinesis::AABB2D text_bounds {
+            .min = { spec.origin.x + spec.swatch_w + spec.gap, y_bot },
+            .max = { spec.origin.x + spec.swatch_w + spec.gap + spec.text_w, y_top },
+        };
+
+        layout.swatches.push_back(RectSpec {
+            .bounds = swatch_bounds,
+            .color = spec.entries[i].color,
+            .name = spec.name_prefix + "_swatch_" + std::to_string(i),
+            .interactive = spec.interactive,
+        });
+
+        layout.labels.push_back(LabelSpec {
+            .text = spec.entries[i].label,
+            .bounds = text_bounds,
+            .color = spec.text_color,
+            .name = spec.name_prefix + "_label_" + std::to_string(i),
+            .interactive = spec.interactive,
+        });
+    }
+
+    return layout;
+}
+
 } // namespace MayaFlux::Portal::Forma::Plot

--- a/src/MayaFlux/Portal/Forma/Plot/PlotSpec.hpp
+++ b/src/MayaFlux/Portal/Forma/Plot/PlotSpec.hpp
@@ -2,7 +2,7 @@
 
 #include "AxisRange.hpp"
 
-#include "MayaFlux/Kinesis/Spatial/Bounds.hpp"
+#include "MayaFlux/Kakshya/NDData/VertexFormats.hpp"
 #include "MayaFlux/Portal/Forma/Primitives/Mapped.hpp"
 
 namespace MayaFlux::Portal::Forma {
@@ -94,5 +94,79 @@ void apply_auto_scale(AxisRange& range,
     Kinesis::AABB2D bounds,
     glm::vec3 color = glm::vec3(1.F),
     const std::shared_ptr<Core::VKImage>& texture = nullptr);
+
+// =============================================================================
+// Grid
+//
+// Static LINE_LIST geometry for NDC-space grid lines. Produces x_divisions
+// vertical lines and y_divisions horizontal lines within bounds. Use as a
+// static FormaBuffer submitted once and related behind the data element.
+//
+// Caller pattern:
+//   auto grid_buf = Portal::Forma::create_buffer(window,
+//       Plot::plot_grid(bounds, 8, 6),
+//       Portal::Graphics::PrimitiveTopology::LINE_LIST);
+//   surface.layer().add(
+//       Portal::Forma::Element{}.non_interactive().with_buffer(grid_buf))
+//       .relate_to(data_el.element.id).to_back();
+// =============================================================================
+
+/**
+ * @brief LINE_LIST grid geometry for a plot area.
+ *
+ * Produces @p x_divisions vertical lines and @p y_divisions horizontal lines
+ * evenly distributed within @p bounds. Intended as a static background buffer.
+ *
+ * @param bounds      Plot area in NDC.
+ * @param x_divisions Vertical line count (columns). 0 = no vertical lines.
+ * @param y_divisions Horizontal line count (rows). 0 = no horizontal lines.
+ * @param color       Line color.
+ * @param thickness   LineVertex::thickness value.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<Kakshya::LineVertex> plot_grid(
+    Kinesis::AABB2D bounds,
+    uint32_t x_divisions,
+    uint32_t y_divisions,
+    glm::vec3 color = glm::vec3(0.12F),
+    float thickness = 1.F);
+
+// =============================================================================
+// Cursor / playhead
+//
+// GeometryFn<float>. Value in [0, 1] maps to a normalised position within
+// bounds along the active axis. vertical=true draws a vertical line (X axis
+// position); vertical=false draws a horizontal line (Y axis position).
+//
+// Produces two LINE_LIST LineVertex pairs. Topology: LINE_LIST.
+//
+// Caller pattern:
+//   auto cursor = Portal::Forma::create_element<float>(
+//       surface,
+//       Plot::plot_cursor(bounds),
+//       0.F,
+//       Portal::Graphics::PrimitiveTopology::LINE_LIST);
+//   // drive from a metro or bridge binding
+//   cursor.state->write(playhead_position);
+// =============================================================================
+
+/**
+ * @brief GeometryFn<float> for a cursor or playhead line within a plot area.
+ *
+ * Value in [0, 1] maps to a position within @p bounds. When @p vertical is
+ * true the line is vertical and the value maps to the X axis; when false the
+ * line is horizontal and the value maps to the Y axis.
+ *
+ * @note Pass @c PrimitiveTopology::LINE_LIST explicitly to create_element.
+ *
+ * @param bounds    Plot area in NDC. The line spans the full perpendicular extent.
+ * @param vertical  True for a vertical playhead (X position), false for horizontal.
+ * @param color     Line color.
+ * @param thickness LineVertex::thickness value.
+ */
+[[nodiscard]] GeometryFn<float> plot_cursor(
+    Kinesis::AABB2D bounds,
+    bool vertical = true,
+    glm::vec3 color = glm::vec3(0.75F),
+    float thickness = 1.F);
 
 } // namespace MayaFlux::Portal::Forma::Plot

--- a/src/MayaFlux/Portal/Forma/Plot/PlotSpec.hpp
+++ b/src/MayaFlux/Portal/Forma/Plot/PlotSpec.hpp
@@ -15,7 +15,120 @@ class PlotContainer;
 
 namespace MayaFlux::Portal::Forma::Plot {
 
-struct SeriesSpec;
+/**
+ * @brief Edge along which tick labels are placed.
+ */
+enum class TickEdge : uint8_t {
+    Bottom, ///< Labels below bounds, values mapped from range.min (left) to range.max (right).
+    Top, ///< Labels above bounds.
+    Left, ///< Labels left of bounds, values mapped from range.min (bottom) to range.max (top).
+    Right, ///< Labels right of bounds.
+};
+
+/**
+ * @brief Construction-free text label description.
+ *
+ * This is only a layout/style spec. It does not own a FormaBuffer, VKImage,
+ * Element, Surface, or Window. Forma is responsible for turning this into
+ * a textured Element via Element::with_text().
+ */
+struct LabelSpec {
+    std::string text;
+    Kinesis::AABB2D bounds {};
+    glm::vec4 color { 0.85F, 0.85F, 0.85F, 1.F };
+
+    /**
+     * @brief Optional logical name for the eventual Element.
+     */
+    std::string name;
+
+    /**
+     * @brief Whether the eventual Element should participate in hit testing.
+     * Plot labels default to passive/non-interactive.
+     */
+    bool interactive { false };
+
+    /**
+     * @brief Optional text pixel/render size override.
+     *
+     * When zero, Forma should derive render_bounds from bounds + window size.
+     */
+    glm::uvec2 render_bounds {};
+};
+
+/**
+ * @brief Lightweight filled rectangle description.
+ *
+ * Used for plot adornments such as legend swatches. Construction-free:
+ * Forma turns this into a buffer/Element later.
+ */
+struct RectSpec {
+    Kinesis::AABB2D bounds {};
+    glm::vec3 color { 1.F };
+    std::string name;
+    bool interactive { false };
+};
+
+/**
+ * @brief Config for generating numeric tick labels on one plot edge.
+ */
+struct TickLabelsSpec {
+    Kinesis::AABB2D plot_bounds {};
+    AxisRange range {};
+    uint32_t count { 2 };
+    TickEdge edge { TickEdge::Bottom };
+    glm::vec4 color { 0.65F, 0.65F, 0.65F, 1.F };
+    uint8_t decimal_places { 2 };
+
+    /**
+     * @brief NDC height of each label strip for Bottom/Top ticks.
+     */
+    float label_h { 0.055F };
+
+    /**
+     * @brief NDC width of each label strip for Left/Right ticks.
+     */
+    float label_w { 0.12F };
+
+    std::string name_prefix { "tick" };
+};
+
+/**
+ * @brief One legend row.
+ */
+struct LegendEntry {
+    std::string label;
+    glm::vec3 color { 1.F };
+};
+
+/**
+ * @brief Construction-free vertical legend configuration.
+ */
+struct LegendSpec {
+    glm::vec2 origin { 0.F };
+    std::vector<LegendEntry> entries;
+
+    float row_h { 0.07F };
+    float swatch_w { 0.04F };
+    float gap { 0.012F };
+    float text_w { 0.35F };
+
+    glm::vec4 text_color { 0.85F, 0.85F, 0.85F, 1.F };
+
+    std::string name_prefix { "legend" };
+    bool interactive { false };
+};
+
+/**
+ * @brief Expanded construction-free legend layout.
+ *
+ * Forma should build one rectangle Element per swatch and one text Element
+ * per label, then relate all produced elements to the plot root/data id.
+ */
+struct LegendLayout {
+    std::vector<RectSpec> swatches;
+    std::vector<LabelSpec> labels;
+};
 
 // =============================================================================
 // series_by_role
@@ -168,5 +281,57 @@ void apply_auto_scale(AxisRange& range,
     bool vertical = true,
     glm::vec3 color = glm::vec3(0.75F),
     float thickness = 1.F);
+
+// =============================================================================
+// Label / tick / legend spec helpers
+// =============================================================================
+
+/**
+ * @brief Create a single construction-free label spec.
+ */
+[[nodiscard]] MAYAFLUX_API LabelSpec plot_label(
+    std::string text,
+    Kinesis::AABB2D bounds,
+    glm::vec4 color = { 0.85F, 0.85F, 0.85F, 1.F },
+    std::string name = {});
+
+/**
+ * @brief Generate construction-free tick label specs.
+ *
+ * Values are evenly interpolated across spec.range. Label bounds are placed
+ * adjacent to spec.plot_bounds according to spec.edge.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<LabelSpec> plot_tick_labels(
+    const TickLabelsSpec& spec);
+
+/**
+ * @brief Convenience overload for generating tick label specs directly.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<LabelSpec> plot_tick_labels(
+    Kinesis::AABB2D bounds,
+    const AxisRange& range,
+    uint32_t count,
+    TickEdge edge = TickEdge::Bottom,
+    glm::vec4 color = { 0.65F, 0.65F, 0.65F, 1.F },
+    uint8_t decimal_places = 2,
+    float label_h = 0.055F,
+    float label_w = 0.12F);
+
+/**
+ * @brief Create a construction-free legend spec from labels and colors.
+ */
+[[nodiscard]] MAYAFLUX_API LegendSpec plot_legend(
+    glm::vec2 origin,
+    std::span<const std::string> labels,
+    std::span<const glm::vec3> colors,
+    float row_h = 0.07F,
+    float swatch_w = 0.04F,
+    glm::vec4 text_color = { 0.85F, 0.85F, 0.85F, 1.F });
+
+/**
+ * @brief Expand a legend spec into swatch rectangle specs and text label specs.
+ */
+[[nodiscard]] MAYAFLUX_API LegendLayout layout_legend(
+    const LegendSpec& spec);
 
 } // namespace MayaFlux::Portal::Forma::Plot

--- a/src/MayaFlux/Portal/Forma/Plot/SeriesBuilder.cpp
+++ b/src/MayaFlux/Portal/Forma/Plot/SeriesBuilder.cpp
@@ -368,4 +368,97 @@ SeriesSpec BarsBuilder::done() const
     };
 }
 
+SeriesSpec FilledWaveformBuilder::done() const
+{
+    auto x_mappings = m_state.x_mappings();
+    auto y_mappings = m_state.y_mappings();
+    const auto global_palette = m_state.palette();
+    const float baseline_data = m_baseline;
+
+    return {
+        .fn = [x_mappings, y_mappings, global_palette, baseline_data](
+                  const std::shared_ptr<Kakshya::PlotContainer>& container,
+                  std::vector<uint8_t>& out,
+                  Element&) mutable {
+            if (!container)
+                return;
+
+            container->process_default();
+
+            struct SeriesEntry {
+                std::span<const double> data;
+                size_t mapping_index;
+                size_t index_within_mapping;
+            };
+            std::vector<SeriesEntry> y_entries;
+            for (size_t mi = 0; mi < y_mappings.size(); ++mi) {
+                auto sv = series_for_mapping(*container, y_mappings[mi]);
+                for (size_t si = 0; si < sv.size(); ++si)
+                    y_entries.push_back({ .data = sv[si], .mapping_index = mi, .index_within_mapping = si });
+            }
+            if (y_entries.empty())
+                return;
+
+            AxisRange x_range = merge_axis(x_mappings);
+            AxisRange y_range = merge_axis(y_mappings);
+
+            std::vector<std::span<const double>> all_y;
+            all_y.reserve(y_entries.size());
+            for (const auto& e : y_entries)
+                all_y.push_back(e.data);
+            apply_auto_scale(y_range, all_y);
+
+            std::vector<std::span<const double>> all_x;
+            if (!x_mappings.empty()) {
+                all_x = series_for_mapping(*container, x_mappings[0]);
+                apply_auto_scale(x_range, all_x);
+            } else {
+                x_range = AxisRange {}.range(-1.F, 1.F);
+            }
+
+            const float baseline_ndc = y_range.to_ndc(baseline_data);
+
+            out.clear();
+
+            for (size_t ei = 0; ei < y_entries.size(); ++ei) {
+                const auto& entry = y_entries[ei];
+                const size_t n    = entry.data.size();
+                if (n == 0)
+                    continue;
+
+                const glm::vec3 color = resolve_color(
+                    y_mappings[entry.mapping_index], global_palette, entry.index_within_mapping);
+
+                const size_t x_idx = std::min(ei, all_x.empty() ? size_t(0) : all_x.size() - 1);
+                const bool has_x   = !all_x.empty() && all_x[x_idx].size() == n;
+
+                const size_t pre_size = out.size();
+
+                for (size_t i = 0; i < n; ++i) {
+                    const float px = has_x
+                        ? x_range.to_ndc(static_cast<float>(all_x[x_idx][i]))
+                        : x_range.to_ndc(x_range.min
+                              + static_cast<float>(i) / static_cast<float>(std::max<size_t>(n - 1, 1))
+                                  * (x_range.max - x_range.min));
+
+                    const float py = y_range.to_ndc(static_cast<float>(entry.data[i]));
+
+                    write_vertex(out, { px, py,          0.F }, color, 1.F);
+                    write_vertex(out, { px, baseline_ndc, 0.F }, color, 0.F);
+                }
+
+                if (ei + 1 < y_entries.size() && out.size() > pre_size) {
+                    const size_t last = out.size() - k_stride;
+                    out.insert(out.end(), out.begin() + static_cast<ptrdiff_t>(last), out.end());
+                }
+            } },
+        .topology = Graphics::PrimitiveTopology::TRIANGLE_STRIP,
+        .capacity_for = [](uint64_t n) { return n * 2 * k_stride + 128; },
+        .background_fn = m_state.has_background()
+            ? std::optional<GeometryFn<float>> { background(
+                  m_state.background_bounds(), m_state.background_color()) }
+            : std::nullopt,
+    };
+}
+
 } // namespace MayaFlux::Portal::Forma::Plot

--- a/src/MayaFlux/Portal/Forma/Plot/SeriesBuilder.cpp
+++ b/src/MayaFlux/Portal/Forma/Plot/SeriesBuilder.cpp
@@ -1,7 +1,5 @@
 #include "SeriesBuilder.hpp"
 
-#include "PlotSpec.hpp"
-
 #include "MayaFlux/Kakshya/Source/PlotContainer.hpp"
 
 namespace MayaFlux::Portal::Forma::Plot {
@@ -50,6 +48,12 @@ namespace {
                 merged.scale_predicate = r.scale_predicate;
         }
         return merged;
+    }
+
+    AxisRange merge_axis_const(const std::vector<Series::AxisMapping>& mappings)
+    {
+        auto copy = mappings;
+        return merge_axis(copy);
     }
 
     /**
@@ -116,6 +120,53 @@ namespace {
     }
 
 } // namespace
+
+// =============================================================================
+// Series adornment resolution
+// =============================================================================
+
+std::vector<TickLabelsSpec> Series::resolved_tick_labels() const
+{
+    std::vector<TickLabelsSpec> resolved;
+    if (!m_plot_bounds)
+        return resolved;
+
+    resolved.reserve(m_ticks.size());
+
+    for (const auto& req : m_ticks) {
+        AxisRange range {};
+        if (req.range) {
+            range = *req.range;
+        } else {
+            switch (req.axis) {
+            case TickAxis::X:
+                range = merge_axis_const(m_x);
+                break;
+            case TickAxis::Y:
+                range = merge_axis_const(m_y);
+                break;
+            case TickAxis::Explicit:
+            default:
+                range = {};
+                break;
+            }
+        }
+
+        resolved.push_back(TickLabelsSpec {
+            .plot_bounds = *m_plot_bounds,
+            .range = std::move(range),
+            .count = req.count,
+            .edge = req.edge,
+            .color = req.color,
+            .decimal_places = req.decimal_places,
+            .label_h = req.label_h,
+            .label_w = req.label_w,
+            .name_prefix = req.name_prefix,
+        });
+    }
+
+    return resolved;
+}
 
 // =============================================================================
 // WaveformBuilder::done
@@ -222,6 +273,10 @@ SeriesSpec WaveformBuilder::done() const
         .background_fn = m_state.has_background()
             ? std::optional<GeometryFn<float>> { background(m_state.background_bounds(), m_state.background_color()) }
             : std::nullopt,
+        .plot_bounds = m_state.plot_bounds(),
+        .labels = m_state.labels(),
+        .tick_labels = m_state.resolved_tick_labels(),
+        .legend = m_state.legend_spec(),
     };
 }
 
@@ -302,6 +357,10 @@ SeriesSpec ScatterBuilder::done() const
         .background_fn = m_state.has_background()
             ? std::optional<GeometryFn<float>> { background(m_state.background_bounds(), m_state.background_color()) }
             : std::nullopt,
+        .plot_bounds = m_state.plot_bounds(),
+        .labels = m_state.labels(),
+        .tick_labels = m_state.resolved_tick_labels(),
+        .legend = m_state.legend_spec(),
     };
 }
 
@@ -365,6 +424,10 @@ SeriesSpec BarsBuilder::done() const
         .background_fn = m_state.has_background()
             ? std::optional<GeometryFn<float>> { background(m_state.background_bounds(), m_state.background_color()) }
             : std::nullopt,
+        .plot_bounds = m_state.plot_bounds(),
+        .labels = m_state.labels(),
+        .tick_labels = m_state.resolved_tick_labels(),
+        .legend = m_state.legend_spec(),
     };
 }
 
@@ -458,6 +521,10 @@ SeriesSpec FilledWaveformBuilder::done() const
             ? std::optional<GeometryFn<float>> { background(
                   m_state.background_bounds(), m_state.background_color()) }
             : std::nullopt,
+        .plot_bounds = m_state.plot_bounds(),
+        .labels = m_state.labels(),
+        .tick_labels = m_state.resolved_tick_labels(),
+        .legend = m_state.legend_spec(),
     };
 }
 

--- a/src/MayaFlux/Portal/Forma/Plot/SeriesBuilder.hpp
+++ b/src/MayaFlux/Portal/Forma/Plot/SeriesBuilder.hpp
@@ -1,13 +1,6 @@
 #pragma once
 
-#include "AxisRange.hpp"
-
-#include "MayaFlux/Kakshya/NDData/NDData.hpp"
-#include "MayaFlux/Portal/Forma/Primitives/Mapped.hpp"
-
-namespace MayaFlux::Kakshya {
-class PlotContainer;
-}
+#include "PlotSpec.hpp"
 
 namespace MayaFlux::Portal::Forma::Plot {
 
@@ -34,6 +27,30 @@ struct SeriesSpec {
     Graphics::PrimitiveTopology topology;
     std::function<size_t(uint64_t sample_count)> capacity_for;
     std::optional<GeometryFn<float>> background_fn;
+
+    /**
+     * @brief Optional plot/data region in NDC used by plot adornments.
+     *
+     * The current data geometry still maps through its own GeometryFn. This
+     * bounds value is for labels, ticks, legends, and other construction
+     * performed by Plot::place().
+     */
+    std::optional<Kinesis::AABB2D> plot_bounds;
+
+    /**
+     * @brief Explicit text labels to materialize when the plot is placed.
+     */
+    std::vector<LabelSpec> labels;
+
+    /**
+     * @brief Concrete tick label generation specs resolved at done() time.
+     */
+    std::vector<TickLabelsSpec> tick_labels;
+
+    /**
+     * @brief Optional legend to materialize when the plot is placed.
+     */
+    std::optional<LegendSpec> legend;
 };
 
 /**
@@ -87,6 +104,28 @@ public:
         std::vector<Role> roles;
         AxisRange range;
         std::vector<glm::vec3> palette;
+    };
+
+    enum class TickAxis : uint8_t {
+        X,
+        Y,
+        Explicit,
+    };
+
+    /**
+     * @brief Tick request collected fluently and resolved into TickLabelsSpec
+     *        by the terminal builder once axis mappings are known.
+     */
+    struct TickRequest {
+        TickAxis axis { TickAxis::Explicit };
+        std::optional<AxisRange> range;
+        uint32_t count { 2 };
+        TickEdge edge { TickEdge::Bottom };
+        glm::vec4 color { 0.65F, 0.65F, 0.65F, 1.F };
+        uint8_t decimal_places { 2 };
+        float label_h { 0.055F };
+        float label_w { 0.12F };
+        std::string name_prefix { "tick" };
     };
 
     // =========================================================================
@@ -241,6 +280,190 @@ public:
     }
 
     // =========================================================================
+    // Plot adornments
+    // =========================================================================
+
+    /**
+     * @brief Set the logical plot/data bounds used by labels, tick labels,
+     *        legends, and future plot adornments.
+     *
+     * This does not remap the generated data geometry by itself. It defines
+     * the NDC area around which Plot::place() should construct adornments.
+     */
+    Series& bounds(Kinesis::AABB2D bounds)
+    {
+        m_plot_bounds = bounds;
+        return *this;
+    }
+
+    /**
+     * @brief Add a construction-free text label to this plot.
+     */
+    Series& label(
+        std::string text,
+        Kinesis::AABB2D bounds,
+        glm::vec4 color = { 0.85F, 0.85F, 0.85F, 1.F },
+        std::string name = {})
+    {
+        m_labels.push_back(plot_label(std::move(text), bounds, color, std::move(name)));
+        return *this;
+    }
+
+    /**
+     * @brief Add an already-built label spec.
+     */
+    Series& label(LabelSpec spec)
+    {
+        m_labels.push_back(std::move(spec));
+        return *this;
+    }
+
+    /**
+     * @brief Request X-axis tick labels. The effective range is resolved
+     *        from X mappings at done() time unless @p range is supplied.
+     */
+    Series& x_ticks(
+        uint32_t count,
+        TickEdge edge = TickEdge::Bottom,
+        uint8_t decimal_places = 2,
+        glm::vec4 color = { 0.65F, 0.65F, 0.65F, 1.F })
+    {
+        m_ticks.push_back(TickRequest {
+            .axis = TickAxis::X,
+            .range = std::nullopt,
+            .count = count,
+            .edge = edge,
+            .color = color,
+            .decimal_places = decimal_places,
+            .name_prefix = "x_tick",
+        });
+        return *this;
+    }
+
+    /**
+     * @brief Request X-axis tick labels with an explicit display range.
+     */
+    Series& x_ticks(
+        AxisRange range,
+        uint32_t count,
+        TickEdge edge = TickEdge::Bottom,
+        uint8_t decimal_places = 2,
+        glm::vec4 color = { 0.65F, 0.65F, 0.65F, 1.F })
+    {
+        m_ticks.push_back(TickRequest {
+            .axis = TickAxis::X,
+            .range = std::move(range),
+            .count = count,
+            .edge = edge,
+            .color = color,
+            .decimal_places = decimal_places,
+            .name_prefix = "x_tick",
+        });
+        return *this;
+    }
+
+    /**
+     * @brief Request Y-axis tick labels. The effective range is resolved
+     *        from Y mappings at done() time unless @p range is supplied.
+     */
+    Series& y_ticks(
+        uint32_t count,
+        TickEdge edge = TickEdge::Left,
+        uint8_t decimal_places = 2,
+        glm::vec4 color = { 0.65F, 0.65F, 0.65F, 1.F })
+    {
+        m_ticks.push_back(TickRequest {
+            .axis = TickAxis::Y,
+            .range = std::nullopt,
+            .count = count,
+            .edge = edge,
+            .color = color,
+            .decimal_places = decimal_places,
+            .name_prefix = "y_tick",
+        });
+        return *this;
+    }
+
+    /**
+     * @brief Request Y-axis tick labels with an explicit display range.
+     */
+    Series& y_ticks(
+        AxisRange range,
+        uint32_t count,
+        TickEdge edge = TickEdge::Left,
+        uint8_t decimal_places = 2,
+        glm::vec4 color = { 0.65F, 0.65F, 0.65F, 1.F })
+    {
+        m_ticks.push_back(TickRequest {
+            .axis = TickAxis::Y,
+            .range = std::move(range),
+            .count = count,
+            .edge = edge,
+            .color = color,
+            .decimal_places = decimal_places,
+            .name_prefix = "y_tick",
+        });
+        return *this;
+    }
+
+    /**
+     * @brief Request tick labels on an arbitrary edge with an explicit range.
+     */
+    Series& ticks(
+        TickEdge edge,
+        AxisRange range,
+        uint32_t count,
+        uint8_t decimal_places = 2,
+        glm::vec4 color = { 0.65F, 0.65F, 0.65F, 1.F })
+    {
+        m_ticks.push_back(TickRequest {
+            .axis = TickAxis::Explicit,
+            .range = std::move(range),
+            .count = count,
+            .edge = edge,
+            .color = color,
+            .decimal_places = decimal_places,
+            .name_prefix = "tick",
+        });
+        return *this;
+    }
+
+    /**
+     * @brief Request an automatic legend. Entries may be resolved later from
+     *        the PlotContainer by Plot::place().
+     */
+    Series& legend(glm::vec2 origin)
+    {
+        m_legend = LegendSpec {
+            .origin = origin,
+            .entries = {},
+        };
+        return *this;
+    }
+
+    /**
+     * @brief Set a manual legend.
+     */
+    Series& legend(glm::vec2 origin, std::initializer_list<LegendEntry> entries)
+    {
+        LegendSpec spec {
+            .origin = origin,
+            .entries = entries,
+        };
+        m_legend = std::move(spec);
+        return *this;
+    }
+
+    /**
+     * @brief Set a manual legend from a pre-built spec.
+     */
+    Series& legend(LegendSpec spec)
+    {
+        m_legend = std::move(spec);
+        return *this;
+    }
+
+    // =========================================================================
     // Encoding terminals
     // =========================================================================
 
@@ -261,6 +484,15 @@ public:
     [[nodiscard]] Kinesis::AABB2D background_bounds() const { return m_background_bounds; }
     [[nodiscard]] glm::vec3 background_color() const { return m_background_color; }
 
+    [[nodiscard]] const std::optional<Kinesis::AABB2D>& plot_bounds() const { return m_plot_bounds; }
+    [[nodiscard]] const std::vector<LabelSpec>& labels() const { return m_labels; }
+    [[nodiscard]] const std::optional<LegendSpec>& legend_spec() const { return m_legend; }
+
+    /**
+     * @brief Resolve pending fluent tick requests into concrete tick label specs.
+     */
+    [[nodiscard]] std::vector<TickLabelsSpec> resolved_tick_labels() const;
+
 private:
     std::vector<AxisMapping> m_x;
     std::vector<AxisMapping> m_y;
@@ -269,6 +501,11 @@ private:
     glm::vec3 m_background_color {};
     bool m_has_background {};
     Kinesis::AABB2D m_background_bounds {};
+
+    std::optional<Kinesis::AABB2D> m_plot_bounds;
+    std::vector<LabelSpec> m_labels;
+    std::vector<TickRequest> m_ticks;
+    std::optional<LegendSpec> m_legend;
 };
 
 // =============================================================================

--- a/src/MayaFlux/Portal/Forma/Plot/SeriesBuilder.hpp
+++ b/src/MayaFlux/Portal/Forma/Plot/SeriesBuilder.hpp
@@ -14,6 +14,7 @@ namespace MayaFlux::Portal::Forma::Plot {
 class WaveformBuilder;
 class ScatterBuilder;
 class BarsBuilder;
+class FilledWaveformBuilder;
 
 // =============================================================================
 // Series
@@ -246,6 +247,7 @@ public:
     [[nodiscard]] WaveformBuilder as_waveform() const;
     [[nodiscard]] ScatterBuilder as_scatter() const;
     [[nodiscard]] BarsBuilder as_bars() const;
+    [[nodiscard]] FilledWaveformBuilder as_filled_waveform() const;
 
     // =========================================================================
     // State accessors — used by encoding terminals in .cpp
@@ -367,8 +369,51 @@ private:
     Series m_state;
 };
 
+/**
+ * @class FilledWaveformBuilder
+ * @brief Terminal builder for filled waveform encoding (TRIANGLE_STRIP).
+ *
+ * For each Y-series, produces a TRIANGLE_STRIP quad strip between the signal
+ * value and a baseline Y (default: y_range.to_ndc(0), clamped to bounds).
+ * Each sample pair contributes two vertices: one at the signal, one at
+ * the baseline. The strip is continuous within a series; separate series
+ * are separated by degenerate vertices.
+ *
+ * Shares all Y-axis, X-axis, palette, and auto-scale machinery with
+ * WaveformBuilder. Use when the filled area under the signal carries
+ * meaning: envelope display, energy readout, spectral band fill.
+ *
+ * .done() produces a SeriesSpec with TRIANGLE_STRIP topology.
+ */
+class FilledWaveformBuilder {
+public:
+    FilledWaveformBuilder(Series state)
+        : m_state(std::move(state))
+    {
+    }
+
+    /**
+     * @brief Override the baseline Y value in data coordinates.
+     *
+     * Defaults to 0.0 (maps to y_range.to_ndc(0)). Set to the range minimum
+     * to always fill downward, or to the range maximum to always fill upward.
+     */
+    FilledWaveformBuilder& baseline(float y)
+    {
+        m_baseline = y;
+        return *this;
+    }
+
+    [[nodiscard]] SeriesSpec done() const;
+
+private:
+    Series m_state;
+    float m_baseline { 0.F };
+};
+
 inline WaveformBuilder Series::as_waveform() const { return { *this }; }
 inline ScatterBuilder Series::as_scatter() const { return { *this }; }
 inline BarsBuilder Series::as_bars() const { return { *this }; }
+inline FilledWaveformBuilder Series::as_filled_waveform() const { return { *this }; }
 
 } // namespace MayaFlux::Portal::Forma::Plot

--- a/src/MayaFlux/Portal/Forma/Primitives/Geometry.cpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/Geometry.cpp
@@ -1,0 +1,382 @@
+#include "Geometry.hpp"
+
+#include "MayaFlux/Kinesis/Geometry2D.hpp"
+#include "MayaFlux/Kinesis/GeometryPrimitives.hpp"
+#include "MayaFlux/Portal/Forma/Context.hpp"
+
+namespace MayaFlux::Portal::Forma::Geometry {
+
+GeometryFn<float> horizontal_fader(
+    Kinesis::AABB2D bounds,
+    float handle_w,
+    glm::vec3 track_color,
+    glm::vec3 handle_color)
+{
+    return [bounds, handle_w, track_color, handle_color](
+               float v, std::vector<uint8_t>& out, Element& el) {
+        float x = bounds.min.x + v * (bounds.width() - handle_w);
+        float yt = bounds.min.y + bounds.height() * 0.35F;
+        float yb = bounds.min.y + bounds.height() * 0.65F;
+
+        Kinesis::AABB2D track { .min = glm::vec2(bounds.min.x, yt), .max = glm::vec2(bounds.max.x, yb) };
+        Kinesis::AABB2D handle { .min = glm::vec2(x, bounds.min.y), .max = glm::vec2(x + handle_w, bounds.max.y) };
+
+        auto verts = Kakshya::to_mesh_vertices(Kinesis::filled_rect(track, track_color));
+        auto herts = Kakshya::to_mesh_vertices(Kinesis::filled_rect(handle, handle_color));
+        verts.insert(verts.end(), herts.begin(), herts.end());
+
+        write_verts(out, verts);
+
+        el.bounds_hint = handle;
+        el.contains = {};
+    };
+}
+
+GeometryFn<float> vertical_fader(
+    Kinesis::AABB2D bounds,
+    float handle_h,
+    glm::vec3 track_color,
+    glm::vec3 handle_color)
+{
+    return [bounds, handle_h, track_color, handle_color](
+               float v, std::vector<uint8_t>& out, Element& el) {
+        const float y = bounds.min.y + v * (bounds.height() - handle_h);
+        const float xl = bounds.min.x + bounds.width() * 0.35F;
+        const float xr = bounds.min.x + bounds.width() * 0.65F;
+
+        const Kinesis::AABB2D track { .min = { xl, bounds.min.y }, .max = { xr, bounds.max.y } };
+        const Kinesis::AABB2D handle { .min = { bounds.min.x, y }, .max = { bounds.max.x, y + handle_h } };
+
+        auto verts = Kakshya::to_mesh_vertices(Kinesis::filled_rect(track, track_color));
+        auto herts = Kakshya::to_mesh_vertices(Kinesis::filled_rect(handle, handle_color));
+        verts.insert(verts.end(), herts.begin(), herts.end());
+
+        write_verts(out, verts);
+
+        el.bounds_hint = handle;
+        el.contains = {};
+    };
+}
+
+GeometryFn<float> radial(
+    glm::vec2 center,
+    float radius,
+    float angle_start,
+    float angle_end,
+    glm::vec3 color)
+{
+    return [center, radius, angle_start, angle_end, color](
+               float v, std::vector<uint8_t>& out, Element& el) {
+        float angle = angle_start + v * (angle_end - angle_start);
+        glm::vec2 tip = center + radius * glm::vec2(std::cos(angle), std::sin(angle));
+
+        using V = Kakshya::LineVertex;
+        std::vector<V> verts = {
+            { .position = { center.x, center.y, 0 }, .color = color },
+            { .position = { tip.x, tip.y, 0 }, .color = color },
+        };
+
+        write_verts(out, verts);
+
+        el.bounds_hint = Kinesis::AABB2D::from_ndc(center, glm::vec2(radius));
+        el.contains = Kinesis::circular_bounds(center, radius);
+    };
+}
+
+GeometryFn<glm::vec2> point(
+    glm::vec3 color,
+    float size,
+    float hit_radius)
+{
+    return [color, size, hit_radius](glm::vec2 pos, std::vector<uint8_t>& out, Element& el) {
+        write_verts(out, Kakshya::PointVertex {
+                             .position = { pos.x, pos.y, 0.0F },
+                             .color = color,
+                             .size = size,
+                         });
+        el.bounds_hint = Kinesis::AABB2D::from_ndc(pos, glm::vec2(hit_radius));
+        el.contains = Kinesis::circular_bounds(pos, hit_radius);
+    };
+}
+
+GeometryFn<glm::vec2> position_picker(
+    Kinesis::AABB2D bounds,
+    glm::vec3 color,
+    float size)
+{
+    return [bounds, color, size](
+               glm::vec2 v, std::vector<uint8_t>& out, Element& el) {
+        float x = bounds.min.x + v.x * bounds.width();
+        float y = bounds.min.y + v.y * bounds.height();
+
+        using V = Kakshya::PointVertex;
+        std::vector<V> verts = {
+            { .position = { x, y, 0 }, .color = color, .size = size },
+        };
+
+        write_verts(out, verts);
+
+        el.bounds_hint = bounds;
+        el.contains = Kinesis::polygon_bounds(std::span<const glm::vec2> {
+            std::array<glm::vec2, 4> {
+                bounds.min,
+                glm::vec2(bounds.max.x, bounds.min.y),
+                bounds.max,
+                glm::vec2(bounds.min.x, bounds.max.y) } });
+    };
+}
+
+GeometryFn<float> stroke_slider(
+    std::span<const glm::vec2> path,
+    std::shared_ptr<Buffers::FormaBuffer> handle_buf,
+    float half_thickness,
+    glm::vec3 track_color,
+    glm::vec3 fill_color,
+    glm::vec3 handle_color,
+    float handle_size)
+{
+    std::vector<glm::vec2> pts(path.begin(), path.end());
+
+    std::vector<float> seg_lengths;
+    seg_lengths.reserve(pts.size() > 0 ? pts.size() - 1 : 0);
+    float total_len = 0.0F;
+    for (size_t i = 0; i + 1 < pts.size(); ++i) {
+        float l = glm::length(pts[i + 1] - pts[i]);
+        seg_lengths.push_back(l);
+        total_len += l;
+    }
+
+    Kinesis::AABB2D aabb { .min = pts.empty() ? glm::vec2(0.F) : pts[0],
+        .max = pts.empty() ? glm::vec2(0.F) : pts[0] };
+    for (const auto& p : pts) {
+        aabb.min = glm::min(aabb.min, p);
+        aabb.max = glm::max(aabb.max, p);
+    }
+    aabb = aabb.expanded(half_thickness);
+
+    return [pts = std::move(pts),
+               seg_lengths = std::move(seg_lengths),
+               total_len,
+               aabb,
+               handle_buf = std::move(handle_buf),
+               half_thickness,
+               track_color,
+               fill_color,
+               handle_color,
+               handle_size](float v, std::vector<uint8_t>& out, Element& el) {
+        if (pts.size() < 2) {
+            out.clear();
+            return;
+        }
+
+        const float target = std::clamp(v, 0.0F, 1.0F) * total_len;
+
+        glm::vec2 handle_pos = pts.front();
+        float accumulated = 0.0F;
+        size_t split_seg = 0;
+        float split_t = 0.0F;
+        for (size_t i = 0; i < seg_lengths.size(); ++i) {
+            if (accumulated + seg_lengths[i] >= target || i + 1 == seg_lengths.size()) {
+                split_t = seg_lengths[i] > 0.0F
+                    ? (target - accumulated) / seg_lengths[i]
+                    : 0.0F;
+                split_t = std::clamp(split_t, 0.0F, 1.0F);
+                handle_pos = glm::mix(pts[i], pts[i + 1], split_t);
+                split_seg = i;
+                break;
+            }
+            accumulated += seg_lengths[i];
+        }
+
+        auto verts = Kinesis::polyline(pts, track_color);
+
+        auto fill = Kinesis::polyline(
+            std::span<const glm::vec2>(pts).subspan(0, split_seg + 1),
+            fill_color);
+        verts.insert(verts.end(), fill.begin(), fill.end());
+
+        if (split_t > 0.0F) {
+            verts.push_back({ .position = { pts[split_seg].x, pts[split_seg].y, 0.0F }, .color = fill_color });
+            verts.push_back({ .position = { handle_pos.x, handle_pos.y, 0.0F }, .color = fill_color });
+        }
+
+        write_verts(out, verts);
+
+        el.bounds_hint = aabb;
+        el.contains = Kinesis::stroke_bounds(pts, half_thickness);
+
+        if (handle_buf) {
+            Kakshya::PointVertex hv {
+                .position = { handle_pos.x, handle_pos.y, 0.0F },
+                .color = handle_color,
+                .size = handle_size,
+            };
+            std::vector<uint8_t> hbytes(sizeof(hv));
+            std::memcpy(hbytes.data(), &hv, sizeof(hv));
+            handle_buf->submit(hbytes);
+        }
+    };
+}
+
+GeometryFn<bool> toggle(
+    Kinesis::AABB2D region,
+    glm::vec3 color_off,
+    glm::vec3 color_on)
+{
+    return [region, color_off, color_on](
+               bool v, std::vector<uint8_t>& out, Element& el) {
+        write_verts(out, Kakshya::to_mesh_vertices(Kinesis::filled_rect(region, v ? color_on : color_off)));
+        el.bounds_hint = region;
+        el.contains = {};
+    };
+}
+
+GeometryFn<float> level_meter(
+    Kinesis::AABB2D bounds,
+    bool horizontal,
+    glm::vec3 fill_color,
+    glm::vec3 track_color)
+{
+    return [bounds, horizontal, fill_color, track_color](
+               float v, std::vector<uint8_t>& out, Element& el) {
+        const float t = std::clamp(v, 0.F, 1.F);
+
+        Kinesis::AABB2D fill {}, remainder {};
+        if (horizontal) {
+            const float split = bounds.min.x + t * bounds.width();
+            fill = { .min = bounds.min, .max = { split, bounds.max.y } };
+            remainder = { .min = { split, bounds.min.y }, .max = bounds.max };
+        } else {
+            const float split = bounds.min.y + t * bounds.height();
+            fill = { .min = bounds.min, .max = { bounds.max.x, split } };
+            remainder = { .min = { bounds.min.x, split }, .max = bounds.max };
+        }
+
+        auto verts = Kakshya::to_mesh_vertices(Kinesis::filled_rect(fill, fill_color));
+        auto rest = Kakshya::to_mesh_vertices(Kinesis::filled_rect(remainder, track_color));
+        verts.insert(verts.end(), rest.begin(), rest.end());
+
+        write_verts(out, verts);
+
+        el.bounds_hint = bounds;
+        el.contains = {};
+    };
+}
+
+GeometryFn<glm::vec2> crosshair(
+    float arm_len,
+    glm::vec3 color,
+    float thickness,
+    float hit_radius)
+{
+    return [arm_len, color, thickness, hit_radius](
+               glm::vec2 pos, std::vector<uint8_t>& out, Element& el) {
+        using V = Kakshya::LineVertex;
+        const std::array<V, 4> verts { {
+            { .position = { pos.x - arm_len, pos.y, 0.F }, .color = color, .thickness = thickness },
+            { .position = { pos.x + arm_len, pos.y, 0.F }, .color = color, .thickness = thickness },
+            { .position = { pos.x, pos.y - arm_len, 0.F }, .color = color, .thickness = thickness },
+            { .position = { pos.x, pos.y + arm_len, 0.F }, .color = color, .thickness = thickness },
+        } };
+        write_verts(out, verts);
+        el.bounds_hint = Kinesis::AABB2D::from_ndc(pos, glm::vec2(arm_len));
+        el.contains = Kinesis::circular_bounds(pos, hit_radius);
+    };
+}
+
+GeometryFn<std::vector<float>> drawable_canvas(
+    Kinesis::AABB2D bounds,
+    glm::vec3 color,
+    float thickness)
+{
+    return [bounds, color, thickness](
+               const std::vector<float>& v, std::vector<uint8_t>& out, Element& el) {
+        if (v.size() < 2) {
+            out.clear();
+            el.bounds_hint = bounds;
+            el.contains = Kinesis::polygon_bounds(std::span<const glm::vec2> {
+                std::array<glm::vec2, 4> {
+                    bounds.min,
+                    glm::vec2(bounds.max.x, bounds.min.y),
+                    bounds.max,
+                    glm::vec2(bounds.min.x, bounds.max.y) } });
+            return;
+        }
+
+        const auto n = v.size();
+        const float x_step = bounds.width() / static_cast<float>(n - 1);
+
+        std::vector<Kakshya::LineVertex> verts;
+        verts.reserve((n - 1) * 2);
+
+        for (size_t i = 0; i + 1 < n; ++i) {
+            const float xa = bounds.min.x + static_cast<float>(i) * x_step;
+            const float xb = bounds.min.x + static_cast<float>(i + 1) * x_step;
+            const float ya = bounds.min.y + std::clamp(v[i], 0.F, 1.F) * bounds.height();
+            const float yb = bounds.min.y + std::clamp(v[i + 1], 0.F, 1.F) * bounds.height();
+
+            verts.push_back({ .position = { xa, ya, 0.F }, .color = color, .thickness = thickness });
+            verts.push_back({ .position = { xb, yb, 0.F }, .color = color, .thickness = thickness });
+        }
+
+        write_verts(out, verts);
+
+        el.bounds_hint = bounds;
+        el.contains = Kinesis::polygon_bounds(std::span<const glm::vec2> {
+            std::array<glm::vec2, 4> {
+                bounds.min,
+                glm::vec2(bounds.max.x, bounds.min.y),
+                bounds.max,
+                glm::vec2(bounds.min.x, bounds.max.y) } });
+    };
+}
+
+void wire_canvas_drag(
+    Context& ctx,
+    uint32_t id,
+    std::shared_ptr<MappedState<std::vector<float>>> state,
+    Kinesis::AABB2D bounds)
+{
+    struct DragState {
+        std::optional<size_t> prev_index;
+    };
+    auto ds = std::make_shared<DragState>();
+
+    ctx.on_drag(id, IO::MouseButtons::Left,
+        [state, bounds, ds](uint32_t, glm::vec2 ndc) {
+            auto& v = state->value;
+            if (v.empty())
+                return;
+
+            const float t = (ndc.x - bounds.min.x) / bounds.width();
+            const float a = (ndc.y - bounds.min.y) / bounds.height();
+            const size_t n = v.size();
+            const size_t idx = static_cast<size_t>(
+                std::clamp(t, 0.F, 1.F) * static_cast<float>(n - 1));
+            const float amp = std::clamp(a, 0.F, 1.F);
+
+            if (ds->prev_index && *ds->prev_index != idx) {
+                const size_t lo = std::min(*ds->prev_index, idx);
+                const size_t hi = std::max(*ds->prev_index, idx);
+                const float v0 = v[*ds->prev_index];
+                const auto span = static_cast<float>(hi - lo);
+                for (size_t i = lo; i <= hi; ++i) {
+                    const float f = span > 0.F
+                        ? static_cast<float>(i - lo) / span
+                        : 1.F;
+                    v[i] = glm::mix(v0, amp, f);
+                }
+            } else {
+                v[idx] = amp;
+            }
+
+            ds->prev_index = idx;
+            ++state->version;
+        });
+
+    ctx.on_release(id, IO::MouseButtons::Left, [ds](uint32_t, glm::vec2) {
+        ds->prev_index = std::nullopt;
+    });
+}
+
+} // namespace MayaFlux::Portal::Forma::Geometry

--- a/src/MayaFlux/Portal/Forma/Primitives/Geometry.hpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/Geometry.hpp
@@ -2,8 +2,9 @@
 
 #include "Mapped.hpp"
 
-#include "MayaFlux/Kinesis/Geometry2D.hpp"
-#include "MayaFlux/Kinesis/GeometryPrimitives.hpp"
+namespace MayaFlux::Portal::Forma {
+class Context;
+}
 
 namespace MayaFlux::Portal::Forma::Geometry {
 
@@ -79,31 +80,11 @@ void write_verts(std::vector<uint8_t>& out, const V& v)
  * @param track_color Track quad color.
  * @param handle_color Handle quad color.
  */
-[[nodiscard]] inline GeometryFn<float> horizontal_fader(
+[[nodiscard]] GeometryFn<float> horizontal_fader(
     Kinesis::AABB2D bounds,
     float handle_w,
     glm::vec3 track_color = glm::vec3(0.3F),
-    glm::vec3 handle_color = glm::vec3(0.9F))
-{
-    return [bounds, handle_w, track_color, handle_color](
-               float v, std::vector<uint8_t>& out, Element& el) {
-        float x = bounds.min.x + v * (bounds.width() - handle_w);
-        float yt = bounds.min.y + bounds.height() * 0.35F;
-        float yb = bounds.min.y + bounds.height() * 0.65F;
-
-        Kinesis::AABB2D track { .min = glm::vec2(bounds.min.x, yt), .max = glm::vec2(bounds.max.x, yb) };
-        Kinesis::AABB2D handle { .min = glm::vec2(x, bounds.min.y), .max = glm::vec2(x + handle_w, bounds.max.y) };
-
-        auto verts = Kakshya::to_mesh_vertices(Kinesis::filled_rect(track, track_color));
-        auto herts = Kakshya::to_mesh_vertices(Kinesis::filled_rect(handle, handle_color));
-        verts.insert(verts.end(), herts.begin(), herts.end());
-
-        write_verts(out, verts);
-
-        el.bounds_hint = handle;
-        el.contains = {};
-    };
-}
+    glm::vec3 handle_color = glm::vec3(0.9F));
 
 // =============================================================================
 // Vertical fader
@@ -125,31 +106,11 @@ void write_verts(std::vector<uint8_t>& out, const V& v)
  * @param track_color  Track quad color.
  * @param handle_color Handle quad color.
  */
-[[nodiscard]] inline GeometryFn<float> vertical_fader(
+[[nodiscard]] GeometryFn<float> vertical_fader(
     Kinesis::AABB2D bounds,
     float handle_h,
     glm::vec3 track_color = glm::vec3(0.3F),
-    glm::vec3 handle_color = glm::vec3(0.9F))
-{
-    return [bounds, handle_h, track_color, handle_color](
-               float v, std::vector<uint8_t>& out, Element& el) {
-        const float y = bounds.min.y + v * (bounds.height() - handle_h);
-        const float xl = bounds.min.x + bounds.width() * 0.35F;
-        const float xr = bounds.min.x + bounds.width() * 0.65F;
-
-        const Kinesis::AABB2D track { .min = { xl, bounds.min.y }, .max = { xr, bounds.max.y } };
-        const Kinesis::AABB2D handle { .min = { bounds.min.x, y }, .max = { bounds.max.x, y + handle_h } };
-
-        auto verts = Kakshya::to_mesh_vertices(Kinesis::filled_rect(track, track_color));
-        auto herts = Kakshya::to_mesh_vertices(Kinesis::filled_rect(handle, handle_color));
-        verts.insert(verts.end(), herts.begin(), herts.end());
-
-        write_verts(out, verts);
-
-        el.bounds_hint = handle;
-        el.contains = {};
-    };
-}
+    glm::vec3 handle_color = glm::vec3(0.9F));
 
 // =============================================================================
 // Radial / arc
@@ -167,30 +128,12 @@ void write_verts(std::vector<uint8_t>& out, const V& v)
  * @param angle_end   End angle in radians (value = 1).
  * @param color       Line color.
  */
-[[nodiscard]] inline GeometryFn<float> radial(
+[[nodiscard]] GeometryFn<float> radial(
     glm::vec2 center,
     float radius,
     float angle_start,
     float angle_end,
-    glm::vec3 color = glm::vec3(0.9F))
-{
-    return [center, radius, angle_start, angle_end, color](
-               float v, std::vector<uint8_t>& out, Element& el) {
-        float angle = angle_start + v * (angle_end - angle_start);
-        glm::vec2 tip = center + radius * glm::vec2(std::cos(angle), std::sin(angle));
-
-        using V = Kakshya::LineVertex;
-        std::vector<V> verts = {
-            { .position = { center.x, center.y, 0 }, .color = color },
-            { .position = { tip.x, tip.y, 0 }, .color = color },
-        };
-
-        write_verts(out, verts);
-
-        el.bounds_hint = Kinesis::AABB2D::from_ndc(center, glm::vec2(radius));
-        el.contains = Kinesis::circular_bounds(center, radius);
-    };
-}
+    glm::vec3 color = glm::vec3(0.9F));
 
 // =============================================================================
 // Point
@@ -211,21 +154,10 @@ void write_verts(std::vector<uint8_t>& out, const V& v)
  * @param size       Point size in pixels.
  * @param hit_radius Hit region radius in NDC units.
  */
-[[nodiscard]] inline GeometryFn<glm::vec2> point(
+[[nodiscard]] GeometryFn<glm::vec2> point(
     glm::vec3 color = glm::vec3(1.0F),
     float size = 10.0F,
-    float hit_radius = 0.04F)
-{
-    return [color, size, hit_radius](glm::vec2 pos, std::vector<uint8_t>& out, Element& el) {
-        write_verts(out, Kakshya::PointVertex {
-                             .position = { pos.x, pos.y, 0.0F },
-                             .color = color,
-                             .size = size,
-                         });
-        el.bounds_hint = Kinesis::AABB2D::from_ndc(pos, glm::vec2(hit_radius));
-        el.contains = Kinesis::circular_bounds(pos, hit_radius);
-    };
-}
+    float hit_radius = 0.04F);
 
 // =============================================================================
 // 2D position picker
@@ -240,32 +172,10 @@ void write_verts(std::vector<uint8_t>& out, const V& v)
  * @param color  Point color.
  * @param size   Point size in pixels.
  */
-[[nodiscard]] inline GeometryFn<glm::vec2> position_picker(
+[[nodiscard]] GeometryFn<glm::vec2> position_picker(
     Kinesis::AABB2D bounds,
     glm::vec3 color = glm::vec3(0.9F),
-    float size = 8.0F)
-{
-    return [bounds, color, size](
-               glm::vec2 v, std::vector<uint8_t>& out, Element& el) {
-        float x = bounds.min.x + v.x * bounds.width();
-        float y = bounds.min.y + v.y * bounds.height();
-
-        using V = Kakshya::PointVertex;
-        std::vector<V> verts = {
-            { .position = { x, y, 0 }, .color = color, .size = size },
-        };
-
-        write_verts(out, verts);
-
-        el.bounds_hint = bounds;
-        el.contains = Kinesis::polygon_bounds(std::span<const glm::vec2> {
-            std::array<glm::vec2, 4> {
-                bounds.min,
-                glm::vec2(bounds.max.x, bounds.min.y),
-                bounds.max,
-                glm::vec2(bounds.min.x, bounds.max.y) } });
-    };
-}
+    float size = 8.0F);
 
 // =============================================================================
 // Stroke slider
@@ -304,97 +214,14 @@ void write_verts(std::vector<uint8_t>& out, const V& v)
  * @param handle_color   Color of the handle point.
  * @param handle_size    Handle point size in pixels.
  */
-[[nodiscard]] inline GeometryFn<float> stroke_slider(
+[[nodiscard]] GeometryFn<float> stroke_slider(
     std::span<const glm::vec2> path,
     std::shared_ptr<Buffers::FormaBuffer> handle_buf,
     float half_thickness = 0.02F,
     glm::vec3 track_color = glm::vec3(0.3F),
     glm::vec3 fill_color = glm::vec3(0.2F, 0.6F, 1.0F),
     glm::vec3 handle_color = glm::vec3(0.95F),
-    float handle_size = 10.0F)
-{
-    std::vector<glm::vec2> pts(path.begin(), path.end());
-
-    std::vector<float> seg_lengths;
-    seg_lengths.reserve(pts.size() > 0 ? pts.size() - 1 : 0);
-    float total_len = 0.0F;
-    for (size_t i = 0; i + 1 < pts.size(); ++i) {
-        float l = glm::length(pts[i + 1] - pts[i]);
-        seg_lengths.push_back(l);
-        total_len += l;
-    }
-
-    Kinesis::AABB2D aabb { .min = pts.empty() ? glm::vec2(0.F) : pts[0],
-        .max = pts.empty() ? glm::vec2(0.F) : pts[0] };
-    for (const auto& p : pts) {
-        aabb.min = glm::min(aabb.min, p);
-        aabb.max = glm::max(aabb.max, p);
-    }
-    aabb = aabb.expanded(half_thickness);
-
-    return [pts = std::move(pts),
-               seg_lengths = std::move(seg_lengths),
-               total_len,
-               aabb,
-               handle_buf = std::move(handle_buf),
-               half_thickness,
-               track_color,
-               fill_color,
-               handle_color,
-               handle_size](float v, std::vector<uint8_t>& out, Element& el) {
-        if (pts.size() < 2) {
-            out.clear();
-            return;
-        }
-
-        const float target = std::clamp(v, 0.0F, 1.0F) * total_len;
-
-        glm::vec2 handle_pos = pts.front();
-        float accumulated = 0.0F;
-        size_t split_seg = 0;
-        float split_t = 0.0F;
-        for (size_t i = 0; i < seg_lengths.size(); ++i) {
-            if (accumulated + seg_lengths[i] >= target || i + 1 == seg_lengths.size()) {
-                split_t = seg_lengths[i] > 0.0F
-                    ? (target - accumulated) / seg_lengths[i]
-                    : 0.0F;
-                split_t = std::clamp(split_t, 0.0F, 1.0F);
-                handle_pos = glm::mix(pts[i], pts[i + 1], split_t);
-                split_seg = i;
-                break;
-            }
-            accumulated += seg_lengths[i];
-        }
-
-        auto verts = Kinesis::polyline(pts, track_color);
-
-        auto fill = Kinesis::polyline(
-            std::span<const glm::vec2>(pts).subspan(0, split_seg + 1),
-            fill_color);
-        verts.insert(verts.end(), fill.begin(), fill.end());
-
-        if (split_t > 0.0F) {
-            verts.push_back({ .position = { pts[split_seg].x, pts[split_seg].y, 0.0F }, .color = fill_color });
-            verts.push_back({ .position = { handle_pos.x, handle_pos.y, 0.0F }, .color = fill_color });
-        }
-
-        write_verts(out, verts);
-
-        el.bounds_hint = aabb;
-        el.contains = Kinesis::stroke_bounds(pts, half_thickness);
-
-        if (handle_buf) {
-            Kakshya::PointVertex hv {
-                .position = { handle_pos.x, handle_pos.y, 0.0F },
-                .color = handle_color,
-                .size = handle_size,
-            };
-            std::vector<uint8_t> hbytes(sizeof(hv));
-            std::memcpy(hbytes.data(), &hv, sizeof(hv));
-            handle_buf->submit(hbytes);
-        }
-    };
-}
+    float handle_size = 10.0F);
 
 // =============================================================================
 // Toggle
@@ -421,18 +248,10 @@ void write_verts(std::vector<uint8_t>& out, const V& v)
  * @param color_off Fill color when false.
  * @param color_on  Fill color when true.
  */
-[[nodiscard]] inline GeometryFn<bool> toggle(
+[[nodiscard]] GeometryFn<bool> toggle(
     Kinesis::AABB2D region,
     glm::vec3 color_off = glm::vec3(0.25F),
-    glm::vec3 color_on = glm::vec3(0.2F, 0.7F, 0.4F))
-{
-    return [region, color_off, color_on](
-               bool v, std::vector<uint8_t>& out, Element& el) {
-        write_verts(out, Kakshya::to_mesh_vertices(Kinesis::filled_rect(region, v ? color_on : color_off)));
-        el.bounds_hint = region;
-        el.contains = {};
-    };
-}
+    glm::vec3 color_on = glm::vec3(0.2F, 0.7F, 0.4F));
 
 // =============================================================================
 // Level meter
@@ -458,37 +277,11 @@ void write_verts(std::vector<uint8_t>& out, const V& v)
  * @param fill_color  Color of the active (filled) portion.
  * @param track_color Color of the inactive remainder.
  */
-[[nodiscard]] inline GeometryFn<float> level_meter(
+[[nodiscard]] GeometryFn<float> level_meter(
     Kinesis::AABB2D bounds,
     bool horizontal = true,
     glm::vec3 fill_color = glm::vec3(0.2F, 0.7F, 0.3F),
-    glm::vec3 track_color = glm::vec3(0.15F))
-{
-    return [bounds, horizontal, fill_color, track_color](
-               float v, std::vector<uint8_t>& out, Element& el) {
-        const float t = std::clamp(v, 0.F, 1.F);
-
-        Kinesis::AABB2D fill {}, remainder {};
-        if (horizontal) {
-            const float split = bounds.min.x + t * bounds.width();
-            fill = { .min = bounds.min, .max = { split, bounds.max.y } };
-            remainder = { .min = { split, bounds.min.y }, .max = bounds.max };
-        } else {
-            const float split = bounds.min.y + t * bounds.height();
-            fill = { .min = bounds.min, .max = { bounds.max.x, split } };
-            remainder = { .min = { bounds.min.x, split }, .max = bounds.max };
-        }
-
-        auto verts = Kakshya::to_mesh_vertices(Kinesis::filled_rect(fill, fill_color));
-        auto rest = Kakshya::to_mesh_vertices(Kinesis::filled_rect(remainder, track_color));
-        verts.insert(verts.end(), rest.begin(), rest.end());
-
-        write_verts(out, verts);
-
-        el.bounds_hint = bounds;
-        el.contains = {};
-    };
-}
+    glm::vec3 track_color = glm::vec3(0.15F));
 
 // =============================================================================
 // Crosshair
@@ -512,25 +305,70 @@ void write_verts(std::vector<uint8_t>& out, const V& v)
  * @note Pass @c PrimitiveTopology::LINE_LIST explicitly to create_element —
  *       the default TRIANGLE_STRIP will misinterpret the 4 vertices.
  */
-[[nodiscard]] inline GeometryFn<glm::vec2> crosshair(
+[[nodiscard]] GeometryFn<glm::vec2> crosshair(
     float arm_len = 0.04F,
     glm::vec3 color = glm::vec3(0.9F),
     float thickness = 1.F,
-    float hit_radius = 0.05F)
-{
-    return [arm_len, color, thickness, hit_radius](
-               glm::vec2 pos, std::vector<uint8_t>& out, Element& el) {
-        using V = Kakshya::LineVertex;
-        const std::array<V, 4> verts { {
-            { .position = { pos.x - arm_len, pos.y, 0.F }, .color = color, .thickness = thickness },
-            { .position = { pos.x + arm_len, pos.y, 0.F }, .color = color, .thickness = thickness },
-            { .position = { pos.x, pos.y - arm_len, 0.F }, .color = color, .thickness = thickness },
-            { .position = { pos.x, pos.y + arm_len, 0.F }, .color = color, .thickness = thickness },
-        } };
-        write_verts(out, verts);
-        el.bounds_hint = Kinesis::AABB2D::from_ndc(pos, glm::vec2(arm_len));
-        el.contains = Kinesis::circular_bounds(pos, hit_radius);
-    };
-}
+    float hit_radius = 0.05F);
+
+// =============================================================================
+// Drawable canvas
+//
+// value is vector<float> of N samples in [0, 1] mapped to the Y axis.
+// X positions are distributed evenly across bounds.
+// Renders as LINE_LIST: N-1 segments connecting adjacent samples.
+//
+// on_drag callback pattern:
+//   ctx->on_drag(el.element.id, IO::MouseButtons::Left,
+//       [&el, bounds](uint32_t, glm::vec2 ndc) {
+//           auto& v = el.state->value;
+//           const float t = (ndc.x - bounds.min.x) / bounds.width();
+//           const size_t i = static_cast<size_t>(
+//               std::clamp(t, 0.F, 1.F) * (v.size() - 1));
+//           const float a = (ndc.y - bounds.min.y) / bounds.height();
+//           v[i] = std::clamp(a, 0.F, 1.F);
+//           ++el.state->version;
+//       });
+//
+// For sparse-sample prevention at high drag speed, interpolate between the
+// previous and current index before calling state->write().
+//
+// Topology: LINE_LIST.
+// =============================================================================
+
+/**
+ * @brief Geometry function for a drawable curve canvas in NDC space.
+ *
+ * Renders the sample vector as a LINE_LIST polyline. Each adjacent sample
+ * pair becomes one segment. The hit region covers the full canvas bounds.
+ *
+ * @param bounds      Canvas extent in NDC.
+ * @param color       Line color.
+ * @param thickness   LineVertex thickness value.
+ */
+[[nodiscard]] GeometryFn<std::vector<float>> drawable_canvas(
+    Kinesis::AABB2D bounds,
+    glm::vec3 color = glm::vec3(0.8F),
+    float thickness = 1.5F);
+
+/**
+ * @brief Wire drag interaction for a drawable canvas element.
+ *
+ * Registers a left-button drag callback on @p ctx that maps NDC cursor
+ * position to a sample index and amplitude, writes into @p state, and
+ * increments the version. Linear interpolation fills the range between the
+ * previously touched index and the current one, preventing sparse samples
+ * under fast drag.
+ *
+ * @param ctx     Context owning the element.
+ * @param id      Element id from the Mapped.
+ * @param state   MappedState<vector<float>> to write into.
+ * @param bounds  Canvas NDC bounds — must match those passed to drawable_canvas().
+ */
+void wire_canvas_drag(
+    Context& ctx,
+    uint32_t id,
+    std::shared_ptr<MappedState<std::vector<float>>> state,
+    Kinesis::AABB2D bounds);
 
 } // namespace MayaFlux::Portal::Forma::Geometry

--- a/src/MayaFlux/Portal/Forma/Primitives/Geometry.hpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/Geometry.hpp
@@ -2,6 +2,7 @@
 
 #include "Mapped.hpp"
 
+#include "MayaFlux/Kinesis/Geometry2D.hpp"
 #include "MayaFlux/Kinesis/GeometryPrimitives.hpp"
 
 namespace MayaFlux::Portal::Forma::Geometry {
@@ -319,18 +320,13 @@ void write_verts(std::vector<uint8_t>& out, const V& v)
             accumulated += seg_lengths[i];
         }
 
-        std::vector<Kakshya::LineVertex> verts;
-        verts.reserve(pts.size() * 4);
+        auto verts = Kinesis::polyline(pts, track_color);
 
-        for (size_t i = 0; i + 1 < pts.size(); ++i) {
-            verts.push_back({ .position = { pts[i].x, pts[i].y, 0.0F }, .color = track_color });
-            verts.push_back({ .position = { pts[i + 1].x, pts[i + 1].y, 0.0F }, .color = track_color });
-        }
+        auto fill = Kinesis::polyline(
+            std::span<const glm::vec2>(pts).subspan(0, split_seg + 1),
+            fill_color);
+        verts.insert(verts.end(), fill.begin(), fill.end());
 
-        for (size_t i = 0; i < split_seg; ++i) {
-            verts.push_back({ .position = { pts[i].x, pts[i].y, 0.0F }, .color = fill_color });
-            verts.push_back({ .position = { pts[i + 1].x, pts[i + 1].y, 0.0F }, .color = fill_color });
-        }
         if (split_t > 0.0F) {
             verts.push_back({ .position = { pts[split_seg].x, pts[split_seg].y, 0.0F }, .color = fill_color });
             verts.push_back({ .position = { handle_pos.x, handle_pos.y, 0.0F }, .color = fill_color });

--- a/src/MayaFlux/Portal/Forma/Primitives/Geometry.hpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/Geometry.hpp
@@ -220,4 +220,138 @@ void write_verts(std::vector<uint8_t>& out, const V& v)
     };
 }
 
+// =============================================================================
+// Stroke slider
+//
+// Value in [0, 1] positions a handle point along a user-supplied polyline.
+// Renders two layers: the full path as a LINE_LIST in track_color, a
+// highlighted prefix segment from path start to the handle position in
+// fill_color, and a PointVertex handle on a caller-supplied secondary buffer.
+//
+// The secondary buffer must be a POINT_LIST FormaBuffer registered with the
+// same BufferManager and window before this function is called. The caller
+// adds it as a separate Element and relates it to the path element via
+// Layer::relate_to so removal and visibility cascade.
+//
+// Hit region: stroke_bounds over the full path at half_thickness.
+// bounds_hint: tight AABB enclosing all path points.
+//
+// Topology for the path buffer: LINE_LIST.
+// Topology for the handle buffer: POINT_LIST.
+// =============================================================================
+
+/**
+ * @brief Geometry function for a value scrubber along an arbitrary polyline.
+ *
+ * Value in [0, 1] maps to arc-length position along @p path. The full path
+ * is rendered as a LINE_LIST in @p track_color; the prefix from the path
+ * start to the handle position is rendered in @p fill_color. The handle
+ * itself is a PointVertex submitted to @p handle_buf each sync.
+ *
+ * @param path           Ordered polyline vertices in NDC. Copied into closure.
+ * @param handle_buf     POINT_LIST FormaBuffer for the handle point.
+ *                       Must be registered and have setup_rendering called.
+ * @param half_thickness Hit region half-thickness in NDC units.
+ * @param track_color    Color of the full path.
+ * @param fill_color     Color of the prefix segment up to the handle.
+ * @param handle_color   Color of the handle point.
+ * @param handle_size    Handle point size in pixels.
+ */
+[[nodiscard]] inline GeometryFn<float> stroke_slider(
+    std::span<const glm::vec2> path,
+    std::shared_ptr<Buffers::FormaBuffer> handle_buf,
+    float half_thickness = 0.02F,
+    glm::vec3 track_color = glm::vec3(0.3F),
+    glm::vec3 fill_color = glm::vec3(0.2F, 0.6F, 1.0F),
+    glm::vec3 handle_color = glm::vec3(0.95F),
+    float handle_size = 10.0F)
+{
+    std::vector<glm::vec2> pts(path.begin(), path.end());
+
+    std::vector<float> seg_lengths;
+    seg_lengths.reserve(pts.size() > 0 ? pts.size() - 1 : 0);
+    float total_len = 0.0F;
+    for (size_t i = 0; i + 1 < pts.size(); ++i) {
+        float l = glm::length(pts[i + 1] - pts[i]);
+        seg_lengths.push_back(l);
+        total_len += l;
+    }
+
+    Kinesis::AABB2D aabb { .min = pts.empty() ? glm::vec2(0.F) : pts[0],
+        .max = pts.empty() ? glm::vec2(0.F) : pts[0] };
+    for (const auto& p : pts) {
+        aabb.min = glm::min(aabb.min, p);
+        aabb.max = glm::max(aabb.max, p);
+    }
+    aabb = aabb.expanded(half_thickness);
+
+    return [pts = std::move(pts),
+               seg_lengths = std::move(seg_lengths),
+               total_len,
+               aabb,
+               handle_buf = std::move(handle_buf),
+               half_thickness,
+               track_color,
+               fill_color,
+               handle_color,
+               handle_size](float v, std::vector<uint8_t>& out, Element& el) {
+        if (pts.size() < 2) {
+            out.clear();
+            return;
+        }
+
+        const float target = std::clamp(v, 0.0F, 1.0F) * total_len;
+
+        glm::vec2 handle_pos = pts.front();
+        float accumulated = 0.0F;
+        size_t split_seg = 0;
+        float split_t = 0.0F;
+        for (size_t i = 0; i < seg_lengths.size(); ++i) {
+            if (accumulated + seg_lengths[i] >= target || i + 1 == seg_lengths.size()) {
+                split_t = seg_lengths[i] > 0.0F
+                    ? (target - accumulated) / seg_lengths[i]
+                    : 0.0F;
+                split_t = std::clamp(split_t, 0.0F, 1.0F);
+                handle_pos = glm::mix(pts[i], pts[i + 1], split_t);
+                split_seg = i;
+                break;
+            }
+            accumulated += seg_lengths[i];
+        }
+
+        std::vector<Kakshya::LineVertex> verts;
+        verts.reserve(pts.size() * 4);
+
+        for (size_t i = 0; i + 1 < pts.size(); ++i) {
+            verts.push_back({ .position = { pts[i].x, pts[i].y, 0.0F }, .color = track_color });
+            verts.push_back({ .position = { pts[i + 1].x, pts[i + 1].y, 0.0F }, .color = track_color });
+        }
+
+        for (size_t i = 0; i < split_seg; ++i) {
+            verts.push_back({ .position = { pts[i].x, pts[i].y, 0.0F }, .color = fill_color });
+            verts.push_back({ .position = { pts[i + 1].x, pts[i + 1].y, 0.0F }, .color = fill_color });
+        }
+        if (split_t > 0.0F) {
+            verts.push_back({ .position = { pts[split_seg].x, pts[split_seg].y, 0.0F }, .color = fill_color });
+            verts.push_back({ .position = { handle_pos.x, handle_pos.y, 0.0F }, .color = fill_color });
+        }
+
+        write_verts(out, verts);
+
+        el.bounds_hint = aabb;
+        el.contains = Kinesis::stroke_bounds(pts, half_thickness);
+
+        if (handle_buf) {
+            Kakshya::PointVertex hv {
+                .position = { handle_pos.x, handle_pos.y, 0.0F },
+                .color = handle_color,
+                .size = handle_size,
+            };
+            std::vector<uint8_t> hbytes(sizeof(hv));
+            std::memcpy(hbytes.data(), &hv, sizeof(hv));
+            handle_buf->submit(hbytes);
+        }
+    };
+}
+
 } // namespace MayaFlux::Portal::Forma::Geometry

--- a/src/MayaFlux/Portal/Forma/Primitives/Geometry.hpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/Geometry.hpp
@@ -106,6 +106,52 @@ void write_verts(std::vector<uint8_t>& out, const V& v)
 }
 
 // =============================================================================
+// Vertical fader
+//
+// Symmetric counterpart to horizontal_fader. Value in [0, 1] moves a handle
+// quad upward along a track quad.
+//
+// Track: thin vertical band through the center of bounds.
+// Handle: small square at y = bounds.min.y + value * (bounds.height() - handle_h).
+//
+// Hit region follows the handle, updated on every sync().
+// Topology: TRIANGLE_STRIP (two quad pairs via to_mesh_vertices).
+// =============================================================================
+
+/**
+ * @brief Geometry function for a vertical fader in NDC space.
+ * @param bounds       Full extent of the fader in NDC.
+ * @param handle_h     Handle height in NDC units.
+ * @param track_color  Track quad color.
+ * @param handle_color Handle quad color.
+ */
+[[nodiscard]] inline GeometryFn<float> vertical_fader(
+    Kinesis::AABB2D bounds,
+    float handle_h,
+    glm::vec3 track_color = glm::vec3(0.3F),
+    glm::vec3 handle_color = glm::vec3(0.9F))
+{
+    return [bounds, handle_h, track_color, handle_color](
+               float v, std::vector<uint8_t>& out, Element& el) {
+        const float y = bounds.min.y + v * (bounds.height() - handle_h);
+        const float xl = bounds.min.x + bounds.width() * 0.35F;
+        const float xr = bounds.min.x + bounds.width() * 0.65F;
+
+        const Kinesis::AABB2D track { .min = { xl, bounds.min.y }, .max = { xr, bounds.max.y } };
+        const Kinesis::AABB2D handle { .min = { bounds.min.x, y }, .max = { bounds.max.x, y + handle_h } };
+
+        auto verts = Kakshya::to_mesh_vertices(Kinesis::filled_rect(track, track_color));
+        auto herts = Kakshya::to_mesh_vertices(Kinesis::filled_rect(handle, handle_color));
+        verts.insert(verts.end(), herts.begin(), herts.end());
+
+        write_verts(out, verts);
+
+        el.bounds_hint = handle;
+        el.contains = {};
+    };
+}
+
+// =============================================================================
 // Radial / arc
 //
 // Value in [0, 1] sweeps an indicator line around a center point.
@@ -347,6 +393,143 @@ void write_verts(std::vector<uint8_t>& out, const V& v)
             std::memcpy(hbytes.data(), &hv, sizeof(hv));
             handle_buf->submit(hbytes);
         }
+    };
+}
+
+// =============================================================================
+// Toggle
+//
+// Value type: bool. Renders a filled rect in one of two colors.
+// The geometry function is purely visual — it carries no interaction.
+// The caller wires on_press to flip state->value:
+//
+//   surface.ctx().on_press(el.element.id, IO::MouseButtons::Left,
+//       [state = el.state](uint32_t, glm::vec2) {
+//           state->write(!state->value);
+//       });
+//
+// Topology: TRIANGLE_STRIP (4 MeshVertex via to_mesh_vertices).
+// =============================================================================
+
+/**
+ * @brief Geometry function for a boolean toggle in NDC space.
+ *
+ * Renders @p region as a filled rect in @p color_off or @p color_on based
+ * on the current bool value. Interaction is the caller's responsibility.
+ *
+ * @param region    NDC bounds of the toggle.
+ * @param color_off Fill color when false.
+ * @param color_on  Fill color when true.
+ */
+[[nodiscard]] inline GeometryFn<bool> toggle(
+    Kinesis::AABB2D region,
+    glm::vec3 color_off = glm::vec3(0.25F),
+    glm::vec3 color_on = glm::vec3(0.2F, 0.7F, 0.4F))
+{
+    return [region, color_off, color_on](
+               bool v, std::vector<uint8_t>& out, Element& el) {
+        write_verts(out, Kakshya::to_mesh_vertices(Kinesis::filled_rect(region, v ? color_on : color_off)));
+        el.bounds_hint = region;
+        el.contains = {};
+    };
+}
+
+// =============================================================================
+// Level meter
+//
+// Value type: float in [0, 1]. Renders a filled bar from the origin edge of
+// bounds proportional to the value, with the remainder as a second color.
+// No handle, no hit region. Suitable for audio level, progress, any scalar readout.
+//
+// Orientation:
+//   horizontal = true  - bar grows left to right
+//   horizontal = false - bar grows bottom to top
+//
+// Topology: TRIANGLE_STRIP (two quad pairs via to_mesh_vertices).
+// =============================================================================
+
+/**
+ * @brief Geometry function for a level meter in NDC space.
+ *
+ * No interaction. Drive from a node via bridge().at(el.state).bind(node).
+ *
+ * @param bounds      Full extent of the meter in NDC.
+ * @param horizontal  True for left-to-right fill, false for bottom-to-top.
+ * @param fill_color  Color of the active (filled) portion.
+ * @param track_color Color of the inactive remainder.
+ */
+[[nodiscard]] inline GeometryFn<float> level_meter(
+    Kinesis::AABB2D bounds,
+    bool horizontal = true,
+    glm::vec3 fill_color = glm::vec3(0.2F, 0.7F, 0.3F),
+    glm::vec3 track_color = glm::vec3(0.15F))
+{
+    return [bounds, horizontal, fill_color, track_color](
+               float v, std::vector<uint8_t>& out, Element& el) {
+        const float t = std::clamp(v, 0.F, 1.F);
+
+        Kinesis::AABB2D fill {}, remainder {};
+        if (horizontal) {
+            const float split = bounds.min.x + t * bounds.width();
+            fill = { .min = bounds.min, .max = { split, bounds.max.y } };
+            remainder = { .min = { split, bounds.min.y }, .max = bounds.max };
+        } else {
+            const float split = bounds.min.y + t * bounds.height();
+            fill = { .min = bounds.min, .max = { bounds.max.x, split } };
+            remainder = { .min = { bounds.min.x, split }, .max = bounds.max };
+        }
+
+        auto verts = Kakshya::to_mesh_vertices(Kinesis::filled_rect(fill, fill_color));
+        auto rest = Kakshya::to_mesh_vertices(Kinesis::filled_rect(remainder, track_color));
+        verts.insert(verts.end(), rest.begin(), rest.end());
+
+        write_verts(out, verts);
+
+        el.bounds_hint = bounds;
+        el.contains = {};
+    };
+}
+
+// =============================================================================
+// Crosshair
+//
+// Value type: glm::vec2 (NDC position). Renders two LINE_LIST segments —
+// horizontal and vertical — crossing at the value position.
+// Hit region: circle centered on the position.
+//
+// Pairs naturally with position_picker sharing the same MappedState<glm::vec2>.
+// Topology: LINE_LIST (4 LineVertex).
+// =============================================================================
+
+/**
+ * @brief Geometry function for a crosshair indicator in NDC space.
+ *
+ * @param arm_len    Half-length of each arm in NDC units.
+ * @param color      Line color.
+ * @param thickness  Line thickness (maps to LineVertex::thickness).
+ * @param hit_radius Hit region radius in NDC units.
+ *
+ * @note Pass @c PrimitiveTopology::LINE_LIST explicitly to create_element —
+ *       the default TRIANGLE_STRIP will misinterpret the 4 vertices.
+ */
+[[nodiscard]] inline GeometryFn<glm::vec2> crosshair(
+    float arm_len = 0.04F,
+    glm::vec3 color = glm::vec3(0.9F),
+    float thickness = 1.F,
+    float hit_radius = 0.05F)
+{
+    return [arm_len, color, thickness, hit_radius](
+               glm::vec2 pos, std::vector<uint8_t>& out, Element& el) {
+        using V = Kakshya::LineVertex;
+        const std::array<V, 4> verts { {
+            { .position = { pos.x - arm_len, pos.y, 0.F }, .color = color, .thickness = thickness },
+            { .position = { pos.x + arm_len, pos.y, 0.F }, .color = color, .thickness = thickness },
+            { .position = { pos.x, pos.y - arm_len, 0.F }, .color = color, .thickness = thickness },
+            { .position = { pos.x, pos.y + arm_len, 0.F }, .color = color, .thickness = thickness },
+        } };
+        write_verts(out, verts);
+        el.bounds_hint = Kinesis::AABB2D::from_ndc(pos, glm::vec2(arm_len));
+        el.contains = Kinesis::circular_bounds(pos, hit_radius);
     };
 }
 


### PR DESCRIPTION
This batch completes Portal::Forma as a first-class authoring surface. The subsystem now covers the full range from static geometry through continuous gesture interaction, keyboard-driven control, and direct data routing to the audio and compute graph. No intermediate toolkit, no retained widget tree, no callbacks that live outside your code.

---

### Interaction

`on_drag` replaces the press-flag-plus-move pattern that every fader and knob previously required. It tracks the originating element through the full gesture, including cursor movement beyond the element's bounds, and gates on button state via `Kriya::mouse_dragged` natively. A fader is now three lines: create, drag, write. The old pattern is still valid for transitions; `on_drag` is the default for continuous gestures.

Keyboard focus transfers on click. Any element can register per-key callbacks via `on_press(key)`, `on_held(key)`, and `on_release(key)`. `on_held` fires on initial press and each OS repeat tick, making arrow-key nudge on a fader or knob a two-line addition after the drag callback. `key_step` packages the common two-direction nudge pattern into a single fluent call that chains. Focus lifecycle (`on_focus_gained`, `on_focus_lost`) supports visual focus indication without coupling geometry to focus state.

---

### Drawable canvas

`drawable_canvas` is a `GeometryFn<vector<float>>` that renders N samples as a LINE_LIST polyline. `wire_canvas_drag` handles all interaction in one call: NDC to sample index, amplitude clamping, linear interpolation between the previous and current sample index to prevent gaps under fast drag, and version increment to trigger `sync()`.

The drawn vector is just numbers. `Bridge` routes it directly:

```cpp
// Wavetable written to audio output
bridge().at(el.state).write(audio_write_processor);

// FIR/IIR coefficient array
bridge().at(el.state).write([fir](std::span<const float> s) {
    fir->setBCoefficients({ s.begin(), s.end() });
});
```

Two canvases on one surface give simultaneous control over IIR feedforward and feedback coefficients. The same approach applies to any N-element consumer: filter coefficients, Random node bounds, shader uniform arrays, or anything that takes a float range.

---

### Bridge bulk routing

`Bridge::write(id, function<void(span<const float>)>)` is the generic outbound sink for array-level state. For `MappedState<vector<float>>` or `vector<double>` the full buffer is forwarded each frame. For scalar state a single-element span is constructed. The type conversion is the caller's concern; Bridge encodes no knowledge of specific consumers. `AudioWriteProcessor` and `DataWriteProcessor` check for a `bulk_reader` before falling back to the scalar path.

---

### Geometry

`Kinesis::Geometry2D` covers filled shapes (circle, ring, polygon, arc, rounded rect, gradient rect), outlines (circle, arc, rect, polygon, polyline with per-vertex color), and `arc_path` for stroke sliders and knobs. The full `Geometry.hpp` set adds vertical fader, toggle, level meter, crosshair, position picker, stroke slider, plot cursor, and filled waveform to the `Mapped<T>` factory table. Coordinate conversion is unified through `Kinesis::to_ndc`; the earlier duplication between Layer and Plot is gone.

`Kinesis::Scalar.hpp` adds framerate-independent smoothing (`damp`), range mapping (`map`, `normalize`, `denormalize`), easing, snapping, deadzone, and ping-pong as constexpr one-liners for geometry functions and animation callbacks.

---

### Plot adornments

The plot layer gains axis tick labels, legends, and static labels via fluent builder methods (`x_ticks`, `y_ticks`, `legend`, `label`, `bounds`). `plot_grid` produces a static LINE_LIST background. `FilledWaveformBuilder` adds filled waveforms sharing the existing Y-axis and palette machinery.

---

### Where this lands

A complete audio control surface is now: create a window, create a surface, place faders and canvases, wire to the graph via Bridge. The drawable canvas specifically opens up a class of interaction that has no equivalent in any conventional toolkit: draw a curve, hear it. Draw two curves, shape an IIR filter in real time. The data and the control are the same object.

The next direction from here is the text input field (focus is done, `press`/`impress`/`repress` are there, the remaining work is keystroke-to-buffer wiring and cursor blink) and the slider array (N `Mapped<float>` with a cross-slider drag overlay, natural consumer being multichannel coefficient sets or `GlyphGeometryNode::set_pen_offsets`).

---

### Examples

**Mouse follower** - `on_move` writing directly to `MappedState<glm::vec2>`, geometry function producing a single `PointVertex`:

```cpp
auto el = Portal::Forma::create_element<glm::vec2>(
    surface,
    Portal::Forma::Geometry::point({ 0.2F, 0.8F, 1.0F }, 14.0F, 0.04F),
    glm::vec2 { 0.F, 0.F },
    Portal::Graphics::PrimitiveTopology::POINT_LIST);

surface.ctx().on_move(el.element.id, [state = el.state](uint32_t, glm::vec2 ndc) {
    state->write(ndc);
});
```

**Audio energy bar** - node output bound inbound via `bridge().at().bind`, custom inline geometry function, no interaction:

```cpp
auto el = Portal::Forma::create_element<float>(
    *Portal::Forma::create_layer(window, "audio_energy").first,
    window,
    [track](float v, std::vector<uint8_t>& out, Portal::Forma::Element& elem) {
        float right = track.min.x + v * track.width();
        Portal::Forma::Geometry::write_verts(out, std::array<Kakshya::LineVertex, 4> { {
            { .position = { track.min.x, track.min.y, 0.F }, .color = { 0.2F, 0.6F, 1.F } },
            { .position = { track.min.x, track.max.y, 0.F }, .color = { 0.2F, 0.6F, 1.F } },
            { .position = { right,        track.min.y, 0.F }, .color = { 0.1F, 0.3F, 0.8F } },
            { .position = { right,        track.max.y, 0.F }, .color = { 0.1F, 0.3F, 0.8F } },
        } });
        elem.bounds_hint = track;
    },
    0.0F, Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP);

auto noise = vega.Random() | Audio[0];
Portal::Forma::bridge().at(el.state).bind([noise] {
    return std::clamp(static_cast<float>(std::abs(noise->get_last_output())), 0.F, 1.F);
});
```

**Spatial arc scrubber** - `stroke_slider` along a semicircular `arc_path`, value routes to a `Constant` node driving spatial panning:

```cpp
const auto arc_pts = Kinesis::arc_path(
    { 0.F, 0.F }, 0.55F, 0.33F,
    glm::radians(180.F), glm::radians(0.F), 16);

auto handle_buf = Portal::Forma::create_buffer(
    window, Portal::Graphics::PrimitiveTopology::POINT_LIST);

auto el = Portal::Forma::create_element<float>(
    surface,
    Portal::Forma::Geometry::stroke_slider(arc_pts, handle_buf,
        0.02F, glm::vec3(0.2F),
        glm::vec3(0.9F, 0.5F, 0.1F),
        glm::vec3(1.F, 0.9F, 0.2F), 12.F),
    0.5F, Portal::Graphics::PrimitiveTopology::LINE_LIST);

surface.layer().add(
    Portal::Forma::Element {}.non_interactive().with_buffer(handle_buf))
    .relate_to(el.element.id);

surface.ctx().on_drag(el.element.id, IO::MouseButtons::Left,
    [state = el.state, arc_pts](uint32_t, glm::vec2 ndc) {
        // project ndc onto arc arc-length, write [0,1]
    });

Portal::Forma::bridge().at(el.state).write(vega.Constant(0.5) | Audio[0]);
```

**Drawable canvas to IIR** - two canvases on one surface, each driving an independent coefficient vector on a live IIR filter:

```cpp
auto b_el = Portal::Forma::create_element<std::vector<float>>(surface,
    Portal::Forma::Geometry::drawable_canvas(b_bounds, { 0.3F, 0.8F, 0.4F }),
    b_init, Portal::Graphics::PrimitiveTopology::LINE_LIST);

auto a_el = Portal::Forma::create_element<std::vector<float>>(surface,
    Portal::Forma::Geometry::drawable_canvas(a_bounds, { 0.8F, 0.4F, 0.3F }),
    a_init, Portal::Graphics::PrimitiveTopology::LINE_LIST);

Portal::Forma::Geometry::wire_canvas_drag(surface.ctx(), b_el.element.id, b_el.state, b_bounds);
Portal::Forma::Geometry::wire_canvas_drag(surface.ctx(), a_el.element.id, a_el.state, a_bounds);

auto rand = vega.Random();
auto iir = vega.IIR(rand, a_init_d, b_init_d) | Audio[0];

Portal::Forma::bridge().at(b_el.state).write([iir](std::span<const float> s) {
    iir->setBCoefficients({ s.begin(), s.end() });
});
Portal::Forma::bridge().at(a_el.state).write([iir](std::span<const float> s) {
    if (!s.empty() && s[0] != 0.F)
        iir->setACoefficients({ s.begin(), s.end() });
});