### PR TITLE
Vision substrate for MayaFlux: CPU pipeline, GPU kernel infrastructure, and validated overlay

### DIFF
--- a/src/MayaFlux/Buffers/Staging/StagingUtils.cpp
+++ b/src/MayaFlux/Buffers/Staging/StagingUtils.cpp
@@ -454,7 +454,8 @@ void download_from_gpu_async(
 std::span<const float> download_and_normalise(
     const std::shared_ptr<Core::VKImage>& image,
     std::vector<uint8_t>& raw_staging,
-    std::vector<float>& work)
+    std::vector<float>& work,
+    const std::shared_ptr<VKBuffer>& gpu_staging)
 {
     if (!image || !image->is_initialized())
         return {};
@@ -473,11 +474,9 @@ std::span<const float> download_and_normalise(
         return {};
 
     raw_staging.resize(byte_size);
-    loom.download_data(
-        image, raw_staging.data(), byte_size, nullptr);
+    loom.download_data(image, raw_staging.data(), byte_size, gpu_staging);
 
     Kakshya::DataVariant variant { raw_staging };
-
     return Kakshya::as_normalised_float(variant, work);
 }
 

--- a/src/MayaFlux/Buffers/Staging/StagingUtils.cpp
+++ b/src/MayaFlux/Buffers/Staging/StagingUtils.cpp
@@ -1,6 +1,11 @@
 #include "StagingUtils.hpp"
 
 #include "MayaFlux/Buffers/AudioBuffer.hpp"
+#include "MayaFlux/Core/Backends/Graphics/Vulkan/VKImage.hpp"
+
+#include "MayaFlux/Kakshya/Utils/DataUtils.hpp"
+#include "MayaFlux/Portal/Graphics/TextureLoom.hpp"
+
 #include "MayaFlux/Registry/BackendRegistry.hpp"
 #include "MayaFlux/Registry/Service/BufferService.hpp"
 
@@ -444,6 +449,36 @@ void download_from_gpu_async(
 
     std::memcpy(data, ptr, size);
     buffer_service->release_fenced(handle);
+}
+
+std::span<const float> download_and_normalise(
+    const std::shared_ptr<Core::VKImage>& image,
+    std::vector<uint8_t>& raw_staging,
+    std::vector<float>& work)
+{
+    if (!image || !image->is_initialized())
+        return {};
+
+    auto& loom = Portal::Graphics::TextureLoom::instance();
+
+    const auto fmt_opt = loom.from_vulkan_format(image->get_format());
+    if (!fmt_opt)
+        return {};
+
+    const size_t byte_size = static_cast<size_t>(image->get_width())
+        * image->get_height()
+        * loom.get_bytes_per_pixel(*fmt_opt);
+
+    if (byte_size == 0)
+        return {};
+
+    raw_staging.resize(byte_size);
+    loom.download_data(
+        image, raw_staging.data(), byte_size, nullptr);
+
+    Kakshya::DataVariant variant { raw_staging };
+
+    return Kakshya::as_normalised_float(variant, work);
 }
 
 void upload_audio_to_gpu(

--- a/src/MayaFlux/Buffers/Staging/StagingUtils.hpp
+++ b/src/MayaFlux/Buffers/Staging/StagingUtils.hpp
@@ -205,6 +205,53 @@ MAYAFLUX_API void download_from_gpu_async(
     std::shared_ptr<VKBuffer>& staging);
 
 /**
+ * @brief Resolve the GPU-resident image from any GpuImageSource buffer.
+ *
+ * Selects get_texture() or get_gpu_texture() at compile time based on which
+ * the concrete buffer type exposes. Returns nullptr if the buffer has not yet
+ * produced a GPU texture.
+ *
+ * @tparam T A type satisfying GpuImageSource.
+ * @param buffer The pixel-bearing buffer to query.
+ * @return GPU-resident VKImage, or nullptr.
+ */
+template <GpuImageSource T>
+[[nodiscard]] std::shared_ptr<Core::VKImage> resolve_gpu_image(const T& buffer)
+{
+    if constexpr (requires(const T& b) {
+                      { b.get_texture() } -> std::convertible_to<std::shared_ptr<Core::VKImage>>;
+                  }) {
+        return buffer.get_texture();
+    } else {
+        return buffer.get_gpu_texture();
+    }
+}
+
+/**
+ * @brief Download a VKImage to CPU and return a normalised float span.
+ *
+ * Downloads @p image into @p raw_staging via TextureLoom::download_data,
+ * then normalises into @p work via Kakshya::as_normalised_float.
+ *
+ * @p raw_staging is resized to match the image byte footprint when the image
+ * dimensions or format change. @p work is the caller-owned scratch buffer
+ * reused across calls to avoid per-frame allocation.
+ *
+ * Returns an empty span if @p image is null, not initialised, or its format
+ * has no ImageFormat mapping.
+ *
+ * @param image       GPU-resident source image.
+ * @param raw_staging Persistent byte buffer for the GPU download. Reuse across calls.
+ * @param work        Persistent float buffer for normalisation output. Reuse across calls.
+ * @return Normalised float span pointing into @p work (or directly into the
+ *         variant storage for float-format images).
+ */
+[[nodiscard]] MAYAFLUX_API std::span<const float> download_and_normalise(
+    const std::shared_ptr<Core::VKImage>& image,
+    std::vector<uint8_t>& raw_staging,
+    std::vector<float>& work);
+
+/**
  * @brief Create staging buffer for transfers
  * @param size Size in bytes
  * @return Host-visible staging buffer ready for transfers

--- a/src/MayaFlux/Buffers/Staging/StagingUtils.hpp
+++ b/src/MayaFlux/Buffers/Staging/StagingUtils.hpp
@@ -243,13 +243,15 @@ template <GpuImageSource T>
  * @param image       GPU-resident source image.
  * @param raw_staging Persistent byte buffer for the GPU download. Reuse across calls.
  * @param work        Persistent float buffer for normalisation output. Reuse across calls.
+ * @param gpu_staging Optional persistent staging buffer for device-local images. Reuse across calls.
  * @return Normalised float span pointing into @p work (or directly into the
  *         variant storage for float-format images).
  */
 [[nodiscard]] MAYAFLUX_API std::span<const float> download_and_normalise(
     const std::shared_ptr<Core::VKImage>& image,
     std::vector<uint8_t>& raw_staging,
-    std::vector<float>& work);
+    std::vector<float>& work,
+    const std::shared_ptr<VKBuffer>& gpu_staging);
 
 /**
  * @brief Create staging buffer for transfers

--- a/src/MayaFlux/Buffers/Textures/ImageCVProcessor.hpp
+++ b/src/MayaFlux/Buffers/Textures/ImageCVProcessor.hpp
@@ -11,40 +11,34 @@
 namespace MayaFlux::Buffers {
 
 /**
- * @class VisionBufferProcessor
+ * @class ImageCVProcessor
  * @brief BufferProcessor executing a Kinesis::Vision pipeline on a GpuImageSource buffer.
  *
- * Compatible with any VKBuffer subclass satisfying GpuImageSource: TextureBuffer
- * and its children (VideoContainerBuffer, TextBuffer), NodeTextureBuffer, and
- * NetworkTextureBuffer. The correct image accessor (get_texture or get_gpu_texture)
- * is resolved at compile time via resolve_gpu_image.
+ * Renamed from ImageCVProcessor. ImageCVProcessor makes the domain
+ * (computer vision on image data) explicit and avoids collision with
+ * VisionProcessor (the Kakshya DataProcessor over pixel containers).
  *
- * Each processing_function call downloads the current GPU image via
- * download_and_normalise, runs the configured VisionSequence through VisionExecutor,
- * stores the VisionResult, and signals the BroadcastSource if wired.
- *
- * m_raw_staging and m_float_work are reused across calls to avoid per-frame
- * allocation. Image dimensions are read from the VKImage each call so dimension
- * changes (resize, video seek) are handled transparently.
+ * m_gpu_staging is a persistent host-visible VKBuffer allocated once in
+ * on_attach, sized to the image footprint. Passed to download_and_normalise
+ * on every call so TextureLoom::download_data uses the fenced path rather
+ * than waitIdle, avoiding graphics queue stalls on each frame download.
  *
  * @tparam T A VKBuffer subclass satisfying GpuImageSource.
- *
- * @see VisionProcessor, GpuImageSource, resolve_gpu_image, download_and_normalise
  */
 template <GpuImageSource T>
-class VisionBufferProcessor : public BufferProcessor {
+class ImageCVProcessor : public BufferProcessor {
 public:
     /**
      * @brief Construct with the vision pipeline to execute each processing_function call.
      * @param sequence Ordered VisionSteps describing the pipeline.
      */
-    explicit VisionBufferProcessor(Kinesis::Vision::VisionSequence sequence)
+    explicit ImageCVProcessor(Kinesis::Vision::VisionSequence sequence)
         : m_sequence(std::move(sequence))
     {
         m_processing_token = ProcessingToken::GRAPHICS_BACKEND;
     }
 
-    ~VisionBufferProcessor() override = default;
+    ~ImageCVProcessor() override = default;
 
     /**
      * @brief Validate the buffer type and reset executor state.
@@ -62,12 +56,18 @@ public:
                 Journal::Component::Buffers,
                 Journal::Context::BufferProcessing,
                 std::source_location::current(),
-                "VisionBufferProcessor<T>: buffer is not the expected type");
+                "ImageCVProcessor<T>: buffer is not the expected type");
         }
         m_buffer = typed;
         m_executor.reset();
+
+        if (!m_gpu_staging) {
+            constexpr size_t k_max_frame_bytes = 3840 * 2160 * 4;
+            m_gpu_staging = create_image_staging_buffer(k_max_frame_bytes);
+        }
+
         MF_INFO(Journal::Component::Buffers, Journal::Context::BufferProcessing,
-            "VisionBufferProcessor attached");
+            "ImageCVProcessor attached");
     }
 
     /**
@@ -78,6 +78,7 @@ public:
     {
         m_buffer.reset();
         m_executor.reset();
+        m_gpu_staging.reset();
     }
 
     /**
@@ -97,7 +98,7 @@ public:
         if (!image || !image->is_initialized())
             return;
 
-        auto frame = download_and_normalise(image, m_raw_staging, m_float_work);
+        auto frame = download_and_normalise(image, m_raw_staging, m_float_work, m_gpu_staging);
         if (frame.empty())
             return;
 
@@ -160,9 +161,9 @@ private:
 
     std::vector<uint8_t> m_raw_staging;
     std::vector<float> m_float_work;
+    std::shared_ptr<VKBuffer> m_gpu_staging;
 
     std::weak_ptr<T> m_buffer;
-
     std::shared_ptr<Vruta::BroadcastSource<Kinesis::Vision::VisionResult>> m_result_source;
     std::atomic<bool> m_is_processing { false };
 };

--- a/src/MayaFlux/Buffers/Textures/VisionBufferProcessor.hpp
+++ b/src/MayaFlux/Buffers/Textures/VisionBufferProcessor.hpp
@@ -1,0 +1,170 @@
+#pragma once
+
+#include "MayaFlux/Buffers/BufferProcessor.hpp"
+#include "MayaFlux/Buffers/Staging/StagingUtils.hpp"
+#include "MayaFlux/Buffers/VKBuffer.hpp"
+#include "MayaFlux/Journal/Archivist.hpp"
+#include "MayaFlux/Kinesis/Vision/VisionExecutor.hpp"
+#include "MayaFlux/Kinesis/Vision/VisionOp.hpp"
+#include "MayaFlux/Vruta/BroadcastSource.hpp"
+
+namespace MayaFlux::Buffers {
+
+/**
+ * @class VisionBufferProcessor
+ * @brief BufferProcessor executing a Kinesis::Vision pipeline on a GpuImageSource buffer.
+ *
+ * Compatible with any VKBuffer subclass satisfying GpuImageSource: TextureBuffer
+ * and its children (VideoContainerBuffer, TextBuffer), NodeTextureBuffer, and
+ * NetworkTextureBuffer. The correct image accessor (get_texture or get_gpu_texture)
+ * is resolved at compile time via resolve_gpu_image.
+ *
+ * Each processing_function call downloads the current GPU image via
+ * download_and_normalise, runs the configured VisionSequence through VisionExecutor,
+ * stores the VisionResult, and signals the BroadcastSource if wired.
+ *
+ * m_raw_staging and m_float_work are reused across calls to avoid per-frame
+ * allocation. Image dimensions are read from the VKImage each call so dimension
+ * changes (resize, video seek) are handled transparently.
+ *
+ * @tparam T A VKBuffer subclass satisfying GpuImageSource.
+ *
+ * @see VisionProcessor, GpuImageSource, resolve_gpu_image, download_and_normalise
+ */
+template <GpuImageSource T>
+class VisionBufferProcessor : public BufferProcessor {
+public:
+    /**
+     * @brief Construct with the vision pipeline to execute each processing_function call.
+     * @param sequence Ordered VisionSteps describing the pipeline.
+     */
+    explicit VisionBufferProcessor(Kinesis::Vision::VisionSequence sequence)
+        : m_sequence(std::move(sequence))
+    {
+        m_processing_token = ProcessingToken::GRAPHICS_BACKEND;
+    }
+
+    ~VisionBufferProcessor() override = default;
+
+    /**
+     * @brief Validate the buffer type and reset executor state.
+     *
+     * Throws std::invalid_argument if the buffer cannot be cast to T.
+     * Called automatically by BufferProcessingChain::add_processor.
+     *
+     * @param buffer The Buffer to attach to.
+     */
+    void on_attach(const std::shared_ptr<Buffer>& buffer) override
+    {
+        auto typed = std::dynamic_pointer_cast<T>(buffer);
+        if (!typed) {
+            error<std::invalid_argument>(
+                Journal::Component::Buffers,
+                Journal::Context::BufferProcessing,
+                std::source_location::current(),
+                "VisionBufferProcessor<T>: buffer is not the expected type");
+        }
+        m_buffer = typed;
+        m_executor.reset();
+        MF_INFO(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "VisionBufferProcessor attached");
+    }
+
+    /**
+     * @brief Clear state and reset executor.
+     * @param buffer The Buffer being detached.
+     */
+    void on_detach(const std::shared_ptr<Buffer>& /*buffer*/) override
+    {
+        m_buffer.reset();
+        m_executor.reset();
+    }
+
+    /**
+     * @brief Download the current GPU image, run the VisionSequence, store the result.
+     *
+     * No-op if the buffer has expired or the image is unavailable.
+     *
+     * @param buffer The GpuImageSource buffer to read from.
+     */
+    void processing_function(const std::shared_ptr<Buffer>& /*buffer*/) override
+    {
+        auto typed = m_buffer.lock();
+        if (!typed)
+            return;
+
+        auto image = resolve_gpu_image(*typed);
+        if (!image || !image->is_initialized())
+            return;
+
+        auto frame = download_and_normalise(image, m_raw_staging, m_float_work);
+        if (frame.empty())
+            return;
+
+        m_is_processing.store(true, std::memory_order_release);
+        m_result = m_executor.run(
+            m_sequence, frame,
+            image->get_width(), image->get_height());
+
+        if (m_result_source)
+            m_result_source->signal(m_result);
+
+        m_is_processing.store(false, std::memory_order_release);
+    }
+
+    /**
+     * @brief Replace the pipeline and reset inter-frame executor state.
+     *
+     * Not thread-safe relative to processing_function. Call only when idle.
+     *
+     * @param sequence Replacement VisionSequence.
+     */
+    void set_sequence(Kinesis::Vision::VisionSequence sequence)
+    {
+        m_sequence = std::move(sequence);
+        m_executor.reset();
+    }
+
+    /**
+     * @brief The result of the last successful processing_function call.
+     *
+     * Default-initialised until the first successful call completes.
+     *
+     * @return Most recent VisionResult.
+     */
+    [[nodiscard]] const Kinesis::Vision::VisionResult& get_result() const { return m_result; }
+
+    /**
+     * @brief Shared BroadcastSource signalled with each VisionResult after a
+     *        successful processing_function call.
+     *
+     * Created on first call. Wire with Kriya::on_signal to consume results
+     * from a coroutine without polling get_result().
+     *
+     * @return Shared pointer to the BroadcastSource, never null after first call.
+     */
+    [[nodiscard]] std::shared_ptr<Vruta::BroadcastSource<Kinesis::Vision::VisionResult>>
+    get_result_source()
+    {
+        if (!m_result_source) {
+            m_result_source = std::make_shared<
+                Vruta::BroadcastSource<Kinesis::Vision::VisionResult>>();
+        }
+        return m_result_source;
+    }
+
+private:
+    Kinesis::Vision::VisionSequence m_sequence;
+    Kinesis::Vision::VisionExecutor m_executor;
+    Kinesis::Vision::VisionResult m_result;
+
+    std::vector<uint8_t> m_raw_staging;
+    std::vector<float> m_float_work;
+
+    std::weak_ptr<T> m_buffer;
+
+    std::shared_ptr<Vruta::BroadcastSource<Kinesis::Vision::VisionResult>> m_result_source;
+    std::atomic<bool> m_is_processing { false };
+};
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/VKBuffer.hpp
+++ b/src/MayaFlux/Buffers/VKBuffer.hpp
@@ -670,4 +670,24 @@ protected:
     void ensure_initialized(const std::shared_ptr<VKBuffer>& buffer);
 };
 
+/**
+ * @concept GpuImageSource
+ * @brief Satisfied by any VKBuffer subclass that exposes a GPU-resident image.
+ *
+ * Covers all pixel-bearing buffer types via whichever accessor they provide:
+ *   - get_texture()     TextureBuffer and all its children
+ *   - get_gpu_texture() NodeTextureBuffer
+ *
+ * New pixel-bearing buffer types satisfy this concept automatically by
+ * implementing either method with the correct return type. No registration
+ * or base class change required.
+ *
+ * Processors constrained by GpuImageSource use if constexpr to select
+ * the correct accessor at compile time.
+ */
+template <typename T>
+concept GpuImageSource = std::derived_from<T, VKBuffer> && (requires(const T& b) {
+            { b.get_texture() } -> std::convertible_to<std::shared_ptr<Core::VKImage>>; } || requires(const T& b) {
+            { b.get_gpu_texture() } -> std::convertible_to<std::shared_ptr<Core::VKImage>>; });
+
 } // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Kakshya/Processors/VisionProcessor.cpp
+++ b/src/MayaFlux/Kakshya/Processors/VisionProcessor.cpp
@@ -5,6 +5,8 @@
 #include "MayaFlux/Kakshya/Source/VideoStreamContainer.hpp"
 #include "MayaFlux/Kakshya/Source/WindowContainer.hpp"
 
+#include "MayaFlux/Vruta/BroadcastSource.hpp"
+
 namespace MayaFlux::Kakshya {
 
 VisionProcessor::VisionProcessor(Kinesis::Vision::VisionSequence sequence)
@@ -69,7 +71,11 @@ void VisionProcessor::process(const std::shared_ptr<SignalSourceContainer>& cont
         return;
 
     m_is_processing.store(true, std::memory_order_release);
+
     m_result = m_executor.run(m_sequence, frame, m_width, m_height);
+    if (m_result_source)
+        m_result_source->signal(m_result);
+
     m_is_processing.store(false, std::memory_order_release);
 }
 
@@ -79,4 +85,10 @@ void VisionProcessor::set_sequence(Kinesis::Vision::VisionSequence sequence)
     m_executor.reset();
 }
 
+std::shared_ptr<Vruta::BroadcastSource<Kinesis::Vision::VisionResult>> VisionProcessor::get_result_source()
+{
+    if (!m_result_source)
+        m_result_source = std::make_shared<Vruta::BroadcastSource<Kinesis::Vision::VisionResult>>();
+    return m_result_source;
+}
 } // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Processors/VisionProcessor.cpp
+++ b/src/MayaFlux/Kakshya/Processors/VisionProcessor.cpp
@@ -1,0 +1,82 @@
+#include "VisionProcessor.hpp"
+
+#include "MayaFlux/Journal/Archivist.hpp"
+#include "MayaFlux/Kakshya/Source/TextureContainer.hpp"
+#include "MayaFlux/Kakshya/Source/VideoStreamContainer.hpp"
+#include "MayaFlux/Kakshya/Source/WindowContainer.hpp"
+
+namespace MayaFlux::Kakshya {
+
+VisionProcessor::VisionProcessor(Kinesis::Vision::VisionSequence sequence)
+    : m_sequence(std::move(sequence))
+{
+}
+
+void VisionProcessor::on_attach(const std::shared_ptr<SignalSourceContainer>& container)
+{
+    if (!container)
+        return;
+
+    const bool valid = std::dynamic_pointer_cast<VideoStreamContainer>(container) || std::dynamic_pointer_cast<WindowContainer>(container) || std::dynamic_pointer_cast<TextureContainer>(container);
+
+    if (!valid) {
+        error<std::invalid_argument>(
+            Journal::Component::Kakshya,
+            Journal::Context::ContainerProcessing,
+            std::source_location::current(),
+            "VisionProcessor requires a VideoStreamContainer, WindowContainer, "
+            "or TextureContainer; got {}",
+            typeid(*container).name());
+    }
+
+    const auto& structure = container->get_structure();
+    m_width = static_cast<uint32_t>(structure.get_width());
+    m_height = static_cast<uint32_t>(structure.get_height());
+    m_executor.reset();
+
+    if (m_width == 0 || m_height == 0) {
+        MF_WARN(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
+            "VisionProcessor attached to container with zero spatial dimensions");
+    } else {
+        MF_INFO(Journal::Component::Kakshya, Journal::Context::ContainerProcessing,
+            "VisionProcessor attached: {}x{}", m_width, m_height);
+    }
+}
+
+void VisionProcessor::on_detach(const std::shared_ptr<SignalSourceContainer>& /*container*/)
+{
+    m_width = 0;
+    m_height = 0;
+    m_executor.reset();
+}
+
+void VisionProcessor::process(const std::shared_ptr<SignalSourceContainer>& container)
+{
+    if (m_width == 0 || m_height == 0 || !container)
+        return;
+
+    std::span<const float> frame;
+
+    if (auto vc = std::dynamic_pointer_cast<VideoStreamContainer>(container)) {
+        frame = vc->processed_frame_as_float(0);
+    } else if (auto wc = std::dynamic_pointer_cast<WindowContainer>(container)) {
+        frame = wc->processed_frame_as_float(0);
+    } else if (auto tc = std::dynamic_pointer_cast<TextureContainer>(container)) {
+        frame = tc->as_normalised_float(0);
+    }
+
+    if (frame.empty())
+        return;
+
+    m_is_processing.store(true, std::memory_order_release);
+    m_result = m_executor.run(m_sequence, frame, m_width, m_height);
+    m_is_processing.store(false, std::memory_order_release);
+}
+
+void VisionProcessor::set_sequence(Kinesis::Vision::VisionSequence sequence)
+{
+    m_sequence = std::move(sequence);
+    m_executor.reset();
+}
+
+} // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Processors/VisionProcessor.cpp
+++ b/src/MayaFlux/Kakshya/Processors/VisionProcessor.cpp
@@ -5,6 +5,7 @@
 #include "MayaFlux/Kakshya/Source/VideoStreamContainer.hpp"
 #include "MayaFlux/Kakshya/Source/WindowContainer.hpp"
 
+#include "MayaFlux/Kriya/Awaiters/BroadcastAwaiter.hpp"
 #include "MayaFlux/Vruta/BroadcastSource.hpp"
 
 namespace MayaFlux::Kakshya {

--- a/src/MayaFlux/Kakshya/Processors/VisionProcessor.hpp
+++ b/src/MayaFlux/Kakshya/Processors/VisionProcessor.hpp
@@ -4,6 +4,11 @@
 #include "MayaFlux/Kinesis/Vision/VisionExecutor.hpp"
 #include "MayaFlux/Kinesis/Vision/VisionOp.hpp"
 
+namespace MayaFlux::Vruta {
+template <typename T>
+class BroadcastSource;
+}
+
 namespace MayaFlux::Kakshya {
 
 /**
@@ -83,17 +88,32 @@ public:
      */
     [[nodiscard]] const Kinesis::Vision::VisionResult& get_result() const { return m_result; }
 
+    /**
+     * @brief Shared BroadcastSource signalled with each VisionResult after a
+     *        successful process() call.
+     *
+     * Created on first call. Wire with Kriya::on_signal to consume results
+     * from a coroutine without polling get_result().
+     *
+     * One coroutine per source. For multiple consumers create one
+     * VisionProcessor per consumer or poll get_result() directly.
+     *
+     * @return Shared pointer to the BroadcastSource, never null after first call.
+     */
+    [[nodiscard]] std::shared_ptr<Vruta::BroadcastSource<Kinesis::Vision::VisionResult>> get_result_source();
+
 private:
     Kinesis::Vision::VisionSequence m_sequence;
     Kinesis::Vision::VisionExecutor m_executor;
     Kinesis::Vision::VisionResult m_result;
 
-    uint32_t m_width { 0 };
-    uint32_t m_height { 0 };
+    uint32_t m_width {};
+    uint32_t m_height {};
 
     mutable std::vector<float> m_float_storage;
 
     std::atomic<bool> m_is_processing { false };
+    std::shared_ptr<Vruta::BroadcastSource<Kinesis::Vision::VisionResult>> m_result_source;
 };
 
 } // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Processors/VisionProcessor.hpp
+++ b/src/MayaFlux/Kakshya/Processors/VisionProcessor.hpp
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "MayaFlux/Kakshya/DataProcessor.hpp"
+#include "MayaFlux/Kinesis/Vision/VisionExecutor.hpp"
+#include "MayaFlux/Kinesis/Vision/VisionOp.hpp"
+
+namespace MayaFlux::Kakshya {
+
+/**
+ * @class VisionProcessor
+ * @brief DataProcessor executing a Kinesis::Vision pipeline on pixel container data.
+ *
+ * Compatible with three container types, each accessed via its native normalised
+ * float path:
+ *   - VideoStreamContainer: processed_frame_as_float(0) on processed_data
+ *   - WindowContainer:      processed_frame_as_float(0) on processed_data
+ *   - TextureContainer:     as_normalised_float(0) on m_data
+ *
+ * on_attach throws std::invalid_argument for any other container type.
+ * Runs the configured VisionSequence through VisionExecutor and stores the
+ * VisionResult as member state for polling via get_result().
+ *
+ * Width and height are read from get_structure() at on_attach time.
+ * m_float_storage is reused across calls to avoid per-frame allocation.
+ *
+ * @see FrameAccessProcessor, WindowAccessProcessor, VisionExecutor, VisionSequence
+ */
+class MAYAFLUX_API VisionProcessor : public DataProcessor {
+public:
+    /**
+     * @brief Construct with the vision pipeline to execute each process() call.
+     * @param sequence Ordered VisionSteps describing the pipeline.
+     */
+    explicit VisionProcessor(Kinesis::Vision::VisionSequence sequence);
+
+    ~VisionProcessor() override = default;
+
+    /**
+     * @brief Cache frame geometry from get_structure(). Resets executor state.
+     *
+     * Called automatically by DataProcessingChain::add_processor.
+     *
+     * @param container The SignalSourceContainer to attach to.
+     */
+    void on_attach(const std::shared_ptr<SignalSourceContainer>& container) override;
+
+    /**
+     * @brief Clear cached geometry and reset executor state.
+     * @param container The SignalSourceContainer being detached.
+     */
+    void on_detach(const std::shared_ptr<SignalSourceContainer>& container) override;
+
+    /**
+     * @brief Execute the VisionSequence on processed_data[0].
+     *
+     * No-op when processed_data is empty, the pixel span normalises to empty,
+     * or geometry was not cached at on_attach time.
+     *
+     * @param container The container to read processed_data[0] from.
+     */
+    void process(const std::shared_ptr<SignalSourceContainer>& container) override;
+
+    [[nodiscard]] bool is_processing() const override
+    {
+        return m_is_processing.load(std::memory_order_acquire);
+    }
+
+    /**
+     * @brief Replace the pipeline and reset inter-frame executor state.
+     *
+     * Not thread-safe relative to process(). Call only when process() is idle.
+     *
+     * @param sequence Replacement VisionSequence.
+     */
+    void set_sequence(Kinesis::Vision::VisionSequence sequence);
+
+    /**
+     * @brief The result of the last successful process() call.
+     *
+     * Default-initialised until the first process() call completes.
+     *
+     * @return Most recent VisionResult.
+     */
+    [[nodiscard]] const Kinesis::Vision::VisionResult& get_result() const { return m_result; }
+
+private:
+    Kinesis::Vision::VisionSequence m_sequence;
+    Kinesis::Vision::VisionExecutor m_executor;
+    Kinesis::Vision::VisionResult m_result;
+
+    uint32_t m_width { 0 };
+    uint32_t m_height { 0 };
+
+    mutable std::vector<float> m_float_storage;
+
+    std::atomic<bool> m_is_processing { false };
+};
+
+} // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Source/TextureContainer.cpp
+++ b/src/MayaFlux/Kakshya/Source/TextureContainer.cpp
@@ -1,11 +1,15 @@
 #include "TextureContainer.hpp"
 
 #include "MayaFlux/Core/Backends/Graphics/Vulkan/VKImage.hpp"
-#include "MayaFlux/Journal/Archivist.hpp"
 #include "MayaFlux/Kakshya/NDData/DataAccess.hpp"
+
 #include "MayaFlux/Kakshya/Utils/CoordUtils.hpp"
+#include "MayaFlux/Kakshya/Utils/DataUtils.hpp"
 #include "MayaFlux/Kakshya/Utils/RegionUtils.hpp"
+
 #include "MayaFlux/Portal/Graphics/TextureLoom.hpp"
+
+#include "MayaFlux/Journal/Archivist.hpp"
 
 namespace MayaFlux::Kakshya {
 
@@ -188,6 +192,12 @@ TextureContainer::TextureContainer(uint32_t width, uint32_t height, ImageFormat 
         m_data.emplace_back(make_empty_storage(m_format, element_count));
     }
 
+    m_normalised_cache.resize(m_data.size());
+
+    m_normalised_dirty = std::vector<std::atomic<bool>>(m_data.size());
+    for (auto& flag : m_normalised_dirty)
+        flag.store(true, std::memory_order_relaxed);
+
     m_slot_locks.resize(m_data.size());
     setup_dimensions();
 
@@ -259,6 +269,7 @@ void TextureContainer::from_image(const std::shared_ptr<Core::VKImage>& image, u
         TextureLoom::instance().download_data(image, ptr, sz, nullptr);
     }
 
+    m_normalised_dirty[layer].store(true, std::memory_order_release);
     update_processing_state(ProcessingState::READY);
 }
 
@@ -294,6 +305,7 @@ void TextureContainer::from_image(
         TextureLoom::instance().download_data(image, ptr, sz, staging);
     }
 
+    m_normalised_dirty[layer].store(true, std::memory_order_release);
     update_processing_state(ProcessingState::READY);
 }
 
@@ -324,6 +336,8 @@ void TextureContainer::from_image_array(const std::shared_ptr<Core::VKImage>& im
         auto [ptr, bytes] = variant_bytes_mut(m_data[i]);
         if (ptr && bytes == layer_bytes)
             std::memcpy(ptr, combined.data() + i * layer_bytes, layer_bytes);
+
+        m_normalised_dirty[i].store(true, std::memory_order_release);
     }
 
     update_processing_state(ProcessingState::READY);
@@ -358,6 +372,8 @@ void TextureContainer::from_image_array(
         auto [ptr, bytes] = variant_bytes_mut(m_data[i]);
         if (ptr && bytes == layer_bytes)
             std::memcpy(ptr, combined.data() + i * layer_bytes, layer_bytes);
+
+        m_normalised_dirty[i].store(true, std::memory_order_release);
     }
 
     update_processing_state(ProcessingState::READY);
@@ -565,6 +581,7 @@ void TextureContainer::set_pixels(std::span<const uint8_t> data, uint32_t layer)
 
     Memory::SeqlockWriteGuard g(m_slot_locks[layer]);
     std::ranges::copy(data, buf->begin());
+    m_normalised_dirty[layer].store(true, std::memory_order_release);
 }
 
 void TextureContainer::set_pixels(std::span<const uint16_t> data, uint32_t layer)
@@ -590,6 +607,7 @@ void TextureContainer::set_pixels(std::span<const uint16_t> data, uint32_t layer
 
     Memory::SeqlockWriteGuard g(m_slot_locks[layer]);
     std::ranges::copy(data, buf->begin());
+    m_normalised_dirty[layer].store(true, std::memory_order_release);
 }
 
 void TextureContainer::set_pixels(std::span<const float> data, uint32_t layer)
@@ -615,6 +633,26 @@ void TextureContainer::set_pixels(std::span<const float> data, uint32_t layer)
 
     Memory::SeqlockWriteGuard g(m_slot_locks[layer]);
     std::ranges::copy(data, buf->begin());
+    m_normalised_dirty[layer].store(true, std::memory_order_release);
+}
+
+std::span<const float> TextureContainer::as_normalised_float(uint32_t layer) const
+{
+    if (layer >= m_data.size())
+        return {};
+
+    if (!m_normalised_dirty[layer].load(std::memory_order_acquire))
+        return { m_normalised_cache[layer] };
+
+    std::span<const float> result;
+    seqlock_read_void(m_slot_locks[layer], 8, [&] {
+        result = Kakshya::as_normalised_float(m_data[layer], m_normalised_cache[layer]);
+    });
+
+    if (!result.empty())
+        m_normalised_dirty[layer].store(false, std::memory_order_release);
+
+    return result;
 }
 
 //=============================================================================

--- a/src/MayaFlux/Kakshya/Source/TextureContainer.hpp
+++ b/src/MayaFlux/Kakshya/Source/TextureContainer.hpp
@@ -261,6 +261,22 @@ public:
      */
     void set_pixels(std::span<const float> data, uint32_t layer = 0);
 
+    /**
+     * @brief Layer pixel data as a normalised float span.
+     *
+     * uint8_t source is divided by 255.0f. uint16_t by 65535.0f.
+     * float source is zero-copy into the variant's own storage.
+     * Returns empty span if layer is out of range or the variant
+     * holds a non-pixel type.
+     *
+     * Result is cached per layer and reused until set_pixels()
+     * or from_image() invalidates it for that layer.
+     *
+     * @param layer Array layer index. Defaults to 0.
+     * @return Normalised float span, w * h * channels elements.
+     */
+    [[nodiscard]] std::span<const float> as_normalised_float(uint32_t layer = 0) const;
+
     //=========================================================================
     // Metadata
     //=========================================================================
@@ -428,6 +444,9 @@ private:
     std::vector<DataVariant> m_processed_data;
     std::shared_ptr<DataProcessor> m_processor;
     std::shared_ptr<DataProcessingChain> m_chain;
+
+    mutable std::vector<std::vector<float>> m_normalised_cache;
+    mutable std::vector<std::atomic<bool>> m_normalised_dirty;
 
     ContainerDataStructure m_structure;
 

--- a/src/MayaFlux/Kakshya/Source/VideoStreamContainer.cpp
+++ b/src/MayaFlux/Kakshya/Source/VideoStreamContainer.cpp
@@ -117,6 +117,14 @@ void VideoStreamContainer::setup_ring(uint64_t total_frames,
         setup_dimensions();
     }
 
+    if (m_float_frame_cache.size() != ring_capacity) {
+        m_float_frame_cache.resize(ring_capacity);
+        m_float_frame_dirty = std::vector<std::atomic<bool>>(ring_capacity);
+
+        for (auto& flag : m_float_frame_dirty)
+            flag.store(true, std::memory_order_relaxed);
+    }
+
     update_processing_state(ProcessingState::IDLE);
 }
 
@@ -671,28 +679,34 @@ void VideoStreamContainer::set_value_impl(
     (*pixels)[idx] = *static_cast<const uint8_t*>(in);
 }
 
-std::span<const float> VideoStreamContainer::processed_frame_as_float(
-    uint64_t frame_index) const
+std::span<const float> VideoStreamContainer::processed_frame_as_float(uint64_t frame_index) const
 {
     if (frame_index >= m_processed_data.size())
         return {};
 
-    if (!m_float_frame_dirty.load(std::memory_order_acquire)
-        && m_float_frame_cached_index == frame_index)
-        return { m_float_frame_cache };
-
-    auto result = as_normalised_float(m_processed_data[frame_index], m_float_frame_cache);
-    if (!result.empty()) {
-        m_float_frame_cached_index = frame_index;
-        m_float_frame_dirty.store(false, std::memory_order_release);
+    if (frame_index >= m_float_frame_cache.size()) {
+        m_float_frame_cache.resize(frame_index + 1);
+        m_float_frame_dirty[frame_index].store(true, std::memory_order_relaxed);
     }
+
+    if (!m_float_frame_dirty[frame_index].load(std::memory_order_acquire))
+        return { m_float_frame_cache[frame_index] };
+
+    auto result = as_normalised_float(m_processed_data[frame_index], m_float_frame_cache[frame_index]);
+    if (!result.empty())
+        m_float_frame_dirty[frame_index].store(false, std::memory_order_release);
 
     return result;
 }
 
 void VideoStreamContainer::invalidate_float_frame_cache()
 {
-    m_float_frame_dirty.store(true, std::memory_order_release);
+    if (m_processed_data.size() > m_float_frame_dirty.size()) {
+        m_float_frame_cache.resize(m_processed_data.size());
+        m_float_frame_dirty = std::vector<std::atomic<bool>>(m_processed_data.size());
+    }
+    for (auto& flag : m_float_frame_dirty)
+        flag.store(true, std::memory_order_release);
 }
 
 } // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Source/VideoStreamContainer.cpp
+++ b/src/MayaFlux/Kakshya/Source/VideoStreamContainer.cpp
@@ -5,6 +5,7 @@
 #include "MayaFlux/Kakshya/NDData/DataAccess.hpp"
 #include "MayaFlux/Kakshya/Processors/FrameAccessProcessor.hpp"
 #include "MayaFlux/Kakshya/Utils/CoordUtils.hpp"
+#include "MayaFlux/Kakshya/Utils/DataUtils.hpp"
 #include "MayaFlux/Kakshya/Utils/RegionUtils.hpp"
 
 #include "MayaFlux/Registry/BackendRegistry.hpp"
@@ -668,6 +669,30 @@ void VideoStreamContainer::set_value_impl(
         return;
 
     (*pixels)[idx] = *static_cast<const uint8_t*>(in);
+}
+
+std::span<const float> VideoStreamContainer::processed_frame_as_float(
+    uint64_t frame_index) const
+{
+    if (frame_index >= m_processed_data.size())
+        return {};
+
+    if (!m_float_frame_dirty.load(std::memory_order_acquire)
+        && m_float_frame_cached_index == frame_index)
+        return { m_float_frame_cache };
+
+    auto result = as_normalised_float(m_processed_data[frame_index], m_float_frame_cache);
+    if (!result.empty()) {
+        m_float_frame_cached_index = frame_index;
+        m_float_frame_dirty.store(false, std::memory_order_release);
+    }
+
+    return result;
+}
+
+void VideoStreamContainer::invalidate_float_frame_cache()
+{
+    m_float_frame_dirty.store(true, std::memory_order_release);
 }
 
 } // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Source/VideoStreamContainer.hpp
+++ b/src/MayaFlux/Kakshya/Source/VideoStreamContainer.hpp
@@ -393,6 +393,23 @@ protected:
     void set_value_impl(const std::vector<uint64_t>& coords,
         const void* in, const std::type_info& type) override;
 
+    /**
+     * @brief Processed frame at @p frame_index as a normalised float span.
+     *
+     * Valid after FrameAccessProcessor has written processed_data.
+     * uint8_t source values are divided by 255.0f. float source is
+     * zero-copy. Returns empty span if frame_index is out of range or
+     * the variant holds a non-pixel type.
+     *
+     * The cache covers the last requested frame_index only. A call with
+     * a different index invalidates and recomputes.
+     *
+     * @param frame_index Zero-based index into processed_data. Defaults to 0.
+     * @return Normalised float span, w * h * channels elements.
+     */
+    [[nodiscard]] std::span<const float> processed_frame_as_float(
+        uint64_t frame_index = 0) const;
+
 private:
     [[nodiscard]] std::span<const uint8_t> get_frame_typed(uint64_t frame_index) const
     {
@@ -400,6 +417,12 @@ private:
     }
 
     void get_frames_typed(std::span<uint8_t> output, uint64_t start_frame, uint64_t num_frames) const;
+
+    void invalidate_float_frame_cache();
+
+    mutable std::vector<float> m_float_frame_cache;
+    mutable std::atomic<bool> m_float_frame_dirty { true };
+    mutable uint64_t m_float_frame_cached_index { std::numeric_limits<uint64_t>::max() };
 };
 
 } // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Source/VideoStreamContainer.hpp
+++ b/src/MayaFlux/Kakshya/Source/VideoStreamContainer.hpp
@@ -183,6 +183,23 @@ public:
         return m_cache_head.load(std::memory_order_acquire);
     }
 
+    /**
+     * @brief Processed frame at @p frame_index as a normalised float span.
+     *
+     * Valid after FrameAccessProcessor has written processed_data.
+     * uint8_t source values are divided by 255.0f. float source is
+     * zero-copy. Returns empty span if frame_index is out of range or
+     * the variant holds a non-pixel type.
+     *
+     * The cache covers the last requested frame_index only. A call with
+     * a different index invalidates and recomputes.
+     *
+     * @param frame_index Zero-based index into processed_data. Defaults to 0.
+     * @return Normalised float span, w * h * channels elements.
+     */
+    [[nodiscard]] std::span<const float> processed_frame_as_float(
+        uint64_t frame_index = 0) const;
+
     // =========================================================================
     // RegionGroup management
     // =========================================================================
@@ -269,6 +286,8 @@ public:
     {
         return m_processing_token_channel.load() == channel;
     }
+
+    void invalidate_float_frame_cache();
 
     // =========================================================================
     // Data access
@@ -393,23 +412,6 @@ protected:
     void set_value_impl(const std::vector<uint64_t>& coords,
         const void* in, const std::type_info& type) override;
 
-    /**
-     * @brief Processed frame at @p frame_index as a normalised float span.
-     *
-     * Valid after FrameAccessProcessor has written processed_data.
-     * uint8_t source values are divided by 255.0f. float source is
-     * zero-copy. Returns empty span if frame_index is out of range or
-     * the variant holds a non-pixel type.
-     *
-     * The cache covers the last requested frame_index only. A call with
-     * a different index invalidates and recomputes.
-     *
-     * @param frame_index Zero-based index into processed_data. Defaults to 0.
-     * @return Normalised float span, w * h * channels elements.
-     */
-    [[nodiscard]] std::span<const float> processed_frame_as_float(
-        uint64_t frame_index = 0) const;
-
 private:
     [[nodiscard]] std::span<const uint8_t> get_frame_typed(uint64_t frame_index) const
     {
@@ -417,8 +419,6 @@ private:
     }
 
     void get_frames_typed(std::span<uint8_t> output, uint64_t start_frame, uint64_t num_frames) const;
-
-    void invalidate_float_frame_cache();
 
     mutable std::vector<std::vector<float>> m_float_frame_cache;
     mutable std::vector<std::atomic<bool>> m_float_frame_dirty;

--- a/src/MayaFlux/Kakshya/Source/VideoStreamContainer.hpp
+++ b/src/MayaFlux/Kakshya/Source/VideoStreamContainer.hpp
@@ -420,9 +420,8 @@ private:
 
     void invalidate_float_frame_cache();
 
-    mutable std::vector<float> m_float_frame_cache;
-    mutable std::atomic<bool> m_float_frame_dirty { true };
-    mutable uint64_t m_float_frame_cached_index { std::numeric_limits<uint64_t>::max() };
+    mutable std::vector<std::vector<float>> m_float_frame_cache;
+    mutable std::vector<std::atomic<bool>> m_float_frame_dirty;
 };
 
 } // namespace MayaFlux::Kakshya

--- a/src/MayaFlux/Kakshya/Source/WindowContainer.cpp
+++ b/src/MayaFlux/Kakshya/Source/WindowContainer.cpp
@@ -5,6 +5,7 @@
 #include "MayaFlux/Kakshya/NDData/DataAccess.hpp"
 #include "MayaFlux/Kakshya/Processors/WindowAccessProcessor.hpp"
 #include "MayaFlux/Kakshya/Utils/CoordUtils.hpp"
+#include "MayaFlux/Kakshya/Utils/DataUtils.hpp"
 #include "MayaFlux/Kakshya/Utils/RegionUtils.hpp"
 #include "MayaFlux/Kakshya/Utils/SurfaceUtils.hpp"
 
@@ -97,6 +98,11 @@ void WindowContainer::setup_dimensions()
     m_data.resize(m_frame_capacity);
     for (auto& slot : m_data)
         slot = std::vector<uint8_t>(sz, 0U);
+
+    m_normalised_cache.resize(m_frame_capacity);
+    m_normalised_dirty = std::vector<std::atomic<bool>>(m_frame_capacity);
+    for (auto& flag : m_normalised_dirty)
+        flag.store(true, std::memory_order_relaxed);
 
     m_processed_data.resize(1);
     m_processed_data[0] = std::vector<uint8_t>(sz, 0U);
@@ -461,6 +467,32 @@ void WindowContainer::handle_surface_resize()
     m_write_head.store(0, std::memory_order_release);
     m_frames_written.store(0, std::memory_order_release);
     setup_dimensions();
+}
+
+std::span<const float> WindowContainer::processed_frame_as_float(uint32_t frame_index) const
+{
+    if (frame_index >= m_processed_data.size())
+        return {};
+
+    if (!m_normalised_dirty[frame_index].load(std::memory_order_acquire))
+        return { m_normalised_cache[frame_index] };
+
+    std::span<const float> result;
+    seqlock_read_void(m_data_lock, 8, [&] {
+        result = Kakshya::as_normalised_float(m_processed_data[frame_index], m_normalised_cache[frame_index]);
+    });
+
+    if (!result.empty())
+        m_normalised_dirty[frame_index].store(false, std::memory_order_release);
+
+    return result;
+}
+
+void WindowContainer::invalidate_float_frame_cache(uint32_t frame_index)
+{
+    if (frame_index >= m_normalised_dirty.size())
+        return;
+    m_normalised_dirty[frame_index].store(true, std::memory_order_release);
 }
 
 // =========================================================================

--- a/src/MayaFlux/Kakshya/Source/WindowContainer.hpp
+++ b/src/MayaFlux/Kakshya/Source/WindowContainer.hpp
@@ -225,6 +225,33 @@ public:
      */
     void handle_surface_resize();
 
+    /**
+     * @brief processed_data[frame_index] as a normalised float span.
+     *
+     * Valid after WindowAccessProcessor has written processed_data[frame_index].
+     * uint8_t values divided by 255.0f; uint16_t by 65535.0f; float is zero-copy.
+     * Returns empty span if frame_index is out of range or the variant holds a
+     * non-pixel type.
+     *
+     * Result is cached per slot and reused until invalidate_float_frame_cache()
+     * is called for that slot.
+     *
+     * @param frame_index Zero-based index into processed_data. Defaults to 0.
+     * @return Normalised float span, width * height * channels elements.
+     */
+    [[nodiscard]] std::span<const float> processed_frame_as_float(uint32_t frame_index = 0) const;
+
+    /**
+     * @brief Invalidate the normalised float cache for a specific processed_data slot.
+     *
+     * Called by WindowAccessProcessor after each successful readback into
+     * processed_data[frame_index]. Forces recomputation on the next
+     * processed_frame_as_float() call for that slot.
+     *
+     * @param frame_index Zero-based index into processed_data.
+     */
+    void invalidate_float_frame_cache(uint32_t frame_index);
+
     // =========================================================================
     // SignalSourceContainer
     // =========================================================================
@@ -290,6 +317,9 @@ private:
     std::vector<DataVariant> m_data;
     std::vector<DataVariant> m_processed_data;
 
+    mutable std::vector<std::vector<float>> m_normalised_cache;
+    mutable std::vector<std::atomic<bool>> m_normalised_dirty;
+
     std::unordered_map<std::string, RegionGroup> m_region_groups;
 
     std::shared_ptr<DataProcessor> m_default_processor;
@@ -313,7 +343,6 @@ private:
 
     void setup_dimensions();
 
-private:
     [[nodiscard]] auto get_frame_typed(uint64_t frame_index) const -> std::span<const uint8_t>;
     void get_frames_typed(std::span<uint8_t> output, uint64_t start_frame, uint64_t num_frames) const;
 };

--- a/src/MayaFlux/Kakshya/Utils/DataUtils.cpp
+++ b/src/MayaFlux/Kakshya/Utils/DataUtils.cpp
@@ -1,5 +1,7 @@
 #include "DataUtils.hpp"
 
+#include "MayaFlux/Transitive/Parallel/Execution.hpp"
+
 namespace MayaFlux::Kakshya {
 
 uint64_t calculate_total_elements(const std::vector<DataDimension>& dimensions)
@@ -54,6 +56,40 @@ void safe_copy_data_variant(const DataVariant& input, DataVariant& output)
         }
     },
         input, output);
+}
+
+std::span<const float> as_normalised_float(
+    const DataVariant& variant, std::vector<float>& storage)
+{
+    return std::visit([&storage](const auto& vec) -> std::span<const float> {
+        using T = typename std::decay_t<decltype(vec)>::value_type;
+
+        if constexpr (std::is_same_v<T, float>) {
+            return { vec.data(), vec.size() };
+
+        } else if constexpr (std::is_same_v<T, uint8_t>) {
+            storage.resize(vec.size());
+            constexpr float k = 1.0F / 255.0F;
+
+            std::transform(Parallel::par_unseq,
+                vec.begin(), vec.end(), storage.begin(),
+                [](uint8_t v) { return static_cast<float>(v) * k; });
+            return { storage.data(), storage.size() };
+
+        } else if constexpr (std::is_same_v<T, uint16_t>) {
+            storage.resize(vec.size());
+            constexpr float k = 1.0F / 65535.0F;
+
+            std::transform(Parallel::par_unseq,
+                vec.begin(), vec.end(), storage.begin(),
+                [](uint16_t v) { return static_cast<float>(v) * k; });
+            return { storage.data(), storage.size() };
+
+        } else {
+            return {};
+        }
+    },
+        variant);
 }
 
 void set_metadata_value(std::unordered_map<std::string, std::any>& metadata, const std::string& key, std::any value)

--- a/src/MayaFlux/Kakshya/Utils/DataUtils.hpp
+++ b/src/MayaFlux/Kakshya/Utils/DataUtils.hpp
@@ -573,6 +573,27 @@ inline std::span<double> convert_variant_to_double(DataVariant& data,
 }
 
 /**
+ * @brief Extract a DataVariant holding pixel data as a normalised float span.
+ *
+ * Normalisation factors:
+ *   uint8_t  -> divided by 255.0f
+ *   uint16_t -> divided by 65535.0f
+ *   float    -> zero-copy span directly into the variant's storage
+ *
+ * Does not mutate the variant. Writes into @p storage only when conversion
+ * is required. Returns an empty span if the active alternative is not one
+ * of the three pixel types (double, complex, and GLM variants return empty).
+ *
+ * @param variant Source DataVariant.
+ * @param storage Caller-supplied buffer. Reuse across calls to avoid
+ *                per-frame allocation. Untouched when float is active.
+ * @return Normalised float span. Points into @p storage for uint8/uint16,
+ *         directly into the variant's internal storage for float.
+ */
+[[nodiscard]] MAYAFLUX_API std::span<const float> as_normalised_float(
+    const DataVariant& variant, std::vector<float>& storage);
+
+/**
  * @brief Set a value in a metadata map (key-value).
  * @param metadata Metadata map.
  * @param key Key to set.

--- a/src/MayaFlux/Kinesis/Vision/ConnectedComponents.cpp
+++ b/src/MayaFlux/Kinesis/Vision/ConnectedComponents.cpp
@@ -1,0 +1,139 @@
+#include "ConnectedComponents.hpp"
+
+namespace MayaFlux::Kinesis::Vision {
+
+namespace {
+
+    inline bool is_fg(float v) noexcept { return v >= 0.5F; }
+
+    // =========================================================================
+    // Union-find with path compression and union by rank
+    // =========================================================================
+
+    struct UnionFind {
+        std::vector<uint32_t> parent;
+        std::vector<uint32_t> rank;
+
+        explicit UnionFind(size_t n)
+            : parent(n)
+            , rank(n, 0)
+        {
+            std::iota(parent.begin(), parent.end(), 0U);
+        }
+
+        uint32_t find(uint32_t x)
+        {
+            while (parent[x] != x) {
+                parent[x] = parent[parent[x]];
+                x = parent[x];
+            }
+            return x;
+        }
+
+        void unite(uint32_t a, uint32_t b)
+        {
+            a = find(a);
+            b = find(b);
+            if (a == b)
+                return;
+            if (rank[a] < rank[b])
+                std::swap(a, b);
+            parent[b] = a;
+            if (rank[a] == rank[b])
+                ++rank[a];
+        }
+    };
+
+} // namespace
+
+ComponentResult connected_components(
+    std::span<const float> mask, uint32_t w, uint32_t h)
+{
+    const size_t n = static_cast<size_t>(w) * h;
+
+    std::vector<uint32_t> labels(n, 0);
+    UnionFind uf(n + 1);
+    uint32_t next_label = 1;
+
+    for (uint32_t py = 0; py < h; ++py) {
+        for (uint32_t px = 0; px < w; ++px) {
+            const size_t idx = static_cast<size_t>(py) * w + px;
+
+            if (!is_fg(mask[idx]))
+                continue;
+
+            uint32_t left = 0;
+            uint32_t above = 0;
+
+            if (px > 0 && is_fg(mask[idx - 1]))
+                left = labels[idx - 1];
+            if (py > 0 && is_fg(mask[idx - w]))
+                above = labels[idx - w];
+
+            if (left == 0 && above == 0) {
+                labels[idx] = next_label++;
+            } else if (left != 0 && above == 0) {
+                labels[idx] = left;
+            } else if (left == 0 && above != 0) {
+                labels[idx] = above;
+            } else {
+                labels[idx] = left;
+                uf.unite(left, above);
+            }
+        }
+    }
+
+    std::vector<uint32_t> remap(next_label, 0);
+    uint32_t compact = 0;
+    for (uint32_t i = 1; i < next_label; ++i) {
+        const uint32_t root = uf.find(i);
+        if (remap[root] == 0)
+            remap[root] = ++compact;
+        remap[i] = remap[root];
+    }
+
+    struct Extent {
+        uint32_t x_min, y_min, x_max, y_max;
+        uint32_t pixel_count;
+    };
+
+    std::vector<Extent> extents(compact + 1,
+        Extent { .x_min = w, .y_min = h, .x_max = 0, .y_max = 0, .pixel_count = 0 });
+
+    for (uint32_t py = 0; py < h; ++py) {
+        for (uint32_t px = 0; px < w; ++px) {
+            const size_t idx = static_cast<size_t>(py) * w + px;
+            if (labels[idx] == 0)
+                continue;
+
+            const uint32_t lbl = remap[labels[idx]];
+            labels[idx] = lbl;
+
+            auto& e = extents[lbl];
+            e.x_min = std::min(e.x_min, px);
+            e.y_min = std::min(e.y_min, py);
+            e.x_max = std::max(e.x_max, px);
+            e.y_max = std::max(e.y_max, py);
+            ++e.pixel_count;
+        }
+    }
+
+    const float inv_w = 1.0F / static_cast<float>(w);
+    const float inv_h = 1.0F / static_cast<float>(h);
+
+    std::vector<BoundingBox> boxes;
+    boxes.reserve(compact);
+
+    for (uint32_t i = 1; i <= compact; ++i) {
+        const auto& e = extents[i];
+        const float x = static_cast<float>(e.x_min) * inv_w;
+        const float y = static_cast<float>(e.y_min) * inv_h;
+        const float bw = static_cast<float>(e.x_max - e.x_min + 1) * inv_w;
+        const float bh = static_cast<float>(e.y_max - e.y_min + 1) * inv_h;
+        boxes.push_back({ .x = x, .y = y, .w = bw, .h = bh, .confidence = 1.0F, .label_id = i });
+    }
+
+    return { .label_map = std::move(labels), .boxes = std::move(boxes), .count = compact };
+}
+
+} // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Kinesis/Vision/ConnectedComponents.hpp
+++ b/src/MayaFlux/Kinesis/Vision/ConnectedComponents.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "Features.hpp"
+
+/**
+ * @file ConnectedComponents.hpp
+ * @brief Connected component labelling on normalised float masks.
+ *
+ * Pure functions. No MayaFlux type dependencies.
+ *
+ * ## Conventions
+ * - Input masks are single-channel float where >= 0.5f is foreground
+ * - Label 0 is background; component labels start at 1
+ * - BoundingBox coordinates are normalised to [0, 1]
+ * - 8-connectivity is used throughout
+ */
+
+namespace MayaFlux::Kinesis::Vision {
+
+/**
+ * @brief Result of connected component labelling.
+ */
+struct ComponentResult {
+    std::vector<uint32_t> label_map; ///< Per-pixel label, same size as input mask.
+    std::vector<BoundingBox> boxes; ///< One BoundingBox per component, label 1..count.
+    uint32_t count; ///< Number of components found.
+};
+
+/**
+ * @brief Label connected foreground components in a binary mask.
+ *
+ * Uses a two-pass union-find algorithm. First pass assigns provisional
+ * labels and records equivalences. Second pass resolves equivalences and
+ * relabels to a compact 1..count range.
+ *
+ * BoundingBox per component is computed during the second pass.
+ * Coordinates are normalised by w and h to [0, 1].
+ *
+ * @param mask Single-channel float span, size must be w * h.
+ * @param w    Image width in pixels.
+ * @param h    Image height in pixels.
+ * @return     ComponentResult with label_map, boxes, and count.
+ */
+[[nodiscard]] MAYAFLUX_API ComponentResult connected_components(
+    std::span<const float> mask, uint32_t w, uint32_t h);
+
+} // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Kinesis/Vision/Contours.cpp
+++ b/src/MayaFlux/Kinesis/Vision/Contours.cpp
@@ -1,0 +1,163 @@
+#include "Contours.hpp"
+
+namespace MayaFlux::Kinesis::Vision {
+
+namespace {
+
+    inline bool is_fg(float v) noexcept { return v >= 0.5F; }
+
+    // 8-connected clockwise direction offsets starting from right (+x)
+    // Order: E, SE, S, SW, W, NW, N, NE
+    constexpr int32_t dx8[] = { 1, 1, 0, -1, -1, -1, 0, 1 };
+    constexpr int32_t dy8[] = { 0, 1, 1, 1, 0, -1, -1, -1 };
+
+    // =========================================================================
+    // Border following (Moore neighbourhood tracing)
+    // =========================================================================
+
+    std::vector<glm::vec2> trace_contour(
+        const std::vector<uint8_t>& visited,
+        std::span<const float> mask,
+        uint32_t w, uint32_t h,
+        uint32_t start_x, uint32_t start_y)
+    {
+        std::vector<glm::vec2> points;
+
+        auto cx = static_cast<int32_t>(start_x);
+        auto cy = static_cast<int32_t>(start_y);
+
+        int32_t start_dir = 0;
+        for (int32_t d = 0; d < 8; ++d) {
+            const int32_t nx = cx + dx8[d];
+            const int32_t ny = cy + dy8[d];
+            if (nx < 0 || ny < 0
+                || nx >= static_cast<int32_t>(w)
+                || ny >= static_cast<int32_t>(h)
+                || !is_fg(mask[static_cast<size_t>(ny) * w + nx])) {
+                start_dir = d;
+                break;
+            }
+        }
+
+        const int32_t orig_x = cx;
+        const int32_t orig_y = cy;
+        int32_t dir = start_dir;
+        bool first = true;
+
+        while (true) {
+            bool found = false;
+            for (int32_t i = 0; i < 8; ++i) {
+                const int32_t d = (dir + 6 + i) % 8;
+                const int32_t nx = cx + dx8[d];
+                const int32_t ny = cy + dy8[d];
+
+                if (nx < 0 || ny < 0
+                    || nx >= static_cast<int32_t>(w)
+                    || ny >= static_cast<int32_t>(h))
+                    continue;
+
+                if (is_fg(mask[static_cast<size_t>(ny) * w + nx])) {
+                    points.emplace_back(static_cast<float>(cx) / static_cast<float>(w),
+                        static_cast<float>(cy) / static_cast<float>(h));
+                    cx = nx;
+                    cy = ny;
+                    dir = d;
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found)
+                break;
+
+            if (!first && cx == orig_x && cy == orig_y)
+                break;
+
+            first = false;
+
+            if (points.size() > static_cast<size_t>(w) * h)
+                break;
+        }
+
+        return points;
+    }
+
+    // =========================================================================
+    // Shoelace area and perimeter
+    // =========================================================================
+
+    float polygon_area(const std::vector<glm::vec2>& pts)
+    {
+        float area = 0.0F;
+        const size_t n = pts.size();
+        for (size_t i = 0, j = n - 1; i < n; j = i++) {
+            area += pts[j].x * pts[i].y;
+            area -= pts[i].x * pts[j].y;
+        }
+        return std::abs(area) * 0.5F;
+    }
+
+    float polygon_perimeter(const std::vector<glm::vec2>& pts)
+    {
+        float perim = 0.0F;
+        const size_t n = pts.size();
+        for (size_t i = 0, j = n - 1; i < n; j = i++)
+            perim += glm::length(pts[i] - pts[j]);
+        return perim;
+    }
+
+} // namespace
+
+std::vector<Contour> find_contours(
+    std::span<const float> mask, uint32_t w, uint32_t h)
+{
+    const size_t n = static_cast<size_t>(w) * h;
+    std::vector<uint8_t> visited(n, 0);
+    std::vector<Contour> result;
+
+    for (uint32_t py = 0; py < h; ++py) {
+        for (uint32_t px = 0; px < w; ++px) {
+            const size_t idx = static_cast<size_t>(py) * w + px;
+
+            if (!is_fg(mask[idx]) || visited[idx])
+                continue;
+
+            bool is_border = false;
+            if (px == 0 || py == 0
+                || px == w - 1 || py == h - 1) {
+                is_border = true;
+            } else {
+                if (!is_fg(mask[idx - 1])
+                    || !is_fg(mask[idx + 1])
+                    || !is_fg(mask[idx - w])
+                    || !is_fg(mask[idx + w]))
+                    is_border = true;
+            }
+
+            if (!is_border) {
+                visited[idx] = 1;
+                continue;
+            }
+
+            auto points = trace_contour(visited, mask, w, h, px, py);
+
+            for (const auto& p : points) {
+                const auto vx = static_cast<uint32_t>(p.x * static_cast<float>(w));
+                const auto vy = static_cast<uint32_t>(p.y * static_cast<float>(h));
+                visited[static_cast<size_t>(vy) * w + vx] = 1;
+            }
+
+            if (points.size() < 3)
+                continue;
+
+            const float area = polygon_area(points);
+            const float perim = polygon_perimeter(points);
+
+            result.push_back({ .points = std::move(points), .area = area, .perimeter = perim });
+        }
+    }
+
+    return result;
+}
+
+} // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Kinesis/Vision/Contours.hpp
+++ b/src/MayaFlux/Kinesis/Vision/Contours.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "Features.hpp"
+
+/**
+ * @file Contours.hpp
+ * @brief Contour extraction from binary float masks.
+ *
+ * Pure functions. No MayaFlux type dependencies.
+ *
+ * ## Conventions
+ * - Input masks are single-channel float where >= 0.5f is foreground
+ * - Contour points are in normalised image coordinates [0, 1]
+ * - 8-connectivity is used for contour tracing
+ * - Area is normalised to [0, 1] relative to total image area (w * h)
+ * - Perimeter is normalised to [0, 1] relative to image diagonal
+ */
+
+namespace MayaFlux::Kinesis::Vision {
+
+/**
+ * @brief Extract outer contours from a binary mask.
+ *
+ * Uses the Suzuki-Abe border following algorithm (single pass).
+ * Only outer contours are extracted; holes are not traced.
+ * Each contour is a closed polygon; the last point connects back
+ * to the first.
+ *
+ * Contours with fewer than 3 points are discarded.
+ *
+ * @param mask Single-channel float span, size must be w * h.
+ * @param w    Image width in pixels.
+ * @param h    Image height in pixels.
+ * @return     Vector of Contour, each with normalised points, area,
+ *             and perimeter.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<Contour> find_contours(
+    std::span<const float> mask, uint32_t w, uint32_t h);
+
+} // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Kinesis/Vision/Features.hpp
+++ b/src/MayaFlux/Kinesis/Vision/Features.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "MayaFlux/Kinesis/Spatial/Bounds.hpp"
+
+namespace MayaFlux::Kinesis::Vision {
+
+/**
+ * @brief Axis-aligned bounding box in normalised image coordinates.
+ *
+ * Origin is top-left, x and y in [0, 1], +Y down. Distinct from
+ * Kinesis::AABB2D which is NDC with center origin and +Y up.
+ *
+ * Use to_ndc() to convert to AABB2D for Forma hit testing.
+ */
+struct BoundingBox {
+    float x {};
+    float y {};
+    float w {};
+    float h {};
+    float confidence { 1.0F };
+    uint32_t label_id {};
+
+    /**
+     * @brief Convert to NDC AABB2D for use with Portal::Forma::Element.
+     *
+     * Maps [0, 1] image space to [-1, 1] NDC, flipping Y axis.
+     */
+    [[nodiscard]] Kinesis::AABB2D to_ndc() const noexcept
+    {
+        return {
+            .min = { x * 2.0F - 1.0F, 1.0F - (y + h) * 2.0F },
+            .max = { (x + w) * 2.0F - 1.0F, 1.0F - y * 2.0F },
+        };
+    }
+};
+
+/**
+ * @brief Closed contour extracted from a binary mask.
+ *
+ * Points are in normalised image coordinates [0, 1], top-left origin.
+ */
+struct Contour {
+    std::vector<glm::vec2> points;
+    float area;
+    float perimeter;
+};
+
+/**
+ * @brief Single interest point produced by a corner or blob detector.
+ *
+ * Position is in normalised image coordinates [0, 1], top-left origin.
+ */
+struct Keypoint {
+    glm::vec2 position;
+    float response;
+    float scale;
+    float angle;
+};
+
+} // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Kinesis/Vision/Filter.cpp
+++ b/src/MayaFlux/Kinesis/Vision/Filter.cpp
@@ -1,0 +1,96 @@
+#include "Filter.hpp"
+
+#include "MayaFlux/Transitive/Parallel/Execution.hpp"
+
+namespace P = MayaFlux::Parallel;
+
+namespace MayaFlux::Kinesis::Vision {
+
+namespace {
+
+    void convolve_horizontal(
+        std::span<const float> src, std::span<float> dst,
+        uint32_t w, uint32_t h,
+        std::span<const float> kernel)
+    {
+        const auto half = static_cast<int32_t>(kernel.size() / 2);
+        const size_t n = static_cast<size_t>(w) * h;
+
+        P::for_each(P::par_unseq,
+            std::views::iota(size_t { 0 }, n).begin(),
+            std::views::iota(size_t { 0 }, n).end(),
+            [&](size_t idx) {
+                const auto py = static_cast<int32_t>(idx / w);
+                const auto px = static_cast<int32_t>(idx % w);
+                float acc = 0.0F;
+                for (int32_t k = -half; k <= half; ++k) {
+                    const int32_t nx = std::clamp(px + k, 0, static_cast<int32_t>(w) - 1);
+                    acc += src[static_cast<size_t>(py) * w + nx]
+                        * kernel[static_cast<size_t>(k + half)];
+                }
+                dst[idx] = acc;
+            });
+    }
+
+    void convolve_vertical(
+        std::span<const float> src, std::span<float> dst,
+        uint32_t w, uint32_t h,
+        std::span<const float> kernel)
+    {
+        const auto half = static_cast<int32_t>(kernel.size() / 2);
+        const size_t n = static_cast<size_t>(w) * h;
+
+        P::for_each(P::par_unseq,
+            std::views::iota(size_t { 0 }, n).begin(),
+            std::views::iota(size_t { 0 }, n).end(),
+            [&](size_t idx) {
+                const auto py = static_cast<int32_t>(idx / w);
+                const auto px = static_cast<int32_t>(idx % w);
+                float acc = 0.0F;
+                for (int32_t k = -half; k <= half; ++k) {
+                    const int32_t ny = std::clamp(py + k, 0, static_cast<int32_t>(h) - 1);
+                    acc += src[static_cast<size_t>(ny) * w + px]
+                        * kernel[static_cast<size_t>(k + half)];
+                }
+                dst[idx] = acc;
+            });
+    }
+
+} // namespace
+
+std::vector<float> filter_separable(
+    std::span<const float> src, uint32_t w, uint32_t h,
+    std::span<const float> kernel_x, std::span<const float> kernel_y)
+{
+    const size_t n = static_cast<size_t>(w) * h;
+    std::vector<float> tmp(n);
+    std::vector<float> out(n);
+
+    convolve_horizontal(src, tmp, w, h, kernel_x);
+    convolve_vertical(tmp, out, w, h, kernel_y);
+
+    return out;
+}
+
+std::vector<float> gaussian_blur(
+    std::span<const float> src, uint32_t w, uint32_t h, float sigma)
+{
+    const auto radius = static_cast<int32_t>(std::ceil(3.0F * sigma));
+    const int32_t size = 2 * radius + 1;
+
+    std::vector<float> kernel(static_cast<size_t>(size));
+    float sum = 0.0F;
+    const float inv_2s2 = 1.0F / (2.0F * sigma * sigma);
+
+    for (int32_t i = -radius; i <= radius; ++i) {
+        const float v = std::exp(-static_cast<float>(i * i) * inv_2s2);
+        kernel[static_cast<size_t>(i + radius)] = v;
+        sum += v;
+    }
+    for (auto& v : kernel)
+        v /= sum;
+
+    return filter_separable(src, w, h, kernel, kernel);
+}
+
+} // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Kinesis/Vision/Filter.hpp
+++ b/src/MayaFlux/Kinesis/Vision/Filter.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+/**
+ * @file Filter.hpp
+ * @brief 2D spatial filtering on normalised float image spans.
+ *
+ * Pure functions. No MayaFlux type dependencies.
+ *
+ * ## Conventions
+ * - All inputs are single-channel normalised float in [0, 1] unless noted
+ * - w and h are pixel dimensions; caller ensures span size == w * h
+ * - Border handling is clamp-to-edge throughout
+ * - Separable filters decompose into two 1D passes for O(w*h*k) cost
+ *   rather than O(w*h*k^2)
+ * - Parallelism handled internally via Parallel::par_unseq
+ */
+
+namespace MayaFlux::Kinesis::Vision {
+
+// ============================================================================
+// Separable convolution
+// ============================================================================
+
+/**
+ * @brief Apply a separable 2D filter via two 1D passes.
+ *
+ * Applies kernel_x horizontally then kernel_y vertically.
+ * Both kernels are applied with clamp-to-edge border handling.
+ *
+ * @param src      Single-channel float span, size must be w * h.
+ * @param w        Image width in pixels.
+ * @param h        Image height in pixels.
+ * @param kernel_x Horizontal 1D kernel. Length must be odd.
+ * @param kernel_y Vertical 1D kernel. Length must be odd.
+ * @return         Filtered float vector of length w * h.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<float> filter_separable(
+    std::span<const float> src, uint32_t w, uint32_t h,
+    std::span<const float> kernel_x, std::span<const float> kernel_y);
+
+// ============================================================================
+// Gaussian blur
+// ============================================================================
+
+/**
+ * @brief Separable Gaussian blur.
+ *
+ * Kernel radius is ceil(3 * sigma). Kernel is normalised to unit sum.
+ * Decomposes into horizontal and vertical 1D passes via filter_separable.
+ *
+ * @param src   Single-channel float span, size must be w * h.
+ * @param w     Image width in pixels.
+ * @param h     Image height in pixels.
+ * @param sigma Standard deviation in pixels. Must be > 0.
+ * @return      Blurred float vector of length w * h.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<float> gaussian_blur(
+    std::span<const float> src, uint32_t w, uint32_t h, float sigma);
+
+} // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Kinesis/Vision/Gradient.cpp
+++ b/src/MayaFlux/Kinesis/Vision/Gradient.cpp
@@ -16,8 +16,9 @@ namespace {
     {
         const size_t n = static_cast<size_t>(w) * h;
 
-        auto dx = filter_separable(gray, w, h, kx, { (const float[]) { 1.0F, 2.0F, 1.0F }, 3 });
-        auto dy = filter_separable(gray, w, h, { (const float[]) { 1.0F, 2.0F, 1.0F }, 3 }, ky);
+        static constexpr float smooth[] = { 1.0f, 2.0f, 1.0f };
+        auto dx = filter_separable(gray, w, h, kx, smooth);
+        auto dy = filter_separable(gray, w, h, smooth, ky);
 
         std::vector<float> mag(n);
         std::vector<float> ang(n);

--- a/src/MayaFlux/Kinesis/Vision/Gradient.cpp
+++ b/src/MayaFlux/Kinesis/Vision/Gradient.cpp
@@ -1,0 +1,155 @@
+#include "Gradient.hpp"
+
+#include "Filter.hpp"
+
+#include "MayaFlux/Transitive/Parallel/Execution.hpp"
+
+namespace P = MayaFlux::Parallel;
+
+namespace MayaFlux::Kinesis::Vision {
+
+namespace {
+
+    GradientResult gradient_from_kernels(
+        std::span<const float> gray, uint32_t w, uint32_t h,
+        std::span<const float> kx, std::span<const float> ky)
+    {
+        const size_t n = static_cast<size_t>(w) * h;
+
+        auto dx = filter_separable(gray, w, h, kx, { (const float[]) { 1.0F, 2.0F, 1.0F }, 3 });
+        auto dy = filter_separable(gray, w, h, { (const float[]) { 1.0F, 2.0F, 1.0F }, 3 }, ky);
+
+        std::vector<float> mag(n);
+        std::vector<float> ang(n);
+
+        float max_mag = 0.0F;
+
+        P::for_each(P::par_unseq,
+            std::views::iota(size_t { 0 }, n).begin(),
+            std::views::iota(size_t { 0 }, n).end(),
+            [&](size_t i) {
+                mag[i] = std::sqrt(dx[i] * dx[i] + dy[i] * dy[i]);
+                ang[i] = std::atan2(dy[i], dx[i]);
+            });
+
+        const float peak = *std::ranges::max_element(mag);
+        if (peak > 0.0F) {
+            const float inv = 1.0F / peak;
+            P::transform(P::par_unseq, mag.begin(), mag.end(), mag.begin(),
+                [inv](float v) { return v * inv; });
+        }
+
+        return { .dx = std::move(dx), .dy = std::move(dy), .magnitude = std::move(mag), .angle = std::move(ang) };
+    }
+
+} // namespace
+
+GradientResult sobel(std::span<const float> gray, uint32_t w, uint32_t h)
+{
+    const float kx[] = { -1.0F, 0.0F, 1.0F };
+    const float ky[] = { -1.0F, 0.0F, 1.0F };
+    return gradient_from_kernels(gray, w, h, kx, ky);
+}
+
+GradientResult scharr(std::span<const float> gray, uint32_t w, uint32_t h)
+{
+    const float kx[] = { -3.0F, 0.0F, 3.0F };
+    const float ky[] = { -3.0F, 0.0F, 3.0F };
+    return gradient_from_kernels(gray, w, h, kx, ky);
+}
+
+std::vector<float> canny(
+    std::span<const float> gray, uint32_t w, uint32_t h,
+    float sigma, float low_threshold, float high_threshold)
+{
+    const size_t n = static_cast<size_t>(w) * h;
+
+    std::vector<float> blurred;
+    std::span<const float> src = gray;
+    if (sigma > 0.0F) {
+        blurred = gaussian_blur(gray, w, h, sigma);
+        src = blurred;
+    }
+
+    auto grad = sobel(src, w, h);
+
+    std::vector<float> nms(n, 0.0F);
+    P::for_each(P::par_unseq,
+        std::views::iota(size_t { 0 }, n).begin(),
+        std::views::iota(size_t { 0 }, n).end(),
+        [&](size_t idx) {
+            const auto px = static_cast<int32_t>(idx % w);
+            const auto py = static_cast<int32_t>(idx / w);
+
+            if (px == 0 || py == 0
+                || px == static_cast<int32_t>(w) - 1
+                || py == static_cast<int32_t>(h) - 1)
+                return;
+
+            const float angle = grad.angle[idx];
+            const float pi = std::numbers::pi_v<float>;
+
+            float norm_angle = angle < 0.0F ? angle + pi : angle;
+            norm_angle = norm_angle / pi * 4.0F;
+
+            int32_t ox = 0, oy = 0;
+            if (norm_angle < 0.5F || norm_angle >= 3.5F) {
+                ox = 1;
+            } else if (norm_angle < 1.5F) {
+                ox = 1;
+                oy = 1;
+            } else if (norm_angle < 2.5F) {
+                oy = 1;
+            } else {
+                ox = -1;
+                oy = 1;
+            }
+
+            const float m = grad.magnitude[idx];
+            const float m_pos = grad.magnitude[static_cast<size_t>(py + oy) * w + static_cast<size_t>(px + ox)];
+            const float m_neg = grad.magnitude[static_cast<size_t>(py - oy) * w + static_cast<size_t>(px - ox)];
+
+            if (m >= m_pos && m >= m_neg)
+                nms[idx] = m;
+        });
+
+    std::vector<float> out(n, 0.0F);
+    std::vector<uint8_t> strong(n, 0);
+    std::vector<uint8_t> weak(n, 0);
+
+    for (size_t i = 0; i < n; ++i) {
+        if (nms[i] >= high_threshold) {
+            strong[i] = 1;
+        } else if (nms[i] >= low_threshold) {
+            weak[i] = 1;
+        }
+    }
+
+    for (size_t idx = 0; idx < n; ++idx) {
+        if (!strong[idx])
+            continue;
+        out[idx] = 1.0F;
+        const auto px = static_cast<int32_t>(idx % w);
+        const auto py = static_cast<int32_t>(idx / w);
+
+        for (int32_t dy = -1; dy <= 1; ++dy) {
+            for (int32_t dx = -1; dx <= 1; ++dx) {
+                if (dx == 0 && dy == 0)
+                    continue;
+                const int32_t nx = px + dx;
+                const int32_t ny = py + dy;
+                if (nx < 0 || ny < 0
+                    || nx >= static_cast<int32_t>(w)
+                    || ny >= static_cast<int32_t>(h))
+                    continue;
+                const size_t ni = static_cast<size_t>(ny) * w + nx;
+                if (weak[ni])
+                    out[ni] = 1.0F;
+            }
+        }
+    }
+
+    return out;
+}
+
+} // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Kinesis/Vision/Gradient.cpp
+++ b/src/MayaFlux/Kinesis/Vision/Gradient.cpp
@@ -125,10 +125,17 @@ std::vector<float> canny(
         }
     }
 
-    for (size_t idx = 0; idx < n; ++idx) {
-        if (!strong[idx])
-            continue;
+    std::vector<size_t> stack;
+    for (size_t i = 0; i < n; ++i) {
+        if (strong[i])
+            stack.push_back(i);
+    }
+
+    while (!stack.empty()) {
+        const size_t idx = stack.back();
+        stack.pop_back();
         out[idx] = 1.0F;
+
         const auto px = static_cast<int32_t>(idx % w);
         const auto py = static_cast<int32_t>(idx / w);
 
@@ -143,8 +150,8 @@ std::vector<float> canny(
                     || ny >= static_cast<int32_t>(h))
                     continue;
                 const size_t ni = static_cast<size_t>(ny) * w + nx;
-                if (weak[ni])
-                    out[ni] = 1.0F;
+                if (weak[ni] && out[ni] == 0.0F)
+                    stack.push_back(ni);
             }
         }
     }

--- a/src/MayaFlux/Kinesis/Vision/Gradient.hpp
+++ b/src/MayaFlux/Kinesis/Vision/Gradient.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+/**
+ * @file Gradient.hpp
+ * @brief Gradient and edge detection on normalised float image spans.
+ *
+ * Pure functions. No MayaFlux type dependencies.
+ *
+ * ## Conventions
+ * - All inputs are single-channel normalised float in [0, 1]
+ * - w and h are pixel dimensions; caller ensures span size == w * h
+ * - Border handling is clamp-to-edge throughout
+ * - Gradient angle is in radians in [-pi, pi], measured from +X axis
+ * - Parallelism handled internally via Parallel::par_unseq
+ */
+
+namespace MayaFlux::Kinesis::Vision {
+
+/**
+ * @brief Gradient maps produced by Sobel and Scharr operators.
+ */
+struct GradientResult {
+    std::vector<float> dx; ///< Horizontal gradient component.
+    std::vector<float> dy; ///< Vertical gradient component.
+    std::vector<float> magnitude; ///< Gradient magnitude, normalised to [0, 1].
+    std::vector<float> angle; ///< Gradient angle in radians, [-pi, pi].
+};
+
+// ============================================================================
+// Gradient operators
+// ============================================================================
+
+/**
+ * @brief Sobel gradient operator.
+ *
+ * 3x3 Sobel kernels applied separably. dx and dy are in [-1, 1].
+ * Magnitude is normalised by the theoretical maximum (4 * 255 / 255 = 4
+ * for uint8 sources, but since input is already [0,1] the max magnitude
+ * is sqrt(2) which is divided out). Angle via atan2(dy, dx).
+ *
+ * @param gray Single-channel float span, size must be w * h.
+ * @param w    Image width in pixels.
+ * @param h    Image height in pixels.
+ * @return     GradientResult with all four maps populated.
+ */
+[[nodiscard]] MAYAFLUX_API GradientResult sobel(
+    std::span<const float> gray, uint32_t w, uint32_t h);
+
+/**
+ * @brief Scharr gradient operator.
+ *
+ * 3x3 Scharr kernels. Better rotational symmetry than Sobel.
+ * Same output contract as sobel().
+ *
+ * @param gray Single-channel float span, size must be w * h.
+ * @param w    Image width in pixels.
+ * @param h    Image height in pixels.
+ * @return     GradientResult with all four maps populated.
+ */
+[[nodiscard]] MAYAFLUX_API GradientResult scharr(
+    std::span<const float> gray, uint32_t w, uint32_t h);
+
+// ============================================================================
+// Edge detection
+// ============================================================================
+
+/**
+ * @brief Canny edge detector.
+ *
+ * Pipeline: gaussian_blur(sigma) -> sobel -> non-maximum suppression ->
+ * double threshold -> hysteresis. Output is binary: 1.0f on edges, 0.0f
+ * elsewhere.
+ *
+ * @param gray           Single-channel float span, size must be w * h.
+ * @param w              Image width in pixels.
+ * @param h              Image height in pixels.
+ * @param sigma          Gaussian pre-blur sigma. 0.0f skips blur.
+ * @param low_threshold  Hysteresis low threshold in [0, 1].
+ * @param high_threshold Hysteresis high threshold in [0, 1].
+ * @return               Binary float vector of length w * h.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<float> canny(
+    std::span<const float> gray, uint32_t w, uint32_t h,
+    float sigma, float low_threshold, float high_threshold);
+
+} // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Kinesis/Vision/Harris.cpp
+++ b/src/MayaFlux/Kinesis/Vision/Harris.cpp
@@ -1,0 +1,114 @@
+#include "Harris.hpp"
+
+#include "Filter.hpp"
+#include "Gradient.hpp"
+
+#include "MayaFlux/Transitive/Parallel/Execution.hpp"
+
+namespace P = MayaFlux::Parallel;
+
+namespace MayaFlux::Kinesis::Vision {
+
+std::vector<float> harris_response(
+    std::span<const float> gray, uint32_t w, uint32_t h,
+    float k, float sigma)
+{
+    const size_t n = static_cast<size_t>(w) * h;
+
+    auto grad = sobel(gray, w, h);
+
+    std::vector<float> ixx(n), iyy(n), ixy(n);
+
+    P::for_each(P::par_unseq,
+        std::views::iota(size_t { 0 }, n).begin(),
+        std::views::iota(size_t { 0 }, n).end(),
+        [&](size_t i) {
+            const float dx = grad.dx[i];
+            const float dy = grad.dy[i];
+            ixx[i] = dx * dx;
+            iyy[i] = dy * dy;
+            ixy[i] = dx * dy;
+        });
+
+    auto sxx = gaussian_blur(ixx, w, h, sigma);
+    auto syy = gaussian_blur(iyy, w, h, sigma);
+    auto sxy = gaussian_blur(ixy, w, h, sigma);
+
+    std::vector<float> response(n);
+
+    P::for_each(P::par_unseq,
+        std::views::iota(size_t { 0 }, n).begin(),
+        std::views::iota(size_t { 0 }, n).end(),
+        [&](size_t i) {
+            const float det = sxx[i] * syy[i] - sxy[i] * sxy[i];
+            const float trace = sxx[i] + syy[i];
+            response[i] = std::max(0.0F, det - k * trace * trace);
+        });
+
+    const float peak = *std::ranges::max_element(response);
+    if (peak > 0.0F) {
+        const float inv = 1.0F / peak;
+        P::transform(P::par_unseq,
+            response.begin(), response.end(), response.begin(),
+            [inv](float v) { return v * inv; });
+    }
+
+    return response;
+}
+
+std::vector<Keypoint> extract_peaks(
+    std::span<const float> response, uint32_t w, uint32_t h,
+    float threshold, uint32_t nms_radius)
+{
+    const auto n = static_cast<size_t>(w) * h;
+    const auto r = static_cast<int32_t>(nms_radius);
+
+    std::vector<Keypoint> keypoints;
+
+    for (uint32_t py = 0; py < h; ++py) {
+        for (uint32_t px = 0; px < w; ++px) {
+            const size_t idx = static_cast<size_t>(py) * w + px;
+            const float val = response[idx];
+
+            if (val < threshold)
+                continue;
+
+            bool is_max = true;
+            for (int32_t dy = -r; dy <= r && is_max; ++dy) {
+                const int32_t ny = static_cast<int32_t>(py) + dy;
+                if (ny < 0 || ny >= static_cast<int32_t>(h))
+                    continue;
+                for (int32_t dx = -r; dx <= r && is_max; ++dx) {
+                    if (dx == 0 && dy == 0)
+                        continue;
+                    const int32_t nx = static_cast<int32_t>(px) + dx;
+                    if (nx < 0 || nx >= static_cast<int32_t>(w))
+                        continue;
+                    const size_t ni = static_cast<size_t>(ny) * w + nx;
+                    if (response[ni] >= val)
+                        is_max = false;
+                }
+            }
+
+            if (!is_max)
+                continue;
+
+            keypoints.push_back({
+                .position = {
+                    (static_cast<float>(px) + 0.5F) / static_cast<float>(w),
+                    (static_cast<float>(py) + 0.5F) / static_cast<float>(h) },
+                .response = val,
+                .scale = 1.0F,
+                .angle = 0.0F,
+            });
+        }
+    }
+
+    std::ranges::sort(keypoints, [](const Keypoint& a, const Keypoint& b) {
+        return a.response > b.response;
+    });
+
+    return keypoints;
+}
+
+} // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Kinesis/Vision/Harris.hpp
+++ b/src/MayaFlux/Kinesis/Vision/Harris.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "Features.hpp"
+
+/**
+ * @file Harris.hpp
+ * @brief Harris corner detection and non-maximum suppression.
+ *
+ * Pure functions. No MayaFlux type dependencies.
+ *
+ * ## Conventions
+ * - Input is single-channel normalised float in [0, 1]
+ * - w and h are pixel dimensions; caller ensures span size == w * h
+ * - Response map is normalised to [0, 1] by observed peak
+ * - Keypoint positions are normalised to [0, 1]
+ * - Parallelism handled internally via Parallel::par_unseq
+ */
+
+namespace MayaFlux::Kinesis::Vision {
+
+/**
+ * @brief Compute the Harris corner response map.
+ *
+ * For each pixel computes R = det(M) - k * trace(M)^2 where M is the
+ * structure tensor accumulated over a sigma-weighted window. Negative
+ * responses are clamped to 0. Output is normalised to [0, 1] by the
+ * observed peak response.
+ *
+ * Structure tensor gradients are computed via a 3x3 Sobel operator.
+ * The tensor is smoothed with a Gaussian of standard deviation sigma
+ * before computing det and trace.
+ *
+ * @param gray  Single-channel float span, size must be w * h.
+ * @param w     Image width in pixels.
+ * @param h     Image height in pixels.
+ * @param k     Harris sensitivity parameter. Typical range [0.04, 0.06].
+ * @param sigma Gaussian smoothing sigma for structure tensor. Must be > 0.
+ * @return      Response map float vector of length w * h, values in [0, 1].
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<float> harris_response(
+    std::span<const float> gray, uint32_t w, uint32_t h,
+    float k = 0.04F, float sigma = 1.0F);
+
+/**
+ * @brief Extract peaks from a response map via non-maximum suppression.
+ *
+ * A pixel is a peak if its response exceeds threshold and it is the
+ * strict maximum within a square window of half-size nms_radius.
+ * Ties are broken in favour of the pixel with the lower raster index.
+ *
+ * Returned Keypoints are sorted by descending response.
+ *
+ * @param response   Response map span, size must be w * h, values in [0, 1].
+ * @param w          Image width in pixels.
+ * @param h          Image height in pixels.
+ * @param threshold  Minimum response value to consider. In [0, 1].
+ * @param nms_radius Non-maximum suppression half-window size in pixels.
+ * @return           Keypoints sorted by descending response.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<Keypoint> extract_peaks(
+    std::span<const float> response, uint32_t w, uint32_t h,
+    float threshold, uint32_t nms_radius);
+
+} // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Kinesis/Vision/Morphology.cpp
+++ b/src/MayaFlux/Kinesis/Vision/Morphology.cpp
@@ -1,0 +1,88 @@
+#include "Morphology.hpp"
+
+#include "MayaFlux/Transitive/Parallel/Execution.hpp"
+
+namespace P = MayaFlux::Parallel;
+
+namespace MayaFlux::Kinesis::Vision {
+
+namespace {
+
+    inline bool is_fg(float v) noexcept { return v >= 0.5F; }
+
+    std::vector<float> morph_op(
+        std::span<const float> mask, uint32_t w, uint32_t h,
+        uint32_t radius, bool dilating)
+    {
+        const size_t n = static_cast<size_t>(w) * h;
+        const auto r = static_cast<int32_t>(radius);
+        std::vector<float> out(n);
+
+        P::for_each(P::par_unseq,
+            std::views::iota(size_t { 0 }, n).begin(),
+            std::views::iota(size_t { 0 }, n).end(),
+            [&](size_t idx) {
+                const auto px = static_cast<int32_t>(idx % w);
+                const auto py = static_cast<int32_t>(idx / w);
+
+                bool result = !dilating;
+
+                for (int32_t dy = -r; dy <= r && result == !dilating; ++dy) {
+                    const int32_t ny = std::clamp(py + dy, 0, static_cast<int32_t>(h) - 1);
+                    for (int32_t dx = -r; dx <= r && result == !dilating; ++dx) {
+                        const int32_t nx = std::clamp(px + dx, 0, static_cast<int32_t>(w) - 1);
+                        const bool fg = is_fg(mask[static_cast<size_t>(ny) * w + nx]);
+                        if (dilating && fg) {
+                            result = true;
+                        } else if (!dilating && !fg) {
+                            result = false;
+                        }
+                    }
+                }
+
+                out[idx] = result ? 1.0F : 0.0F;
+            });
+
+        return out;
+    }
+
+} // namespace
+
+std::vector<float> erode(
+    std::span<const float> mask, uint32_t w, uint32_t h, uint32_t radius)
+{
+    return morph_op(mask, w, h, radius, false);
+}
+
+std::vector<float> dilate(
+    std::span<const float> mask, uint32_t w, uint32_t h, uint32_t radius)
+{
+    return morph_op(mask, w, h, radius, true);
+}
+
+std::vector<float> open(
+    std::span<const float> mask, uint32_t w, uint32_t h, uint32_t radius)
+{
+    return dilate(erode(mask, w, h, radius), w, h, radius);
+}
+
+std::vector<float> close(
+    std::span<const float> mask, uint32_t w, uint32_t h, uint32_t radius)
+{
+    return erode(dilate(mask, w, h, radius), w, h, radius);
+}
+
+std::vector<float> morph_gradient(
+    std::span<const float> mask, uint32_t w, uint32_t h, uint32_t radius)
+{
+    const auto d = dilate(mask, w, h, radius);
+    const auto e = erode(mask, w, h, radius);
+
+    std::vector<float> out(d.size());
+    P::transform(P::par_unseq, d.begin(), d.end(), e.begin(), out.begin(),
+        [](float dv, float ev) { return dv - ev; });
+
+    return out;
+}
+
+} // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Kinesis/Vision/Morphology.hpp
+++ b/src/MayaFlux/Kinesis/Vision/Morphology.hpp
@@ -1,0 +1,101 @@
+#pragma once
+
+/**
+ * @file Morphology.hpp
+ * @brief Binary morphological operations on normalised float masks.
+ *
+ * Pure functions. No MayaFlux type dependencies.
+ *
+ * ## Conventions
+ * - Input masks are single-channel float where 1.0f is foreground
+ *   and 0.0f is background. Values are treated as binary: >= 0.5f
+ *   is foreground, < 0.5f is background.
+ * - Output is strictly binary: 1.0f or 0.0f
+ * - w and h are pixel dimensions; caller ensures span size == w * h
+ * - radius is the structuring element half-size in pixels. A radius
+ *   of 1 produces a 3x3 square structuring element.
+ * - Border handling is clamp-to-edge throughout
+ * - Parallelism handled internally via Parallel::par_unseq
+ */
+
+namespace MayaFlux::Kinesis::Vision {
+
+// ============================================================================
+// Primitive operations
+// ============================================================================
+
+/**
+ * @brief Morphological erosion with square structuring element.
+ *
+ * A pixel is 1.0f only if all pixels within radius are foreground.
+ *
+ * @param mask   Single-channel float span, size must be w * h.
+ * @param w      Image width in pixels.
+ * @param h      Image height in pixels.
+ * @param radius Structuring element half-size in pixels.
+ * @return       Eroded binary float vector of length w * h.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<float> erode(
+    std::span<const float> mask, uint32_t w, uint32_t h, uint32_t radius);
+
+/**
+ * @brief Morphological dilation with square structuring element.
+ *
+ * A pixel is 1.0f if any pixel within radius is foreground.
+ *
+ * @param mask   Single-channel float span, size must be w * h.
+ * @param w      Image width in pixels.
+ * @param h      Image height in pixels.
+ * @param radius Structuring element half-size in pixels.
+ * @return       Dilated binary float vector of length w * h.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<float> dilate(
+    std::span<const float> mask, uint32_t w, uint32_t h, uint32_t radius);
+
+// ============================================================================
+// Compound operations
+// ============================================================================
+
+/**
+ * @brief Morphological opening: erode then dilate.
+ *
+ * Removes small foreground regions and smooths boundaries.
+ *
+ * @param mask   Single-channel float span, size must be w * h.
+ * @param w      Image width in pixels.
+ * @param h      Image height in pixels.
+ * @param radius Structuring element half-size in pixels.
+ * @return       Opened binary float vector of length w * h.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<float> open(
+    std::span<const float> mask, uint32_t w, uint32_t h, uint32_t radius);
+
+/**
+ * @brief Morphological closing: dilate then erode.
+ *
+ * Fills small holes and gaps in foreground regions.
+ *
+ * @param mask   Single-channel float span, size must be w * h.
+ * @param w      Image width in pixels.
+ * @param h      Image height in pixels.
+ * @param radius Structuring element half-size in pixels.
+ * @return       Closed binary float vector of length w * h.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<float> close(
+    std::span<const float> mask, uint32_t w, uint32_t h, uint32_t radius);
+
+/**
+ * @brief Morphological gradient: dilate minus erode.
+ *
+ * Produces the outline of foreground regions.
+ *
+ * @param mask   Single-channel float span, size must be w * h.
+ * @param w      Image width in pixels.
+ * @param h      Image height in pixels.
+ * @param radius Structuring element half-size in pixels.
+ * @return       Binary float vector of length w * h.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<float> morph_gradient(
+    std::span<const float> mask, uint32_t w, uint32_t h, uint32_t radius);
+
+} // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Kinesis/Vision/OpticalFlow.cpp
+++ b/src/MayaFlux/Kinesis/Vision/OpticalFlow.cpp
@@ -1,0 +1,204 @@
+#include "OpticalFlow.hpp"
+
+#include "Filter.hpp"
+#include "Gradient.hpp"
+
+#include "MayaFlux/Transitive/Parallel/Execution.hpp"
+
+namespace P = MayaFlux::Parallel;
+
+namespace MayaFlux::Kinesis::Vision {
+
+namespace {
+
+    // =========================================================================
+    // Bilinear sample with clamp-to-edge
+    // =========================================================================
+
+    float sample(std::span<const float> img, uint32_t w, uint32_t h,
+        float x, float y)
+    {
+        x = std::clamp(x, 0.0F, static_cast<float>(w) - 1.001F);
+        y = std::clamp(y, 0.0F, static_cast<float>(h) - 1.001F);
+
+        const auto ix = static_cast<int32_t>(x);
+        const auto iy = static_cast<int32_t>(y);
+        const float fx = x - static_cast<float>(ix);
+        const float fy = y - static_cast<float>(iy);
+
+        const int32_t ix1 = std::min(ix + 1, static_cast<int32_t>(w) - 1);
+        const int32_t iy1 = std::min(iy + 1, static_cast<int32_t>(h) - 1);
+
+        const float v00 = img[static_cast<size_t>(iy) * w + ix];
+        const float v10 = img[static_cast<size_t>(iy) * w + ix1];
+        const float v01 = img[static_cast<size_t>(iy1) * w + ix];
+        const float v11 = img[static_cast<size_t>(iy1) * w + ix1];
+
+        return v00 * (1.0F - fx) * (1.0F - fy)
+            + v10 * fx * (1.0F - fy)
+            + v01 * (1.0F - fx) * fy
+            + v11 * fx * fy;
+    }
+
+    // =========================================================================
+    // Lucas-Kanade for a single point
+    // =========================================================================
+
+    TrackResult lk_point(
+        std::span<const float> prev,
+        std::span<const float> curr,
+        std::span<const float> dx,
+        std::span<const float> dy,
+        uint32_t w, uint32_t h,
+        glm::vec2 pt,
+        uint32_t window_radius,
+        uint32_t max_iterations,
+        float eigen_threshold,
+        float error_threshold)
+    {
+        const auto pw = static_cast<float>(w);
+        const auto ph = static_cast<float>(h);
+
+        float px = pt.x * pw - 0.5F;
+        float py = pt.y * ph - 0.5F;
+
+        const auto r = static_cast<int32_t>(window_radius);
+
+        float sxx = 0.0F, syy = 0.0F, sxy = 0.0F;
+
+        for (int32_t wy = -r; wy <= r; ++wy) {
+            for (int32_t wx = -r; wx <= r; ++wx) {
+                const float sx = std::clamp(px + wx, 0.0F, pw - 1.0F);
+                const float sy = std::clamp(py + wy, 0.0F, ph - 1.0F);
+                const auto ix = static_cast<int32_t>(sx);
+                const auto iy = static_cast<int32_t>(sy);
+                const size_t ni = static_cast<size_t>(iy) * w + ix;
+
+                const float gx = dx[ni];
+                const float gy = dy[ni];
+                sxx += gx * gx;
+                syy += gy * gy;
+                sxy += gx * gy;
+            }
+        }
+
+        const float trace = sxx + syy;
+        const float det = sxx * syy - sxy * sxy;
+        const float disc = std::sqrt(std::max(0.0F,
+            trace * trace * 0.25F - det));
+        const float min_eig = trace * 0.5F - disc;
+
+        if (min_eig < eigen_threshold)
+            return { .position = pt, .error = 1.0F, .tracked = false };
+
+        const float inv_det = 1.0F / (det + 1e-10F);
+
+        float vx = 0.0F, vy = 0.0F;
+
+        for (uint32_t iter = 0; iter < max_iterations; ++iter) {
+            float bx = 0.0F, by = 0.0F;
+
+            for (int32_t wy = -r; wy <= r; ++wy) {
+                for (int32_t wx = -r; wx <= r; ++wx) {
+                    const float sx = std::clamp(px + wx, 0.0F, pw - 1.0F);
+                    const float sy = std::clamp(py + wy, 0.0F, ph - 1.0F);
+                    const auto ix = static_cast<int32_t>(sx);
+                    const auto iy = static_cast<int32_t>(sy);
+                    const size_t ni = static_cast<size_t>(iy) * w + ix;
+
+                    const float gx = dx[ni];
+                    const float gy = dy[ni];
+
+                    const float p_val = prev[ni];
+                    const float c_val = sample(curr, w, h,
+                        px + wx + vx, py + wy + vy);
+                    const float it = p_val - c_val;
+
+                    bx += it * gx;
+                    by += it * gy;
+                }
+            }
+
+            const float dvx = (syy * bx - sxy * by) * inv_det;
+            const float dvy = (sxx * by - sxy * bx) * inv_det;
+
+            vx += dvx;
+            vy += dvy;
+
+            if (dvx * dvx + dvy * dvy < 0.03F * 0.03F)
+                break;
+        }
+
+        const float nx = px + vx;
+        const float ny = py + vy;
+
+        if (nx < 0.0F || ny < 0.0F
+            || nx >= pw || ny >= ph)
+            return { .position = pt, .error = 1.0F, .tracked = false };
+
+        float error = 0.0F;
+        int32_t count = 0;
+        for (int32_t wy = -r; wy <= r; ++wy) {
+            for (int32_t wx = -r; wx <= r; ++wx) {
+                const float sx = std::clamp(px + wx, 0.0F, pw - 1.0F);
+                const float sy = std::clamp(py + wy, 0.0F, ph - 1.0F);
+                const auto ix = static_cast<int32_t>(sx);
+                const auto iy = static_cast<int32_t>(sy);
+                const float p_val = prev[static_cast<size_t>(iy) * w + ix];
+                const float c_val = sample(curr, w, h,
+                    nx + wx, ny + wy);
+                const float diff = p_val - c_val;
+                error += diff * diff;
+                ++count;
+            }
+        }
+        error = std::sqrt(error / static_cast<float>(count));
+
+        if (error > error_threshold)
+            return { .position = pt, .error = error, .tracked = false };
+
+        return {
+            .position = {
+                (nx + 0.5F) / pw,
+                (ny + 0.5F) / ph },
+            .error = error,
+            .tracked = true,
+        };
+    }
+
+} // namespace
+
+std::vector<TrackResult> track_keypoints(
+    std::span<const float> prev_gray,
+    std::span<const float> curr_gray,
+    uint32_t w, uint32_t h,
+    std::span<const glm::vec2> prev_points,
+    uint32_t window_radius,
+    uint32_t max_iterations,
+    float eigen_threshold,
+    float error_threshold)
+{
+    auto grad = sobel(prev_gray, w, h);
+
+    const size_t np = prev_points.size();
+    std::vector<TrackResult> results(np);
+
+    P::for_each(P::par_unseq,
+        std::views::iota(size_t { 0 }, np).begin(),
+        std::views::iota(size_t { 0 }, np).end(),
+        [&](size_t i) {
+            results[i] = lk_point(
+                prev_gray, curr_gray,
+                grad.dx, grad.dy,
+                w, h,
+                prev_points[i],
+                window_radius,
+                max_iterations,
+                eigen_threshold,
+                error_threshold);
+        });
+
+    return results;
+}
+
+} // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Kinesis/Vision/OpticalFlow.hpp
+++ b/src/MayaFlux/Kinesis/Vision/OpticalFlow.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "Features.hpp"
+
+/**
+ * @file OpticalFlow.hpp
+ * @brief Sparse optical flow via Lucas-Kanade tracker.
+ *
+ * Pure functions. No MayaFlux type dependencies.
+ *
+ * ## Conventions
+ * - All inputs are single-channel normalised float in [0, 1]
+ * - w and h are pixel dimensions; caller ensures span size == w * h
+ * - Keypoint positions are normalised to [0, 1]
+ * - window_radius is the half-size of the tracking window in pixels
+ * - Points that fail to track are returned at their previous position
+ *   with tracked = false
+ * - Parallelism handled internally via Parallel::par_unseq
+ */
+
+namespace MayaFlux::Kinesis::Vision {
+
+/**
+ * @brief Result for a single tracked point.
+ */
+struct TrackResult {
+    glm::vec2 position; ///< Tracked position in normalised [0, 1] coordinates.
+    float error; ///< Residual photometric error after convergence.
+    bool tracked; ///< False if tracking failed or diverged.
+};
+
+/**
+ * @brief Track keypoints from prev_gray to curr_gray via Lucas-Kanade.
+ *
+ * For each input point, solves the Lucas-Kanade optical flow equation
+ * within a window_radius x window_radius patch using iterative
+ * Newton-Raphson refinement. Iteration stops when the displacement
+ * update falls below 0.03 pixels or max_iterations is reached.
+ *
+ * A point is marked tracked=false if:
+ *   - The structure tensor within its window is near-singular
+ *     (min eigenvalue below eigen_threshold)
+ *   - The tracked position moves outside the image boundary
+ *   - The residual error after convergence exceeds error_threshold
+ *
+ * prev_points and the returned vector have the same length and order.
+ * Callers should discard points where tracked == false before passing
+ * to subsequent frames.
+ *
+ * @param prev_gray       Previous frame, single-channel float, size w * h.
+ * @param curr_gray       Current frame, single-channel float, size w * h.
+ * @param w               Image width in pixels.
+ * @param h               Image height in pixels.
+ * @param prev_points     Points to track in normalised [0, 1] coordinates.
+ * @param window_radius   Half-size of the tracking patch in pixels.
+ * @param max_iterations  Maximum Newton-Raphson iterations per point.
+ * @param eigen_threshold Minimum eigenvalue for structure tensor validity.
+ * @param error_threshold Maximum residual error to accept a track.
+ * @return                TrackResult per input point, same order.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<TrackResult> track_keypoints(
+    std::span<const float> prev_gray,
+    std::span<const float> curr_gray,
+    uint32_t w, uint32_t h,
+    std::span<const glm::vec2> prev_points,
+    uint32_t window_radius = 7,
+    uint32_t max_iterations = 20,
+    float eigen_threshold = 1e-4F,
+    float error_threshold = 0.3F);
+
+} // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Kinesis/Vision/PixelOps.cpp
+++ b/src/MayaFlux/Kinesis/Vision/PixelOps.cpp
@@ -1,0 +1,204 @@
+#include "PixelOps.hpp"
+
+#include "MayaFlux/Transitive/Parallel/Execution.hpp"
+
+namespace P = MayaFlux::Parallel;
+
+namespace MayaFlux::Kinesis::Vision {
+
+std::vector<float> rgba_to_gray(
+    std::span<const float> rgba, uint32_t w, uint32_t h)
+{
+    const size_t n = static_cast<size_t>(w) * h;
+    std::vector<float> out(n);
+
+    P::for_each(P::par_unseq,
+        std::views::iota(size_t { 0 }, n).begin(),
+        std::views::iota(size_t { 0 }, n).end(),
+        [&](size_t i) {
+            const size_t p = i * 4;
+            out[i] = rgba[p] * 0.299F
+                + rgba[p + 1] * 0.587F
+                + rgba[p + 2] * 0.114F;
+        });
+
+    return out;
+}
+
+std::vector<float> rgba_to_hsv(
+    std::span<const float> rgba, uint32_t w, uint32_t h)
+{
+    const size_t n = static_cast<size_t>(w) * h;
+    std::vector<float> out(n * 3);
+
+    P::for_each(P::par_unseq,
+        std::views::iota(size_t { 0 }, n).begin(),
+        std::views::iota(size_t { 0 }, n).end(),
+        [&](size_t i) {
+            const float r = rgba[i * 4];
+            const float g = rgba[i * 4 + 1];
+            const float b = rgba[i * 4 + 2];
+
+            const float cmax = std::max({ r, g, b });
+            const float cmin = std::min({ r, g, b });
+            const float delta = cmax - cmin;
+
+            float h_val = 0.0F;
+            if (delta > 0.0F) {
+                if (cmax == r) {
+                    h_val = std::fmod((g - b) / delta, 6.0F);
+                } else if (cmax == g) {
+                    h_val = (b - r) / delta + 2.0F;
+                } else {
+                    h_val = (r - g) / delta + 4.0F;
+                }
+                h_val /= 6.0F;
+                if (h_val < 0.0F)
+                    h_val += 1.0F;
+            }
+
+            out[i * 3] = h_val;
+            out[i * 3 + 1] = cmax > 0.0F ? delta / cmax : 0.0F;
+            out[i * 3 + 2] = cmax;
+        });
+
+    return out;
+}
+
+std::vector<float> gray_to_rgba(
+    std::span<const float> gray, uint32_t w, uint32_t h)
+{
+    const size_t n = static_cast<size_t>(w) * h;
+    std::vector<float> out(n * 4);
+
+    P::for_each(P::par_unseq,
+        std::views::iota(size_t { 0 }, n).begin(),
+        std::views::iota(size_t { 0 }, n).end(),
+        [&](size_t i) {
+            const float v = gray[i];
+            out[i * 4] = v;
+            out[i * 4 + 1] = v;
+            out[i * 4 + 2] = v;
+            out[i * 4 + 3] = 1.0F;
+        });
+
+    return out;
+}
+
+std::vector<float> threshold(std::span<const float> gray, float value)
+{
+    std::vector<float> out(gray.size());
+    P::transform(P::par_unseq, gray.begin(), gray.end(), out.begin(),
+        [value](float v) { return v >= value ? 1.0F : 0.0F; });
+    return out;
+}
+
+std::vector<float> threshold_adaptive(
+    std::span<const float> gray, uint32_t w, uint32_t h,
+    uint32_t block_size, float offset)
+{
+    const size_t n = static_cast<size_t>(w) * h;
+    std::vector<float> out(n);
+    const auto half = static_cast<int32_t>(block_size / 2);
+
+    P::for_each(P::par_unseq,
+        std::views::iota(size_t { 0 }, n).begin(),
+        std::views::iota(size_t { 0 }, n).end(),
+        [&](size_t idx) {
+            const auto px = static_cast<int32_t>(idx % w);
+            const auto py = static_cast<int32_t>(idx / w);
+
+            float sum = 0.0F;
+            int32_t count = 0;
+
+            for (int32_t dy = -half; dy <= half; ++dy) {
+                const int32_t ny = std::clamp(py + dy, 0, static_cast<int32_t>(h) - 1);
+                for (int32_t dx = -half; dx <= half; ++dx) {
+                    const int32_t nx = std::clamp(px + dx, 0, static_cast<int32_t>(w) - 1);
+                    sum += gray[static_cast<size_t>(ny) * w + nx];
+                    ++count;
+                }
+            }
+
+            const float mean = sum / static_cast<float>(count);
+            out[idx] = gray[idx] >= (mean - offset) ? 1.0F : 0.0F;
+        });
+
+    return out;
+}
+
+std::vector<float> threshold_otsu(std::span<const float> gray)
+{
+    constexpr int32_t bins = 256;
+    std::array<float, bins> hist {};
+
+    for (float v : gray)
+        hist[static_cast<int32_t>(std::clamp(v, 0.0F, 1.0F) * (bins - 1))]++;
+
+    const auto total = static_cast<float>(gray.size());
+    for (auto& h : hist)
+        h /= total;
+
+    float sum_all = 0.0F;
+    for (int32_t i = 0; i < bins; ++i)
+        sum_all += static_cast<float>(i) * hist[i];
+
+    float sum_bg = 0.0F;
+    float w_bg = 0.0F;
+    float best_var = 0.0F;
+    int32_t best_t = 0;
+
+    for (int32_t t = 0; t < bins; ++t) {
+        w_bg += hist[t];
+        if (w_bg == 0.0F)
+            continue;
+
+        const float w_fg = 1.0F - w_bg;
+        if (w_fg == 0.0F)
+            break;
+
+        sum_bg += static_cast<float>(t) * hist[t];
+
+        const float mean_bg = sum_bg / w_bg;
+        const float mean_fg = (sum_all - sum_bg) / w_fg;
+        const float diff = mean_fg - mean_bg;
+        const float var = w_bg * w_fg * diff * diff;
+
+        if (var > best_var) {
+            best_var = var;
+            best_t = t;
+        }
+    }
+
+    const float t_norm = static_cast<float>(best_t) / static_cast<float>(bins - 1);
+    return threshold(gray, t_norm);
+}
+
+void normalize_inplace(std::span<float> data)
+{
+    if (data.empty())
+        return;
+
+    const auto [mn, mx] = std::ranges::minmax(data);
+    const float range = mx - mn;
+    if (range == 0.0F)
+        return;
+
+    const float inv = 1.0F / range;
+    P::transform(P::par_unseq, data.begin(), data.end(), data.begin(),
+        [mn, inv](float v) { return (v - mn) * inv; });
+}
+
+void normalize_range_inplace(std::span<float> data, float lo, float hi)
+{
+    if (lo == hi)
+        return;
+
+    const float inv = 1.0F / (hi - lo);
+    P::transform(P::par_unseq, data.begin(), data.end(), data.begin(),
+        [lo, inv](float v) {
+            return std::clamp((v - lo) * inv, 0.0F, 1.0F);
+        });
+}
+
+} // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Kinesis/Vision/PixelOps.hpp
+++ b/src/MayaFlux/Kinesis/Vision/PixelOps.hpp
@@ -1,0 +1,133 @@
+#pragma once
+
+/**
+ * @file PixelOps.hpp
+ * @brief Pointwise pixel operations for MayaFlux::Kinesis::Vision
+ *
+ * Pure functions operating on contiguous normalised float spans.
+ * No MayaFlux type dependencies beyond std.
+ *
+ * ## Conventions
+ * - All inputs are normalised float in [0, 1]
+ * - RGBA layout: r, g, b, a interleaved, 4 floats per pixel
+ * - Gray layout: 1 float per pixel
+ * - w and h are pixel dimensions; callers are responsible for ensuring
+ *   span size == w * h * channels
+ * - Parallelism is handled internally via std::execution::par_unseq
+ * - No allocation inside functions except for the returned vector
+ */
+
+namespace MayaFlux::Kinesis::Vision {
+
+// ============================================================================
+// Colour space conversion
+// ============================================================================
+
+/**
+ * @brief Convert RGBA to luminance gray using BT.601 coefficients.
+ *
+ * Output is one float per pixel. Alpha channel is discarded.
+ * Coefficients: R*0.299 + G*0.587 + B*0.114
+ *
+ * @param rgba Interleaved RGBA span, size must be w * h * 4.
+ * @param w    Image width in pixels.
+ * @param h    Image height in pixels.
+ * @return     Grayscale float vector of length w * h.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<float> rgba_to_gray(
+    std::span<const float> rgba, uint32_t w, uint32_t h);
+
+/**
+ * @brief Convert RGBA to HSV.
+ *
+ * Output is interleaved HSV, 3 floats per pixel.
+ * H in [0, 1] (mapped from [0, 360]), S and V in [0, 1].
+ * Alpha channel is discarded.
+ *
+ * @param rgba Interleaved RGBA span, size must be w * h * 4.
+ * @param w    Image width in pixels.
+ * @param h    Image height in pixels.
+ * @return     Interleaved HSV float vector of length w * h * 3.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<float> rgba_to_hsv(
+    std::span<const float> rgba, uint32_t w, uint32_t h);
+
+/**
+ * @brief Convert single-channel gray to RGBA.
+ *
+ * R, G, B are all set to the gray value. Alpha is 1.0f.
+ *
+ * @param gray Gray float span, size must be w * h.
+ * @param w    Image width in pixels.
+ * @param h    Image height in pixels.
+ * @return     Interleaved RGBA float vector of length w * h * 4.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<float> gray_to_rgba(
+    std::span<const float> gray, uint32_t w, uint32_t h);
+
+// ============================================================================
+// Thresholding
+// ============================================================================
+
+/**
+ * @brief Global threshold: output is 1.0f where input >= value, else 0.0f.
+ *
+ * @param gray  Single-channel float span, size must be w * h.
+ * @param value Threshold value in [0, 1].
+ * @return      Binary float vector of length w * h.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<float> threshold(
+    std::span<const float> gray, float value);
+
+/**
+ * @brief Adaptive threshold using local block mean minus offset.
+ *
+ * Each pixel is thresholded against the mean of its block_size x block_size
+ * neighbourhood minus offset. Pixels at the border use a clamped neighbourhood.
+ *
+ * @param gray       Single-channel float span, size must be w * h.
+ * @param w          Image width in pixels.
+ * @param h          Image height in pixels.
+ * @param block_size Neighbourhood size in pixels. Must be odd and >= 3.
+ * @param offset     Subtracted from local mean before comparison.
+ * @return           Binary float vector of length w * h.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<float> threshold_adaptive(
+    std::span<const float> gray, uint32_t w, uint32_t h,
+    uint32_t block_size, float offset);
+
+/**
+ * @brief Otsu threshold: finds the optimal global threshold by maximising
+ *        inter-class variance, then applies it.
+ *
+ * @param gray Single-channel float span, size must be w * h.
+ * @return     Binary float vector of length w * h.
+ */
+[[nodiscard]] MAYAFLUX_API std::vector<float> threshold_otsu(
+    std::span<const float> gray);
+
+// ============================================================================
+// Normalisation
+// ============================================================================
+
+/**
+ * @brief Stretch values to fill [0, 1] using the span's observed min and max.
+ *
+ * No-op if min == max. Operates in-place.
+ *
+ * @param data Float span to normalise in-place.
+ */
+MAYAFLUX_API void normalize_inplace(std::span<float> data);
+
+/**
+ * @brief Clamp and remap values from [lo, hi] to [0, 1] in-place.
+ *
+ * Values outside [lo, hi] are clamped before remapping.
+ *
+ * @param data Float span to remap in-place.
+ * @param lo   Input range lower bound.
+ * @param hi   Input range upper bound.
+ */
+MAYAFLUX_API void normalize_range_inplace(std::span<float> data, float lo, float hi);
+
+} // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Kinesis/Vision/VisionExecutor.cpp
+++ b/src/MayaFlux/Kinesis/Vision/VisionExecutor.cpp
@@ -1,0 +1,281 @@
+#include "VisionExecutor.hpp"
+
+#include "Contours.hpp"
+#include "Filter.hpp"
+#include "Gradient.hpp"
+#include "Harris.hpp"
+#include "Morphology.hpp"
+#include "OpticalFlow.hpp"
+#include "PixelOps.hpp"
+
+#include "MayaFlux/Journal/Archivist.hpp"
+
+namespace MayaFlux::Kinesis::Vision {
+
+namespace {
+
+    // =========================================================================
+    // Parameter accessors — crash clearly on wrong variant rather than silently
+    // =========================================================================
+
+    template <typename T>
+    const T& get_params(const VisionParams& p, VisionOp op)
+    {
+        const T* ptr = std::get_if<T>(&p);
+        if (!ptr) {
+            error<std::logic_error>(
+                Journal::Component::Kinesis, Journal::Context::Runtime, std::source_location::current(),
+                "VisionExecutor: parameter type mismatch for op {}",
+                Reflect::enum_to_string(op));
+        }
+        return *ptr;
+    }
+
+} // namespace
+
+VisionResult VisionExecutor::run(
+    const VisionSequence& sequence,
+    std::span<const float> frame,
+    uint32_t w, uint32_t h)
+{
+    VisionResult result;
+    result.w = w;
+    result.h = h;
+
+    std::vector<float> current(frame.begin(), frame.end());
+
+    for (const auto& step : sequence.steps) {
+        switch (step.op) {
+
+            // =====================================================================
+            // Colour space
+            // =====================================================================
+
+        case VisionOp::RgbaToGray:
+            current = rgba_to_gray(current, w, h);
+            result.structured = std::monostate {};
+            break;
+
+        case VisionOp::RgbaToHsv:
+            current = rgba_to_hsv(current, w, h);
+            result.structured = std::monostate {};
+            break;
+
+        case VisionOp::GrayToRgba:
+            current = gray_to_rgba(current, w, h);
+            result.structured = std::monostate {};
+            break;
+
+            // =====================================================================
+            // Thresholding
+            // =====================================================================
+
+        case VisionOp::Threshold: {
+            const auto& p = get_params<ThresholdParams>(step.params, step.op);
+            current = threshold(current, p.value);
+            result.structured = std::monostate {};
+            break;
+        }
+
+        case VisionOp::ThresholdAdaptive: {
+            const auto& p = get_params<ThresholdAdaptiveParams>(step.params, step.op);
+            current = threshold_adaptive(current, w, h, p.block_size, p.offset);
+            result.structured = std::monostate {};
+            break;
+        }
+
+        case VisionOp::ThresholdOtsu:
+            current = threshold_otsu(current);
+            result.structured = std::monostate {};
+            break;
+
+            // =====================================================================
+            // Normalisation
+            // =====================================================================
+
+        case VisionOp::NormalizeInplace:
+            normalize_inplace(current);
+            result.structured = std::monostate {};
+            break;
+
+        case VisionOp::NormalizeRange: {
+            const auto& p = get_params<NormalizeRangeParams>(step.params, step.op);
+            normalize_range_inplace(current, p.lo, p.hi);
+            result.structured = std::monostate {};
+            break;
+        }
+
+            // =====================================================================
+            // Filter
+            // =====================================================================
+
+        case VisionOp::GaussianBlur: {
+            const auto& p = get_params<GaussianBlurParams>(step.params, step.op);
+            current = gaussian_blur(current, w, h, p.sigma);
+            result.structured = std::monostate {};
+            break;
+        }
+
+        case VisionOp::FilterSeparable: {
+            const auto& p = get_params<FilterSeparableParams>(step.params, step.op);
+            current = filter_separable(current, w, h, p.kernel_x, p.kernel_y);
+            result.structured = std::monostate {};
+            break;
+        }
+
+            // =====================================================================
+            // Gradient
+            // =====================================================================
+
+        case VisionOp::Sobel: {
+            auto grad = sobel(current, w, h);
+            result.structured = grad;
+            current = std::move(grad.magnitude);
+            break;
+        }
+
+        case VisionOp::Scharr: {
+            auto grad = scharr(current, w, h);
+            result.structured = grad;
+            current = std::move(grad.magnitude);
+            break;
+        }
+
+        case VisionOp::Canny: {
+            const auto& p = get_params<CannyParams>(step.params, step.op);
+            current = canny(current, w, h, p.sigma, p.low_threshold, p.high_threshold);
+            result.structured = std::monostate {};
+            break;
+        }
+
+            // =====================================================================
+            // Morphology
+            // =====================================================================
+
+        case VisionOp::Erode: {
+            const auto& p = get_params<MorphParams>(step.params, step.op);
+            current = erode(current, w, h, p.radius);
+            result.structured = std::monostate {};
+            break;
+        }
+
+        case VisionOp::Dilate: {
+            const auto& p = get_params<MorphParams>(step.params, step.op);
+            current = dilate(current, w, h, p.radius);
+            result.structured = std::monostate {};
+            break;
+        }
+
+        case VisionOp::Open: {
+            const auto& p = get_params<MorphParams>(step.params, step.op);
+            current = open(current, w, h, p.radius);
+            result.structured = std::monostate {};
+            break;
+        }
+
+        case VisionOp::Close: {
+            const auto& p = get_params<MorphParams>(step.params, step.op);
+            current = close(current, w, h, p.radius);
+            result.structured = std::monostate {};
+            break;
+        }
+
+        case VisionOp::MorphGradient: {
+            const auto& p = get_params<MorphParams>(step.params, step.op);
+            current = morph_gradient(current, w, h, p.radius);
+            result.structured = std::monostate {};
+            break;
+        }
+
+        case VisionOp::ConnectedComponents: {
+            auto cc = connected_components(current, w, h);
+            result.structured = std::move(cc);
+            current.clear();
+            result.w = 0;
+            result.h = 0;
+            break;
+        }
+
+        case VisionOp::FindContours: {
+            auto contours = find_contours(current, w, h);
+            result.structured = std::move(contours);
+            current.clear();
+            result.w = 0;
+            result.h = 0;
+            break;
+        }
+
+            // =====================================================================
+            // Harris
+            // =====================================================================
+
+        case VisionOp::HarrisResponse: {
+            const auto& p = get_params<HarrisParams>(step.params, step.op);
+            current = harris_response(current, w, h, p.k, p.sigma);
+            result.structured = std::monostate {};
+            break;
+        }
+
+        case VisionOp::ExtractPeaks: {
+            const auto& p = get_params<ExtractPeaksParams>(step.params, step.op);
+            auto kpts = extract_peaks(current, w, h, p.threshold, p.nms_radius);
+            m_prev_keypoints = kpts;
+            result.structured = std::move(kpts);
+            current.clear();
+            result.w = 0;
+            result.h = 0;
+            break;
+        }
+
+            // =====================================================================
+            // Optical flow
+            // =====================================================================
+
+        case VisionOp::TrackKeypoints: {
+            const auto& p = get_params<TrackKeypointsParams>(step.params, step.op);
+
+            if (m_prev_gray.empty() || m_prev_keypoints.empty()) {
+                m_prev_gray = current;
+                result.structured = std::vector<TrackResult> {};
+                current.clear();
+                result.w = 0;
+                result.h = 0;
+                break;
+            }
+
+            std::vector<glm::vec2> prev_positions;
+            prev_positions.reserve(m_prev_keypoints.size());
+            for (const auto& kp : m_prev_keypoints)
+                prev_positions.push_back(kp.position);
+
+            auto tracked = track_keypoints(
+                m_prev_gray, current,
+                w, h,
+                prev_positions,
+                p.window_radius,
+                p.max_iterations,
+                p.eigen_threshold,
+                p.error_threshold);
+
+            m_prev_gray = current;
+            result.structured = std::move(tracked);
+            current.clear();
+            result.w = 0;
+            result.h = 0;
+            break;
+        }
+
+        } // switch
+    }
+
+    result.pixel_image = std::move(current);
+    return result;
+}
+
+void VisionExecutor::reset()
+{
+    m_prev_gray.clear();
+    m_prev_keypoints.clear();
+}
+
+} // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Kinesis/Vision/VisionExecutor.hpp
+++ b/src/MayaFlux/Kinesis/Vision/VisionExecutor.hpp
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "ConnectedComponents.hpp"
+#include "Features.hpp"
+#include "MayaFlux/Kinesis/Vision/Gradient.hpp"
+#include "OpticalFlow.hpp"
+#include "VisionOp.hpp"
+
+/**
+ * @file VisionExecutor.hpp
+ * @brief Dispatch engine for VisionSequence execution.
+ *
+ * VisionExecutor::run() is the single entry point for executing a
+ * VisionSequence. It maintains per-frame state (previous gray frame for
+ * optical flow) and returns a VisionResult carrying both the final pixel
+ * image and any structured outputs produced by the terminal step.
+ *
+ * No MayaFlux type dependencies beyond Kinesis::Vision itself.
+ */
+
+namespace MayaFlux::Kinesis::Vision {
+
+/**
+ * @brief Union of possible structured outputs from a VisionSequence.
+ *
+ * The active alternative matches the terminal step of the sequence:
+ *   - std::monostate   : terminal step produced only a pixel image
+ *   - GradientResult   : terminal step was Sobel or Scharr
+ *   - ComponentResult  : terminal step was connected_components
+ *   - vector<Contour>  : terminal step was find_contours
+ *   - vector<Keypoint> : terminal step was extract_peaks
+ *   - vector<TrackResult>: terminal step was track_keypoints
+ */
+using StructuredOutput = std::variant<
+    std::monostate,
+    GradientResult,
+    ComponentResult,
+    std::vector<Contour>,
+    std::vector<Keypoint>,
+    std::vector<TrackResult>>;
+
+/**
+ * @brief Result of executing a VisionSequence on one frame.
+ *
+ * pixel_image holds the final float pixel buffer produced by the sequence.
+ * It is empty when the terminal step produces only structured output with
+ * no pixel image (e.g. extract_peaks, track_keypoints).
+ *
+ * structured holds the terminal step's structured output when the step
+ * produces one. It is monostate when the terminal step produces only a
+ * pixel image.
+ *
+ * w and h are the dimensions of pixel_image. Both are 0 when pixel_image
+ * is empty.
+ */
+struct VisionResult {
+    std::vector<float> pixel_image;
+    StructuredOutput structured { std::monostate {} };
+    uint32_t w { 0 };
+    uint32_t h { 0 };
+};
+
+/**
+ * @class VisionExecutor
+ * @brief Stateful executor for a VisionSequence.
+ *
+ * Holds the previous gray frame for optical flow tracking across calls.
+ * All other steps are stateless; the executor carries no other mutable state.
+ *
+ * One executor instance per pipeline: do not share across containers or
+ * threads without external synchronisation.
+ */
+class MAYAFLUX_API VisionExecutor {
+public:
+    VisionExecutor() = default;
+
+    /**
+     * @brief Execute a VisionSequence on one frame.
+     *
+     * @param sequence Ordered steps to execute.
+     * @param frame    Normalised float input frame. Format must match the
+     *                 first step: RGBA (4 floats/pixel) for RgbaToGray /
+     *                 RgbaToHsv, single-channel (1 float/pixel) for all
+     *                 other entry points.
+     * @param w        Frame width in pixels.
+     * @param h        Frame height in pixels.
+     * @return         VisionResult with pixel_image and/or structured output.
+     */
+    [[nodiscard]] VisionResult run(
+        const VisionSequence& sequence,
+        std::span<const float> frame,
+        uint32_t w, uint32_t h);
+
+    /**
+     * @brief Clear the stored previous frame.
+     *
+     * Call when the source changes (new camera device, seek in video file)
+     * so the next track_keypoints step starts from a clean state.
+     */
+    void reset();
+
+private:
+    std::vector<float> m_prev_gray;
+    std::vector<Keypoint> m_prev_keypoints;
+};
+
+} // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Kinesis/Vision/VisionOp.hpp
+++ b/src/MayaFlux/Kinesis/Vision/VisionOp.hpp
@@ -48,6 +48,8 @@ enum class VisionOp : uint8_t {
     Open,
     Close,
     MorphGradient,
+    ConnectedComponents,
+    FindContours,
 
     HarrisResponse,
     ExtractPeaks,

--- a/src/MayaFlux/Kinesis/Vision/VisionOp.hpp
+++ b/src/MayaFlux/Kinesis/Vision/VisionOp.hpp
@@ -1,0 +1,293 @@
+#pragma once
+
+/**
+ * @file VisionOp.hpp
+ * @brief Declarative description of a Kinesis::Vision processing sequence.
+ *
+ * VisionStep names one operation and carries the parameters needed to invoke
+ * it. VisionSequence is an ordered list of steps. Both are pure value types
+ * with no MayaFlux dependencies.
+ *
+ * Processors (VisionDataProcessor, VisionBufferProcessor) accept a
+ * VisionSequence at construction and execute it each cycle without knowing
+ * which specific algorithms are involved. No per-algorithm processor subclass
+ * is needed.
+ */
+
+namespace MayaFlux::Kinesis::Vision {
+
+/**
+ * @enum VisionOp
+ * @brief Named operations available in a VisionSequence.
+ *
+ * Each enumerator maps 1:1 to a function in Kinesis::Vision.
+ * The processor dispatches on this enum; parameters are carried
+ * by the corresponding VisionStep variant field.
+ */
+enum class VisionOp : uint8_t {
+    RgbaToGray,
+    RgbaToHsv,
+    GrayToRgba,
+
+    Threshold,
+    ThresholdAdaptive,
+    ThresholdOtsu,
+
+    NormalizeInplace,
+    NormalizeRange,
+
+    GaussianBlur,
+    FilterSeparable,
+
+    Sobel,
+    Scharr,
+    Canny,
+
+    Erode,
+    Dilate,
+    Open,
+    Close,
+    MorphGradient,
+
+    HarrisResponse,
+    ExtractPeaks,
+
+    TrackKeypoints,
+};
+
+// ============================================================================
+// Per-op parameter structs
+// ============================================================================
+
+struct ThresholdParams {
+    float value;
+};
+struct ThresholdAdaptiveParams {
+    uint32_t block_size;
+    float offset;
+};
+struct NormalizeRangeParams {
+    float lo;
+    float hi;
+};
+struct GaussianBlurParams {
+    float sigma;
+};
+
+struct FilterSeparableParams {
+    std::vector<float> kernel_x;
+    std::vector<float> kernel_y;
+};
+
+struct CannyParams {
+    float sigma;
+    float low_threshold;
+    float high_threshold;
+};
+
+struct MorphParams {
+    uint32_t radius;
+};
+
+struct HarrisParams {
+    float k = 0.04F;
+    float sigma = 1.0F;
+};
+
+struct ExtractPeaksParams {
+    float threshold;
+    uint32_t nms_radius;
+};
+
+struct TrackKeypointsParams {
+    uint32_t window_radius = 7;
+    uint32_t max_iterations = 20;
+    float eigen_threshold = 1e-4F;
+    float error_threshold = 0.3F;
+};
+
+/**
+ * @brief Parameter variant covering all ops that carry parameters.
+ *
+ * Ops with no parameters (RgbaToGray, Sobel, Scharr, ThresholdOtsu,
+ * NormalizeInplace, GrayToRgba, RgbaToHsv, MorphGradient, Erode, Dilate,
+ * Open, Close) use std::monostate.
+ */
+using VisionParams = std::variant<
+    std::monostate,
+    ThresholdParams,
+    ThresholdAdaptiveParams,
+    NormalizeRangeParams,
+    GaussianBlurParams,
+    FilterSeparableParams,
+    CannyParams,
+    MorphParams,
+    HarrisParams,
+    ExtractPeaksParams,
+    TrackKeypointsParams>;
+
+/**
+ * @brief One step in a VisionSequence: an op and its parameters.
+ */
+struct VisionStep {
+    VisionOp op;
+    VisionParams params { std::monostate {} };
+};
+
+/**
+ * @brief Ordered sequence of VisionSteps describing a complete vision pipeline.
+ *
+ * Constructed via the fluent VisionSequence::Builder.
+ */
+struct VisionSequence {
+    std::vector<VisionStep> steps;
+
+    /**
+     * @brief Fluent builder for VisionSequence.
+     *
+     * Each method appends one step and returns *this for chaining.
+     * Call build() to produce the final VisionSequence.
+     *
+     * @code
+     * auto seq = VisionSequence::Builder{}
+     *     .rgba_to_gray()
+     *     .gaussian_blur(1.5f)
+     *     .threshold(0.4f)
+     *     .build();
+     * @endcode
+     */
+    class Builder {
+    public:
+        Builder& rgba_to_gray()
+        {
+            return push(VisionOp::RgbaToGray);
+        }
+
+        Builder& rgba_to_hsv()
+        {
+            return push(VisionOp::RgbaToHsv);
+        }
+
+        Builder& gray_to_rgba()
+        {
+            return push(VisionOp::GrayToRgba);
+        }
+
+        Builder& threshold(float value)
+        {
+            return push(VisionOp::Threshold, ThresholdParams { .value = value });
+        }
+
+        Builder& threshold_adaptive(uint32_t block_size, float offset)
+        {
+            return push(VisionOp::ThresholdAdaptive,
+                ThresholdAdaptiveParams { .block_size = block_size, .offset = offset });
+        }
+
+        Builder& threshold_otsu()
+        {
+            return push(VisionOp::ThresholdOtsu);
+        }
+
+        Builder& normalize()
+        {
+            return push(VisionOp::NormalizeInplace);
+        }
+
+        Builder& normalize_range(float lo, float hi)
+        {
+            return push(VisionOp::NormalizeRange,
+                NormalizeRangeParams { .lo = lo, .hi = hi });
+        }
+
+        Builder& gaussian_blur(float sigma)
+        {
+            return push(VisionOp::GaussianBlur, GaussianBlurParams { .sigma = sigma });
+        }
+
+        Builder& filter_separable(
+            std::vector<float> kx, std::vector<float> ky)
+        {
+            return push(VisionOp::FilterSeparable,
+                FilterSeparableParams { .kernel_x = std::move(kx), .kernel_y = std::move(ky) });
+        }
+
+        Builder& sobel()
+        {
+            return push(VisionOp::Sobel);
+        }
+
+        Builder& scharr()
+        {
+            return push(VisionOp::Scharr);
+        }
+
+        Builder& canny(float sigma, float lo, float hi)
+        {
+            return push(VisionOp::Canny, CannyParams { .sigma = sigma, .low_threshold = lo, .high_threshold = hi });
+        }
+
+        Builder& erode(uint32_t radius)
+        {
+            return push(VisionOp::Erode, MorphParams { .radius = radius });
+        }
+
+        Builder& dilate(uint32_t radius)
+        {
+            return push(VisionOp::Dilate, MorphParams { .radius = radius });
+        }
+
+        Builder& open(uint32_t radius)
+        {
+            return push(VisionOp::Open, MorphParams { .radius = radius });
+        }
+
+        Builder& close(uint32_t radius)
+        {
+            return push(VisionOp::Close, MorphParams { .radius = radius });
+        }
+
+        Builder& morph_gradient(uint32_t radius)
+        {
+            return push(VisionOp::MorphGradient, MorphParams { .radius = radius });
+        }
+
+        Builder& harris_response(float k = 0.04F, float sigma = 1.0F)
+        {
+            return push(VisionOp::HarrisResponse, HarrisParams { .k = k, .sigma = sigma });
+        }
+
+        Builder& extract_peaks(float threshold, uint32_t nms_radius)
+        {
+            return push(VisionOp::ExtractPeaks,
+                ExtractPeaksParams { .threshold = threshold, .nms_radius = nms_radius });
+        }
+
+        Builder& track_keypoints(
+            uint32_t window_radius = 7,
+            uint32_t max_iterations = 20,
+            float eigen_threshold = 1e-4F,
+            float error_threshold = 0.3F)
+        {
+            return push(VisionOp::TrackKeypoints,
+                TrackKeypointsParams {
+                    .window_radius = window_radius, .max_iterations = max_iterations, .eigen_threshold = eigen_threshold, .error_threshold = error_threshold });
+        }
+
+        [[nodiscard]] VisionSequence build()
+        {
+            return VisionSequence { .steps = std::move(m_steps) };
+        }
+
+    private:
+        std::vector<VisionStep> m_steps;
+
+        Builder& push(VisionOp op, VisionParams p = std::monostate {})
+        {
+            m_steps.push_back({ .op = op, .params = std::move(p) });
+            return *this;
+        }
+    };
+};
+
+} // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Nodes/Filters/Filter.cpp
+++ b/src/MayaFlux/Nodes/Filters/Filter.cpp
@@ -203,7 +203,7 @@ std::vector<double> Filter::process_batch(unsigned int num_samples)
 {
     std::vector<double> output(num_samples);
     for (unsigned int i = 0; i < num_samples; ++i) {
-        output[i] = process_sample(0.0); // The input value doesn't matter since we have an input node
+        output[i] = process_sample(0.0);
     }
     return output;
 }

--- a/src/MayaFlux/Portal/Graphics/AsmGenerator.cpp
+++ b/src/MayaFlux/Portal/Graphics/AsmGenerator.cpp
@@ -4,42 +4,24 @@
  * @file AsmGenerator.cpp
  * @brief SPIR-V assembly and GLSL kernel emitters for ShaderSpec.
  *
- * Current state
+ * SPIR-V assembly path (emit_spirv_asm): complete for all SSBO element types
+ * (SCALAR_F32, VEC2_F32, VEC3_F32, VEC4_F32) with all KernelOps. IMAGE_2D
+ * storage image path (emit_image_body) supports single and dual input images
+ * with all single- and two-operand KernelOps. GLSL kernel path
+ * (emit_glsl_kernel): complete, dispatched when spec.kernel is set via
+ * MF_KERNEL.
  *
- * SPIR-V assembly path (emit_spirv_asm): complete for SCALAR_F32 SSBOs with
- * any KernelOp. IMAGE_2D storage image output path (emit_image_body) is
- * complete for single-output write ops (Scale, ScaleOffset, Offset, Clip,
- * Abs, Negate). GLSL kernel path (emit_glsl_kernel): complete, dispatched
- * when spec.kernel is set via MF_KERNEL.
+ * Remaining gap
  *
- * What needs adding after Kinesis::Vision is active
- *
- *
- * 1. IMAGE_2D two-image ops (read-from-storage-image + write).
- *    emit_image_body resolves one img_in and one img_out. KernelOp::Add,
- *    Multiply, Mix in emit_image_body fall through to default (passthrough)
- *    because they need two img_in slots. Fix: extend the img_in resolution
- *    to collect all Input/InOut IMAGE_2D bindings as an ordered list, then
- *    emit OpImageRead for each and apply the two-operand op. StorageImageRead
- *    WithoutFormat capability must also be added to emit_header when any
- *    Input IMAGE_2D binding is present. Callers: Kinesis::Vision blend,
- *    composite, difference ops.
- *
- * 2. TEXTURE_2D sampled image bindings in the SPIR-V assembly path.
- *    emit_header, emit_decorations, emit_types all silently skip TEXTURE_2D
- *    bindings. No OpTypeSampledImage, no combined image sampler variable, no
- *    OpImageSampleExplicitLod in the body. Fix requires OpCapability Sampled1D
- *    or similar, OpTypeSampler, OpTypeSampledImage, OpVariable for the combined
- *    sampler, and OpImageSampleExplicitLod or OpImageFetch in the body. This
- *    is structurally heavier than storage image. Callers: Kinesis::Vision
- *    filter ops that read from a TextureContainer as a sampled source.
- *
- * 3. Reduction body completion.
- *    emit_reduction_body is a placeholder. The shared memory tree is partially
- *    emitted but the loop structure is missing — no OpLoopMerge, no back-edge.
- *    KernelOp::Sum and KernelOp::Max route here but produce invalid SPIR-V.
- *    Fix: full workgroup reduction loop with OpLoopMerge/OpBranch/OpPhi.
- *    No caller exercises this path yet.
+ * TEXTURE_2D sampled image bindings in the SPIR-V assembly path.
+ * emit_header, emit_decorations, and emit_types all silently skip TEXTURE_2D
+ * bindings. No OpTypeSampledImage, no combined image sampler variable, no
+ * OpImageSampleExplicitLod in the body. Fix requires OpTypeSampler,
+ * OpTypeSampledImage, OpVariable for the combined sampler, and
+ * OpImageSampleExplicitLod or OpImageFetch in the body. The GLSL path via
+ * MF_KERNEL handles TEXTURE_2D correctly today. The assembly path gap only
+ * matters for filter ops that read a TextureContainer as a sampled source
+ * without a user-supplied kernel.
  */
 
 namespace MayaFlux::Portal::Graphics::detail {
@@ -116,9 +98,13 @@ namespace {
         const auto& ws = spec.workgroup_size;
 
         bool has_storage_image = false;
+        bool has_input_image = false;
         for (const auto& b : spec.bindings) {
-            if (b.modality == Kakshya::DataModality::IMAGE_2D)
+            if (b.modality == Kakshya::DataModality::IMAGE_2D) {
                 has_storage_image = true;
+                if (b.direction != BindingDirection::Output)
+                    has_input_image = true;
+            }
         }
 
         std::string iface = "%gid_var";
@@ -139,8 +125,12 @@ namespace {
 
         std::string o;
         o += "OpCapability Shader\n";
+
         if (has_storage_image)
             o += "OpCapability StorageImageWriteWithoutFormat\n";
+        if (has_input_image)
+            o += "OpCapability StorageImageReadWithoutFormat\n";
+
         o += "%glsl = OpExtInstImport \"GLSL.std.450\"\n";
         o += "OpMemoryModel Logical GLSL450\n";
         o += "OpEntryPoint GLCompute %main \"main\" " + iface + "\n";
@@ -437,6 +427,10 @@ namespace {
             o += "%res = OpFAdd %f32 " + v0 + " %scl\n";
             result = "%res";
             break;
+        case KernelOp::Sub:
+            o += "%res = OpFSub " + et + " " + v0 + " " + v1 + "\n";
+            result = "%res";
+            break;
         case KernelOp::Fma:
             o += "%res = OpExtInst %f32 %glsl Fma " + v0 + " " + p0 + " " + p1 + "\n";
             result = "%res";
@@ -618,14 +612,14 @@ namespace {
     std::string emit_image_body(const ShaderSpec& spec)
     {
         const BindingSlot* img_out = nullptr;
-        const BindingSlot* img_in = nullptr;
+        std::vector<const BindingSlot*> img_inputs;
         for (const auto& b : spec.bindings) {
             if (b.modality != Kakshya::DataModality::IMAGE_2D)
                 continue;
             if (b.direction == BindingDirection::Output && !img_out) {
                 img_out = &b;
-            } else if (b.direction != BindingDirection::Output && !img_in) {
-                img_in = &b;
+            } else if (b.direction != BindingDirection::Output) {
+                img_inputs.push_back(&b);
             }
         }
 
@@ -648,51 +642,90 @@ namespace {
         if (!spec.pc_fields.empty())
             o += "\n";
 
-        if (img_in) {
-            o += "%raw_in = OpImageRead %v4f32 %img_" + std::string(img_in->name) + " %coord\n";
-        } else {
-            o += "%raw_in = OpCompositeConstruct %v4f32 %img_czero %img_czero %img_czero %img_czero\n";
+        for (size_t ii = 0; ii < img_inputs.size(); ++ii) {
+            o += "%raw_in" + std::to_string(ii) + " = OpImageRead %v4f32 %img_"
+                + img_inputs[ii]->name + " %coord\n";
         }
+        if (img_inputs.empty()) {
+            o += "%raw_in0 = OpCompositeConstruct %v4f32 %img_czero %img_czero"
+                 " %img_czero %img_czero\n";
+        }
+        o += "\n";
 
-        o += "%ch_r = OpCompositeExtract %f32 %raw_in 0\n";
-        o += "%ch_g = OpCompositeExtract %f32 %raw_in 1\n";
-        o += "%ch_b = OpCompositeExtract %f32 %raw_in 2\n";
-        o += "%ch_a = OpCompositeExtract %f32 %raw_in 3\n\n";
+        o += "%ch0_r = OpCompositeExtract %f32 %raw_in0 0\n";
+        o += "%ch0_g = OpCompositeExtract %f32 %raw_in0 1\n";
+        o += "%ch0_b = OpCompositeExtract %f32 %raw_in0 2\n";
+        o += "%ch0_a = OpCompositeExtract %f32 %raw_in0 3\n";
 
-        const std::string p0 = spec.pc_fields.empty() ? "" : ("%pc_" + spec.pc_fields[0].name);
-        const std::string p1 = spec.pc_fields.size() > 1 ? ("%pc_" + spec.pc_fields[1].name) : "";
+        const bool has_second = img_inputs.size() > 1;
+        if (has_second) {
+            o += "%ch1_r = OpCompositeExtract %f32 %raw_in1 0\n";
+            o += "%ch1_g = OpCompositeExtract %f32 %raw_in1 1\n";
+            o += "%ch1_b = OpCompositeExtract %f32 %raw_in1 2\n";
+            o += "%ch1_a = OpCompositeExtract %f32 %raw_in1 3\n";
+        }
+        o += "\n";
 
-        auto emit_channel_op = [&](const std::string& ch, const std::string& suffix) {
+        const std::string p0 = spec.pc_fields.empty()
+            ? ""
+            : ("%pc_" + spec.pc_fields[0].name);
+        const std::string p1 = spec.pc_fields.size() > 1
+            ? ("%pc_" + spec.pc_fields[1].name)
+            : "";
+
+        auto emit_channel_op = [&](
+                                   const std::string& c0, const std::string& c1,
+                                   const std::string& suffix) {
             switch (spec.op) {
             case KernelOp::Scale:
-                o += "%res_" + suffix + " = OpFMul %f32 " + ch + " " + p0 + "\n";
+                o += "%res_" + suffix + " = OpFMul %f32 " + c0 + " " + p0 + "\n";
                 break;
             case KernelOp::ScaleOffset:
-                o += "%mul_" + suffix + " = OpFMul %f32 " + ch + " " + p0 + "\n";
+                o += "%mul_" + suffix + " = OpFMul %f32 " + c0 + " " + p0 + "\n";
                 o += "%res_" + suffix + " = OpFAdd %f32 %mul_" + suffix + " " + p1 + "\n";
                 break;
             case KernelOp::Offset:
-                o += "%res_" + suffix + " = OpFAdd %f32 " + ch + " " + p0 + "\n";
+                o += "%res_" + suffix + " = OpFAdd %f32 " + c0 + " " + p0 + "\n";
                 break;
             case KernelOp::Clip:
-                o += "%res_" + suffix + " = OpExtInst %f32 %glsl FClamp " + ch + " " + p0 + " " + p1 + "\n";
+                o += "%res_" + suffix + " = OpExtInst %f32 %glsl FClamp "
+                    + c0 + " " + p0 + " " + p1 + "\n";
                 break;
             case KernelOp::Abs:
-                o += "%res_" + suffix + " = OpExtInst %f32 %glsl FAbs " + ch + "\n";
+                o += "%res_" + suffix + " = OpExtInst %f32 %glsl FAbs " + c0 + "\n";
                 break;
             case KernelOp::Negate:
-                o += "%res_" + suffix + " = OpFNegate %f32 " + ch + "\n";
+                o += "%res_" + suffix + " = OpFNegate %f32 " + c0 + "\n";
+                break;
+            case KernelOp::Add:
+                o += "%res_" + suffix + " = OpFAdd %f32 " + c0 + " " + c1 + "\n";
+                break;
+            case KernelOp::Multiply:
+                o += "%res_" + suffix + " = OpFMul %f32 " + c0 + " " + c1 + "\n";
+                break;
+            case KernelOp::Mix:
+                o += "%res_" + suffix + " = OpExtInst %f32 %glsl FMix "
+                    + c0 + " " + c1 + " " + p0 + "\n";
+                break;
+            case KernelOp::Sub:
+                o += "%res_" + suffix + " = OpFSub %f32 " + c0 + " " + c1 + "\n";
                 break;
             default:
-                o += "%res_" + suffix + " = OpCopyObject %f32 " + ch + "\n";
+                o += "%res_" + suffix + " = OpCopyObject %f32 " + c0 + "\n";
                 break;
             }
         };
 
-        emit_channel_op("%ch_r", "r");
-        emit_channel_op("%ch_g", "g");
-        emit_channel_op("%ch_b", "b");
-        emit_channel_op("%ch_a", "a");
+        const std::string zero = "%img_czero";
+        const std::string c1r = has_second ? "%ch1_r" : zero;
+        const std::string c1g = has_second ? "%ch1_g" : zero;
+        const std::string c1b = has_second ? "%ch1_b" : zero;
+        const std::string c1a = has_second ? "%ch1_a" : zero;
+
+        emit_channel_op("%ch0_r", c1r, "r");
+        emit_channel_op("%ch0_g", c1g, "g");
+        emit_channel_op("%ch0_b", c1b, "b");
+        emit_channel_op("%ch0_a", c1a, "a");
         o += "\n";
 
         o += "%out_vec = OpCompositeConstruct %v4f32 %res_r %res_g %res_b %res_a\n";

--- a/src/MayaFlux/Portal/Graphics/AsmGenerator.cpp
+++ b/src/MayaFlux/Portal/Graphics/AsmGenerator.cpp
@@ -4,24 +4,30 @@
  * @file AsmGenerator.cpp
  * @brief SPIR-V assembly and GLSL kernel emitters for ShaderSpec.
  *
- * SPIR-V assembly path (emit_spirv_asm): complete for all SSBO element types
- * (SCALAR_F32, VEC2_F32, VEC3_F32, VEC4_F32) with all KernelOps. IMAGE_2D
- * storage image path (emit_image_body) supports single and dual input images
- * with all single- and two-operand KernelOps. GLSL kernel path
- * (emit_glsl_kernel): complete, dispatched when spec.kernel is set via
- * MF_KERNEL.
+ * The assembly path (emit_spirv_asm) is complete for all binding modalities:
  *
- * Remaining gap
+ * SSBO (SCALAR_F32, VEC2_F32, VEC3_F32, VEC4_F32) — all KernelOps via
+ * emit_elementwise_body. Element type, ArrayStride, and pointer type are
+ * derived from GpuDataFormat. Scalar PC operands are splatted to vector
+ * width via OpCompositeConstruct before arithmetic.
  *
- * TEXTURE_2D sampled image bindings in the SPIR-V assembly path.
- * emit_header, emit_decorations, and emit_types all silently skip TEXTURE_2D
- * bindings. No OpTypeSampledImage, no combined image sampler variable, no
- * OpImageSampleExplicitLod in the body. Fix requires OpTypeSampler,
- * OpTypeSampledImage, OpVariable for the combined sampler, and
- * OpImageSampleExplicitLod or OpImageFetch in the body. The GLSL path via
- * MF_KERNEL handles TEXTURE_2D correctly today. The assembly path gap only
- * matters for filter ops that read a TextureContainer as a sampled source
- * without a user-supplied kernel.
+ * IMAGE_2D storage images — emit_image_body handles any number of Input/InOut
+ * images and one Output image. All single- and two-operand KernelOps apply
+ * per channel. StorageImageReadWithoutFormat emitted when any input image
+ * is present.
+ *
+ * TEXTURE_2D sampled images — emit_image_body loads each sampled texture via
+ * OpTypeSampledImage / OpImageSampleExplicitLod at normalised UV derived from
+ * GlobalInvocationID divided by width/height push constant fields. By
+ * convention the first two PC fields of any spec with TEXTURE_2D bindings
+ * are width and height; op-specific PC fields follow.
+ *
+ * GLSL kernel path (emit_glsl_kernel) handles all three modalities when
+ * spec.kernel is set via MF_KERNEL.
+ *
+ * Remaining incomplete path: emit_reduction_body. The shared memory tree
+ * is partially emitted but lacks OpLoopMerge and the back-edge. KernelOp::Sum
+ * and KernelOp::Max produce invalid SPIR-V. No caller exercises this path.
  */
 
 namespace MayaFlux::Portal::Graphics::detail {
@@ -109,9 +115,12 @@ namespace {
 
         std::string iface = "%gid_var";
         for (const auto& b : spec.bindings) {
-            if (b.modality == Kakshya::DataModality::TEXTURE_2D
-                || b.modality == Kakshya::DataModality::IMAGE_2D)
+            if (b.modality == Kakshya::DataModality::IMAGE_2D)
                 continue;
+            if (b.modality == Kakshya::DataModality::TEXTURE_2D) {
+                iface += " %tex_" + b.name;
+                continue;
+            }
             iface += " %buf_" + b.name;
         }
         if (has_storage_image) {
@@ -178,6 +187,14 @@ namespace {
             } else if (b.direction == BindingDirection::Output) {
                 o += "OpDecorate " + var + " NonReadable\n";
             }
+        }
+
+        for (const auto& b : spec.bindings) {
+            if (b.modality != Kakshya::DataModality::TEXTURE_2D)
+                continue;
+            o += "OpDecorate %tex_" + b.name + " DescriptorSet 0\n";
+            o += "OpDecorate %tex_" + b.name + " Binding "
+                + std::to_string(b.binding_index) + "\n";
         }
 
         if (!spec.pc_fields.empty()) {
@@ -276,6 +293,30 @@ namespace {
                     continue;
                 o += "%img_" + b.name + " = OpVariable %ptr_img2d UniformConstant\n";
             }
+            o += "\n";
+        }
+
+        bool has_texture_2d = false;
+        for (const auto& b : spec.bindings) {
+            if (b.modality == Kakshya::DataModality::TEXTURE_2D) {
+                has_texture_2d = true;
+                break;
+            }
+        }
+
+        if (has_texture_2d) {
+            if (!need_v2f32 && !has_image_2d)
+                o += "%v2f32      = OpTypeVector %f32 2\n";
+            o += "%sampler_t  = OpTypeSampler\n";
+            o += "%img2d_s_t  = OpTypeImage %f32 2D 0 0 0 1 Unknown\n";
+            o += "%simgc_t    = OpTypeSampledImage %img2d_s_t\n";
+            o += "%ptr_simg   = OpTypePointer UniformConstant %simgc_t\n";
+            for (const auto& b : spec.bindings) {
+                if (b.modality != Kakshya::DataModality::TEXTURE_2D)
+                    continue;
+                o += "%tex_" + b.name + " = OpVariable %ptr_simg UniformConstant\n";
+            }
+            o += "%lod_zero   = OpConstant %f32 0.0\n";
             o += "\n";
         }
 
@@ -642,6 +683,35 @@ namespace {
         if (!spec.pc_fields.empty())
             o += "\n";
 
+        std::vector<const BindingSlot*> tex_inputs;
+        for (const auto& b : spec.bindings) {
+            if (b.modality == Kakshya::DataModality::TEXTURE_2D)
+                tex_inputs.push_back(&b);
+        }
+
+        if (!tex_inputs.empty()) {
+            const std::string pw = spec.pc_fields.size() > 0
+                ? ("%pc_" + spec.pc_fields[0].name)
+                : "%lod_zero";
+            const std::string ph = spec.pc_fields.size() > 1
+                ? ("%pc_" + spec.pc_fields[1].name)
+                : "%lod_zero";
+            o += "%fix = OpConvertUToF %f32 %ix\n";
+            o += "%fiy = OpConvertUToF %f32 %iy\n";
+            o += "%u   = OpFDiv %f32 %fix " + pw + "\n";
+            o += "%v   = OpFDiv %f32 %fiy " + ph + "\n";
+            o += "%uv  = OpCompositeConstruct %v2f32 %u %v\n\n";
+
+            for (size_t ti = 0; ti < tex_inputs.size(); ++ti) {
+                const std::string idx = std::to_string(img_inputs.size() + ti);
+                o += "%simg_" + tex_inputs[ti]->name
+                    + " = OpLoad %simgc_t %tex_" + tex_inputs[ti]->name + "\n";
+                o += "%raw_in" + idx + " = OpImageSampleExplicitLod %v4f32 %simg_"
+                    + tex_inputs[ti]->name + " %uv Lod %lod_zero\n";
+            }
+            o += "\n";
+        }
+
         for (size_t ii = 0; ii < img_inputs.size(); ++ii) {
             o += "%raw_in" + std::to_string(ii) + " = OpImageRead %v4f32 %img_"
                 + img_inputs[ii]->name + " %coord\n";
@@ -657,12 +727,19 @@ namespace {
         o += "%ch0_b = OpCompositeExtract %f32 %raw_in0 2\n";
         o += "%ch0_a = OpCompositeExtract %f32 %raw_in0 3\n";
 
-        const bool has_second = img_inputs.size() > 1;
-        if (has_second) {
-            o += "%ch1_r = OpCompositeExtract %f32 %raw_in1 0\n";
-            o += "%ch1_g = OpCompositeExtract %f32 %raw_in1 1\n";
-            o += "%ch1_b = OpCompositeExtract %f32 %raw_in1 2\n";
-            o += "%ch1_a = OpCompositeExtract %f32 %raw_in1 3\n";
+        const bool has_second = img_inputs.size() > 1
+            || (!img_inputs.empty() && !tex_inputs.empty())
+            || tex_inputs.size() > 1;
+
+        const std::string second_idx = img_inputs.size() > 1
+            ? "1"
+            : (!tex_inputs.empty() ? std::to_string(img_inputs.size()) : "");
+
+        if (has_second && !second_idx.empty()) {
+            o += "%ch1_r = OpCompositeExtract %f32 %raw_in" + second_idx + " 0\n";
+            o += "%ch1_g = OpCompositeExtract %f32 %raw_in" + second_idx + " 1\n";
+            o += "%ch1_b = OpCompositeExtract %f32 %raw_in" + second_idx + " 2\n";
+            o += "%ch1_a = OpCompositeExtract %f32 %raw_in" + second_idx + " 3\n";
         }
         o += "\n";
 

--- a/src/MayaFlux/Portal/Graphics/AsmGenerator.cpp
+++ b/src/MayaFlux/Portal/Graphics/AsmGenerator.cpp
@@ -14,20 +14,8 @@
  *
  * What needs adding after Kinesis::Vision is active
  *
- * 1. Multi-component SSBO types in the SPIR-V assembly path.
- *    emit_decorations hardcodes ArrayStride 4 for every SSBO binding.
- *    emit_types hardcodes OpTypeRuntimeArray %f32 for every SSBO binding.
- *    emit_elementwise_body hardcodes %pf32_<name> pointer and scalar load/store.
- *    VEC2_F32 (stride 8), VEC3_F32 (stride 12), VEC4_F32 (stride 16) all
- *    produce wrong access chains. Fix: ssbo_type_info() helper maps
- *    GpuDataFormat to (elem_type, ptr_type_name, array_stride). Emit
- *    deduplicated vector type declarations in emit_types, use typed access
- *    chains and OpVectorTimesScalar / splat constructs in emit_elementwise_body
- *    for ops that mix scalar PC with vector SSBO elements. No caller exists
- *    yet — Kinesis::Vision pixel ops on uint8/float pixel SSBOs are the first
- *    concrete callers.
  *
- * 2. IMAGE_2D two-image ops (read-from-storage-image + write).
+ * 1. IMAGE_2D two-image ops (read-from-storage-image + write).
  *    emit_image_body resolves one img_in and one img_out. KernelOp::Add,
  *    Multiply, Mix in emit_image_body fall through to default (passthrough)
  *    because they need two img_in slots. Fix: extend the img_in resolution
@@ -37,7 +25,7 @@
  *    Input IMAGE_2D binding is present. Callers: Kinesis::Vision blend,
  *    composite, difference ops.
  *
- * 3. TEXTURE_2D sampled image bindings in the SPIR-V assembly path.
+ * 2. TEXTURE_2D sampled image bindings in the SPIR-V assembly path.
  *    emit_header, emit_decorations, emit_types all silently skip TEXTURE_2D
  *    bindings. No OpTypeSampledImage, no combined image sampler variable, no
  *    OpImageSampleExplicitLod in the body. Fix requires OpCapability Sampled1D
@@ -46,15 +34,7 @@
  *    is structurally heavier than storage image. Callers: Kinesis::Vision
  *    filter ops that read from a TextureContainer as a sampled source.
  *
- * 4. MF_KERNEL image body.
- *    emit_glsl_kernel generates correct GLSL for SSBO and IMAGE_2D bindings,
- *    but TEXTURE_2D sampled bindings use sampler2D which requires a combined
- *    image sampler descriptor — a different GpuBufferBinding::ElementType than
- *    IMAGE_STORAGE. The GLSL generation is correct; the binding declaration
- *    in bindings_from_spec maps TEXTURE_2D to IMAGE_SAMPLED which is correct.
- *    No gap in the GLSL path; gap is only in the SPIR-V assembly path (see 3).
- *
- * 5. Reduction body completion.
+ * 3. Reduction body completion.
  *    emit_reduction_body is a placeholder. The shared memory tree is partially
  *    emitted but the loop structure is missing — no OpLoopMerge, no back-edge.
  *    KernelOp::Sum and KernelOp::Max route here but produce invalid SPIR-V.
@@ -88,6 +68,41 @@ namespace {
             return "uint";
         default:
             return "float";
+        }
+    }
+
+    /**
+     * Returns the SPIR-V type ID string for the element type of an SSBO binding.
+     */
+    std::string_view ssbo_elem_spirv_type(Kakshya::GpuDataFormat fmt) noexcept
+    {
+        switch (fmt) {
+        case Kakshya::GpuDataFormat::VEC2_F32:
+            return "%v2f32";
+        case Kakshya::GpuDataFormat::VEC3_F32:
+            return "%v3f32";
+        case Kakshya::GpuDataFormat::VEC4_F32:
+            return "%v4f32";
+        default:
+            return "%f32";
+        }
+    }
+
+    /**
+     * Returns the component count for a GpuDataFormat SSBO element.
+     * Scalar formats return 1.
+     */
+    uint32_t ssbo_elem_components(Kakshya::GpuDataFormat fmt) noexcept
+    {
+        switch (fmt) {
+        case Kakshya::GpuDataFormat::VEC2_F32:
+            return 2;
+        case Kakshya::GpuDataFormat::VEC3_F32:
+            return 3;
+        case Kakshya::GpuDataFormat::VEC4_F32:
+            return 4;
+        default:
+            return 1;
         }
     }
 
@@ -149,7 +164,9 @@ namespace {
                 || b.modality == Kakshya::DataModality::IMAGE_2D)
                 continue;
 
-            o += "OpDecorate %rta_" + b.name + " ArrayStride 4\n";
+            const auto stride = static_cast<uint32_t>(Kakshya::gpu_data_format_bytes(b.format));
+            o += "OpDecorate %rta_" + b.name + " ArrayStride "
+                + std::to_string(stride) + "\n";
             o += "OpMemberDecorate %blk_" + b.name + " 0 Offset 0\n";
             o += "OpDecorate %blk_" + b.name + " Block\n";
             o += "OpDecorate %buf_" + b.name + " DescriptorSet 0\n";
@@ -179,7 +196,8 @@ namespace {
             for (size_t i = 0; i < spec.pc_fields.size(); ++i) {
                 o += "OpMemberDecorate %pc_blk " + std::to_string(i)
                     + " Offset " + std::to_string(off) + "\n";
-                off += Kakshya::gpu_data_format_bytes(spec.pc_fields[i].format);
+                off += static_cast<uint32_t>(
+                    Kakshya::gpu_data_format_bytes(spec.pc_fields[i].format));
             }
         }
         o += "\n";
@@ -201,26 +219,62 @@ namespace {
         o += "%ptr_in_v3u32 = OpTypePointer Input %v3u32\n";
         o += "%gid_var = OpVariable %ptr_in_v3u32 Input\n\n";
 
+        bool need_v2f32 = false;
+        bool need_v3f32 = false;
+        bool need_v4f32 = false;
+
         for (const auto& b : spec.bindings) {
             if (b.modality == Kakshya::DataModality::TEXTURE_2D
                 || b.modality == Kakshya::DataModality::IMAGE_2D)
                 continue;
-            o += "%rta_" + b.name + " = OpTypeRuntimeArray %f32\n";
-            o += "%blk_" + b.name + " = OpTypeStruct %rta_" + b.name + "\n";
-            o += "%pblk_" + b.name + " = OpTypePointer StorageBuffer %blk_" + b.name + "\n";
-            o += "%buf_" + b.name + " = OpVariable %pblk_" + b.name + " StorageBuffer\n";
-            o += "%pf32_" + b.name + " = OpTypePointer StorageBuffer %f32\n";
-        }
-        o += "\n";
-
-        bool any_image = false;
-        for (const auto& b : spec.bindings) {
-            if (b.modality == Kakshya::DataModality::IMAGE_2D) {
-                any_image = true;
+            switch (b.format) {
+            case Kakshya::GpuDataFormat::VEC2_F32:
+                need_v2f32 = true;
+                break;
+            case Kakshya::GpuDataFormat::VEC3_F32:
+                need_v3f32 = true;
+                break;
+            case Kakshya::GpuDataFormat::VEC4_F32:
+                need_v4f32 = true;
+                break;
+            default:
                 break;
             }
         }
-        if (any_image) {
+
+        if (need_v2f32)
+            o += "%v2f32 = OpTypeVector %f32 2\n";
+        if (need_v3f32)
+            o += "%v3f32 = OpTypeVector %f32 3\n";
+
+        bool has_image_2d = false;
+        for (const auto& b : spec.bindings) {
+            if (b.modality == Kakshya::DataModality::IMAGE_2D) {
+                has_image_2d = true;
+                break;
+            }
+        }
+        if (need_v4f32 && !has_image_2d)
+            o += "%v4f32 = OpTypeVector %f32 4\n";
+        if (need_v2f32 || need_v3f32 || (need_v4f32 && !has_image_2d))
+            o += "\n";
+
+        for (const auto& b : spec.bindings) {
+            if (b.modality == Kakshya::DataModality::TEXTURE_2D
+                || b.modality == Kakshya::DataModality::IMAGE_2D)
+                continue;
+
+            const std::string_view etype = ssbo_elem_spirv_type(b.format);
+            o += "%rta_" + b.name + " = OpTypeRuntimeArray " + std::string(etype) + "\n";
+            o += "%blk_" + b.name + " = OpTypeStruct %rta_" + b.name + "\n";
+            o += "%pblk_" + b.name + " = OpTypePointer StorageBuffer %blk_" + b.name + "\n";
+            o += "%buf_" + b.name + " = OpVariable %pblk_" + b.name + " StorageBuffer\n";
+            o += "%pelem_" + b.name + " = OpTypePointer StorageBuffer "
+                + std::string(etype) + "\n";
+        }
+        o += "\n";
+
+        if (has_image_2d) {
             o += "%i32          = OpTypeInt 32 1\n";
             o += "%v2i32        = OpTypeVector %i32 2\n";
             o += "%v4f32        = OpTypeVector %f32 4\n";
@@ -285,52 +339,96 @@ namespace {
             ssbos.push_back(&b);
         }
 
+        Kakshya::GpuDataFormat primary_fmt = Kakshya::GpuDataFormat::FLOAT32;
         for (const auto* b : ssbos) {
-            o += "%gep_" + b->name + " = OpAccessChain %pf32_" + b->name
+            if (b->direction != BindingDirection::Output) {
+                primary_fmt = b->format;
+                break;
+            }
+        }
+        const std::string_view etype = ssbo_elem_spirv_type(primary_fmt);
+        const uint32_t ncomp = ssbo_elem_components(primary_fmt);
+        const bool is_vector = (ncomp > 1);
+
+        for (const auto* b : ssbos) {
+            o += "%gep_" + b->name + " = OpAccessChain %pelem_" + b->name
                 + " %buf_" + b->name + " %c0u %i\n";
-            if (b->direction != BindingDirection::Output)
-                o += "%val_" + b->name + " = OpLoad %f32 %gep_" + b->name + "\n";
+            if (b->direction != BindingDirection::Output) {
+                o += "%val_" + b->name + " = OpLoad " + std::string(etype)
+                    + " %gep_" + b->name + "\n";
+            }
         }
         o += "\n";
 
-        std::string result;
+        auto pc_operand = [&](const std::string& field_name) -> std::string {
+            if (!is_vector)
+                return "%pc_" + field_name;
+            const std::string splat = "%spc_" + field_name;
+            std::string construct = splat + " = OpCompositeConstruct "
+                + std::string(etype);
+            const std::string scalar = " %pc_" + field_name;
+            for (uint32_t c = 0; c < ncomp; ++c)
+                construct += scalar;
+            o += construct + "\n";
+            return splat;
+        };
+
         const std::string v0 = ssbos.empty() ? "" : ("%val_" + ssbos[0]->name);
         const std::string v1 = ssbos.size() > 1 ? ("%val_" + ssbos[1]->name) : "";
-        const std::string p0 = spec.pc_fields.empty() ? "" : ("%pc_" + spec.pc_fields[0].name);
-        const std::string p1 = spec.pc_fields.size() > 1 ? ("%pc_" + spec.pc_fields[1].name) : "";
+        const std::string p0 = spec.pc_fields.empty() ? ""
+                                                      : pc_operand(spec.pc_fields[0].name);
+        const std::string p1 = spec.pc_fields.size() > 1
+            ? pc_operand(spec.pc_fields[1].name)
+            : "";
 
+        std::string result;
+        const std::string et = std::string(etype);
         switch (spec.op) {
         case KernelOp::Scale:
-            o += "%res = OpFMul %f32 " + v0 + " " + p0 + "\n";
+            if (is_vector) {
+                o += "%res = OpVectorTimesScalar " + et + " " + v0
+                    + " %pc_" + spec.pc_fields[0].name + "\n";
+            } else {
+                o += "%res = OpFMul " + et + " " + v0 + " " + p0 + "\n";
+            }
+
             result = "%res";
             break;
         case KernelOp::ScaleOffset:
-            o += "%mul = OpFMul %f32 " + v0 + " " + p0 + "\n";
-            o += "%res = OpFAdd %f32 %mul " + p1 + "\n";
+            if (is_vector) {
+                o += "%scaled = OpVectorTimesScalar " + et + " " + v0
+                    + " %pc_" + spec.pc_fields[0].name + "\n";
+                o += "%res = OpFAdd " + et + " %scaled " + p1 + "\n";
+            } else {
+                o += "%mul = OpFMul " + et + " " + v0 + " " + p0 + "\n";
+                o += "%res = OpFAdd " + et + " %mul " + p1 + "\n";
+            }
+
             result = "%res";
             break;
         case KernelOp::Offset:
-            o += "%res = OpFAdd %f32 " + v0 + " " + p0 + "\n";
+            o += "%res = OpFAdd " + et + " " + v0 + " " + p0 + "\n";
             result = "%res";
             break;
         case KernelOp::Clip:
-            o += "%res = OpExtInst %f32 %glsl FClamp " + v0 + " " + p0 + " " + p1 + "\n";
+            o += "%res = OpExtInst " + et + " %glsl FClamp " + v0
+                + " " + p0 + " " + p1 + "\n";
             result = "%res";
             break;
         case KernelOp::Abs:
-            o += "%res = OpExtInst %f32 %glsl FAbs " + v0 + "\n";
+            o += "%res = OpExtInst " + et + " %glsl FAbs " + v0 + "\n";
             result = "%res";
             break;
         case KernelOp::Negate:
-            o += "%res = OpFNegate %f32 " + v0 + "\n";
+            o += "%res = OpFNegate " + et + " " + v0 + "\n";
             result = "%res";
             break;
         case KernelOp::Add:
-            o += "%res = OpFAdd %f32 " + v0 + " " + v1 + "\n";
+            o += "%res = OpFAdd " + et + " " + v0 + " " + v1 + "\n";
             result = "%res";
             break;
         case KernelOp::Multiply:
-            o += "%res = OpFMul %f32 " + v0 + " " + v1 + "\n";
+            o += "%res = OpFMul " + et + " " + v0 + " " + v1 + "\n";
             result = "%res";
             break;
         case KernelOp::Mix:
@@ -448,7 +546,8 @@ namespace {
             result = "%res";
             break;
         default:
-            result = v0;
+            o += "%res = OpCopyObject " + et + " " + v0 + "\n";
+            result = "%res";
             break;
         }
         o += "\n";
@@ -457,7 +556,6 @@ namespace {
             if (b->direction == BindingDirection::Input)
                 continue;
             o += "OpStore %gep_" + b->name + " " + result + "\n";
-            break;
         }
 
         o += "OpReturn\n";

--- a/src/MayaFlux/Portal/Graphics/AsmGenerator.cpp
+++ b/src/MayaFlux/Portal/Graphics/AsmGenerator.cpp
@@ -4,30 +4,30 @@
  * @file AsmGenerator.cpp
  * @brief SPIR-V assembly and GLSL kernel emitters for ShaderSpec.
  *
- * The assembly path (emit_spirv_asm) is complete for all binding modalities:
+ * The assembly path (emit_spirv_asm) covers all binding modalities and
+ * kernel templates:
  *
  * SSBO (SCALAR_F32, VEC2_F32, VEC3_F32, VEC4_F32) — all KernelOps via
- * emit_elementwise_body. Element type, ArrayStride, and pointer type are
- * derived from GpuDataFormat. Scalar PC operands are splatted to vector
- * width via OpCompositeConstruct before arithmetic.
+ * emit_elementwise_body. ArrayStride, element type, and pointer type derived
+ * from GpuDataFormat. Scalar PC operands splatted to vector width via
+ * OpCompositeConstruct before arithmetic.
  *
  * IMAGE_2D storage images — emit_image_body handles any number of Input/InOut
- * images and one Output image. All single- and two-operand KernelOps apply
- * per channel. StorageImageReadWithoutFormat emitted when any input image
- * is present.
+ * images and one Output image with all single- and two-operand KernelOps
+ * applied per channel.
  *
- * TEXTURE_2D sampled images — emit_image_body loads each sampled texture via
- * OpTypeSampledImage / OpImageSampleExplicitLod at normalised UV derived from
- * GlobalInvocationID divided by width/height push constant fields. By
- * convention the first two PC fields of any spec with TEXTURE_2D bindings
- * are width and height; op-specific PC fields follow.
+ * TEXTURE_2D sampled images — emit_image_body loads each binding via
+ * OpTypeSampledImage / OpImageSampleExplicitLod at normalised UV derived
+ * from GlobalInvocationID divided by width/height PC fields (first two PC
+ * fields by convention when TEXTURE_2D bindings are present).
  *
- * GLSL kernel path (emit_glsl_kernel) handles all three modalities when
- * spec.kernel is set via MF_KERNEL.
+ * KernelTemplate::Reduction — emit_reduction_body emits a structured
+ * workgroup tree reduction with OpLoopMerge, OpPhi for the stride variable,
+ * OpULessThan active-thread guard, and two OpControlBarrier synchronisation
+ * points per iteration. Supports KernelOp::Sum and KernelOp::Max.
  *
- * Remaining incomplete path: emit_reduction_body. The shared memory tree
- * is partially emitted but lacks OpLoopMerge and the back-edge. KernelOp::Sum
- * and KernelOp::Max produce invalid SPIR-V. No caller exercises this path.
+ * GLSL kernel path (emit_glsl_kernel) handles all three binding modalities
+ * when spec.kernel is set via MF_KERNEL.
  */
 
 namespace MayaFlux::Portal::Graphics::detail {
@@ -132,6 +132,9 @@ namespace {
         if (!spec.pc_fields.empty())
             iface += " %pc";
 
+        if (spec.tmpl == KernelTemplate::Reduction)
+            iface += " %lid_var";
+
         std::string o;
         o += "OpCapability Shader\n";
 
@@ -196,6 +199,9 @@ namespace {
             o += "OpDecorate %tex_" + b.name + " Binding "
                 + std::to_string(b.binding_index) + "\n";
         }
+
+        if (spec.tmpl == KernelTemplate::Reduction)
+            o += "OpDecorate %lid_var BuiltIn LocalInvocationId\n";
 
         if (!spec.pc_fields.empty()) {
             o += "OpDecorate %pc_blk Block\n";
@@ -317,6 +323,21 @@ namespace {
                 o += "%tex_" + b.name + " = OpVariable %ptr_simg UniformConstant\n";
             }
             o += "%lod_zero   = OpConstant %f32 0.0\n";
+            o += "\n";
+        }
+
+        if (spec.tmpl == KernelTemplate::Reduction) {
+            const uint32_t local = spec.workgroup_size[0];
+            const std::string ls = std::to_string(local);
+            o += "%bool        = OpTypeBool\n";
+            o += "%lid_var  = OpVariable %ptr_in_v3u32 Input\n";
+            o += "%arr_sh_t    = OpTypeArray %f32 %c" + ls + "u\n";
+            o += "%psh_arr     = OpTypePointer Workgroup %arr_sh_t\n";
+            o += "%shared      = OpVariable %psh_arr Workgroup\n";
+            o += "%psh_f32     = OpTypePointer Workgroup %f32\n";
+            o += "%c" + ls + "u   = OpConstant %u32 " + ls + "\n";
+            o += "%c2u         = OpConstant %u32 2\n";
+            o += "%c264u       = OpConstant %u32 264\n"; // AcquireRelease | WorkgroupMemory
             o += "\n";
         }
 
@@ -603,38 +624,75 @@ namespace {
         const uint32_t local = spec.workgroup_size[0];
         const std::string ls = std::to_string(local);
         const bool is_max = (spec.op == KernelOp::Max);
+        const auto& b0 = spec.bindings.front();
 
         std::string o;
-        o += "%arr_t   = OpTypeArray %f32 %c" + ls + "u\n";
-        o += "%pshared = OpTypePointer Workgroup %f32\n";
-        o += "%shared  = OpVariable %pshared Workgroup\n\n";
-        o += "%c" + ls + "u = OpConstant %u32 " + ls + "\n\n";
+        o += "%main    = OpFunction %void None %voidfn\n";
+        o += "%entry   = OpLabel\n";
 
-        o += "%main  = OpFunction %void None %voidfn\n";
-        o += "%entry = OpLabel\n";
-        o += "%gid3  = OpLoad %v3u32 %gid_var\n";
-        o += "%i     = OpCompositeExtract %u32 %gid3 0\n";
-        o += "%lid   = OpCompositeExtract %u32 %gid3 0\n\n";
+        o += "%gid3    = OpLoad %v3u32 %gid_var\n";
+        o += "%i       = OpCompositeExtract %u32 %gid3 0\n";
+        o += "%lid3    = OpLoad %v3u32 %lid_var\n";
+        o += "%lid     = OpCompositeExtract %u32 %lid3 0\n\n";
 
-        const auto& b0 = spec.bindings.front();
-        o += "%gep0    = OpAccessChain %pf32_" + b0.name + " %buf_" + b0.name + " %c0u %i\n";
-        o += "%elem    = OpLoad %f32 %gep0\n";
-        o += "%pgep_sh = OpAccessChain %pshared %shared %lid\n";
-        o += "OpStore %pgep_sh %elem\n";
+        o += "%gep_in  = OpAccessChain %pelem_" + b0.name
+            + " %buf_" + b0.name + " %c0u %i\n";
+        o += "%elem    = OpLoad %f32 %gep_in\n";
+        o += "%pgsh    = OpAccessChain %psh_f32 %shared %lid\n";
+        o += "OpStore %pgsh %elem\n";
         o += "OpControlBarrier %c2u %c2u %c264u\n\n";
 
-        o += "%s_init = OpShiftRightLogical %u32 %c" + ls + "u %c1u\n";
-        o += "; reduction tree (caller must ensure workgroup is power of two)\n";
+        o += "%s_init  = OpShiftRightLogical %u32 %c" + ls + "u %c1u\n";
+        o += "OpBranch %loop_hdr\n\n";
+
+        o += "%loop_hdr = OpLabel\n";
+        o += "%stride  = OpPhi %u32 %s_init %entry %s_next %loop_cont\n";
+        o += "OpLoopMerge %loop_merge %loop_cont None\n";
+        o += "OpBranch %loop_body\n\n";
+
+        o += "%loop_body = OpLabel\n";
+        o += "%active  = OpULessThan %bool %lid %stride\n";
+        o += "OpSelectionMerge %sel_merge None\n";
+        o += "OpBranchConditional %active %do_op %sel_merge\n\n";
+
+        o += "%do_op   = OpLabel\n";
+        o += "%pgsh_a  = OpAccessChain %psh_f32 %shared %lid\n";
+        o += "%a       = OpLoad %f32 %pgsh_a\n";
+        o += "%lid_b   = OpIAdd %u32 %lid %stride\n";
+        o += "%pgsh_b  = OpAccessChain %psh_f32 %shared %lid_b\n";
+        o += "%b       = OpLoad %f32 %pgsh_b\n";
+
         if (is_max) {
-            o += "%cur  = OpLoad %f32 %pgep_sh\n";
-            o += "%res  = OpExtInst %f32 %glsl FMax %cur %elem\n";
+            o += "%combined = OpExtInst %f32 %glsl FMax %a %b\n";
         } else {
-            o += "%cur  = OpLoad %f32 %pgep_sh\n";
-            o += "%res  = OpFAdd %f32 %cur %elem\n";
+            o += "%combined = OpFAdd %f32 %a %b\n";
         }
-        o += "OpStore %pgep_sh %res\n";
-        o += "OpControlBarrier %c2u %c2u %c264u\n\n";
 
+        o += "OpStore %pgsh_a %combined\n";
+        o += "OpBranch %sel_merge\n\n";
+
+        o += "%sel_merge = OpLabel\n";
+        o += "OpBranch %loop_cont\n\n";
+
+        o += "%loop_cont = OpLabel\n";
+        o += "OpControlBarrier %c2u %c2u %c264u\n";
+        o += "%s_next  = OpShiftRightLogical %u32 %stride %c1u\n";
+        o += "%done    = OpIEqual %bool %s_next %c0u\n";
+        o += "OpBranchConditional %done %loop_merge %loop_hdr\n\n";
+
+        o += "%loop_merge = OpLabel\n";
+        o += "%is_zero = OpIEqual %bool %lid %c0u\n";
+        o += "OpSelectionMerge %write_merge None\n";
+        o += "OpBranchConditional %is_zero %do_write %write_merge\n\n";
+
+        o += "%do_write = OpLabel\n";
+        o += "%result  = OpLoad %f32 %pgsh\n";
+        o += "%gep_out = OpAccessChain %pelem_" + b0.name
+            + " %buf_" + b0.name + " %c0u %c0u\n";
+        o += "OpStore %gep_out %result\n";
+        o += "OpBranch %write_merge\n\n";
+
+        o += "%write_merge = OpLabel\n";
         o += "OpReturn\n";
         o += "OpFunctionEnd\n";
         return o;

--- a/src/MayaFlux/Portal/Graphics/ShaderSpec.hpp
+++ b/src/MayaFlux/Portal/Graphics/ShaderSpec.hpp
@@ -199,6 +199,7 @@ struct KernelSource {
  *   Add          out[i] = a[i] + b[i]
  *   Multiply     out[i] = a[i] * b[i]
  *   Mix          out[i] = a[i] + (b[i] - a[i]) * pc[0]
+ *   Sub          out[i] = a[i] - b[i]
  *   Pow          out[i] = pow(a[i], b[i])
  *   Atan2        out[i] = atan(a[i], b[i])
  *   Min          out[i] = min(a[i], b[i])
@@ -246,6 +247,7 @@ enum class KernelOp : uint8_t {
     Add,
     Multiply,
     Mix,
+    Sub,
     Pow,
     Atan2,
     Min,

--- a/src/MayaFlux/Yantra/Analyzers/VisionAnalyzer.cpp
+++ b/src/MayaFlux/Yantra/Analyzers/VisionAnalyzer.cpp
@@ -1,0 +1,32 @@
+#include "VisionAnalyzer.hpp"
+#include <numeric>
+
+namespace MayaFlux::Yantra {
+
+double extract_scalar_vision(
+    const VisionAnalysis& analysis, const std::string& qualifier)
+{
+    const auto& f = analysis.frame;
+
+    if (qualifier == "box_count")
+        return static_cast<double>(f.boxes.size());
+    if (qualifier == "contour_count")
+        return static_cast<double>(f.contours.size());
+    if (qualifier == "keypoint_count")
+        return static_cast<double>(f.keypoints.size());
+    if (qualifier == "track_count")
+        return static_cast<double>(f.tracks.size());
+    if (qualifier == "component_count")
+        return static_cast<double>(f.components.count);
+    if (qualifier == "mean_gradient_magnitude") {
+        const auto& mag = f.gradient.magnitude;
+        if (mag.empty())
+            return 0.0;
+        return std::accumulate(mag.begin(), mag.end(), 0.0)
+            / static_cast<double>(mag.size());
+    }
+
+    return 0.0;
+}
+
+} // namespace MayaFlux::Yantra

--- a/src/MayaFlux/Yantra/Analyzers/VisionAnalyzer.hpp
+++ b/src/MayaFlux/Yantra/Analyzers/VisionAnalyzer.hpp
@@ -1,0 +1,316 @@
+#pragma once
+
+#include "UniversalAnalyzer.hpp"
+
+#include "MayaFlux/Journal/Archivist.hpp"
+#include "MayaFlux/Kakshya/Utils/DataUtils.hpp"
+#include "MayaFlux/Kinesis/Vision/VisionExecutor.hpp"
+#include "MayaFlux/Kinesis/Vision/VisionOp.hpp"
+#include "MayaFlux/Yantra/OperationSpec/OperationHelper.hpp"
+
+namespace MayaFlux::Yantra {
+
+// ============================================================================
+// Result types
+// ============================================================================
+
+/**
+ * @brief Flattened structured outputs from one VisionResult.
+ *
+ * Each field is populated only when the terminal VisionSequence step
+ * produces the corresponding type. Empty/default otherwise.
+ * BoundingBox is surfaced from ComponentResult::boxes directly.
+ */
+struct MAYAFLUX_API DetectionSummary {
+    std::vector<Kinesis::Vision::BoundingBox> boxes;
+    std::vector<Kinesis::Vision::Contour> contours;
+    std::vector<Kinesis::Vision::Keypoint> keypoints;
+    std::vector<Kinesis::Vision::TrackResult> tracks;
+    Kinesis::Vision::GradientResult gradient;
+    Kinesis::Vision::ComponentResult components;
+};
+
+/**
+ * @struct VisionAnalysis
+ * @brief Analysis result produced by VisionAnalyzer for one frame.
+ */
+struct MAYAFLUX_API VisionAnalysis {
+    DetectionSummary frame;
+    std::vector<float> pixel_image;
+    uint32_t w { 0 };
+    uint32_t h { 0 };
+};
+
+/**
+ * @brief Extract a named scalar from a VisionAnalysis result.
+ *
+ * Supported qualifiers:
+ *   "box_count"               number of bounding boxes
+ *   "contour_count"           number of contours
+ *   "keypoint_count"          number of keypoints
+ *   "track_count"             number of tracked points
+ *   "component_count"         number of connected components
+ *   "mean_gradient_magnitude" mean of GradientResult::magnitude
+ *
+ * Unknown or empty qualifier returns 0.0.
+ *
+ * @param analysis Result produced by VisionAnalyzer.
+ * @param qualifier Name of the scalar to extract.
+ */
+[[nodiscard]] MAYAFLUX_API double extract_scalar_vision(
+    const VisionAnalysis& analysis, const std::string& qualifier);
+
+// ============================================================================
+// VisionAnalyzer
+// ============================================================================
+
+/**
+ * @class VisionAnalyzer
+ * @brief UniversalAnalyzer that takes any pixel-bearing input, runs a
+ *        VisionSequence via VisionExecutor, and surfaces structured results
+ *        into the Yantra compute graph.
+ *
+ * InputType can be any ComputeData type carrying pixel data:
+ *   - std::vector<DataVariant>                 (direct pixel variants)
+ *   - std::shared_ptr<SignalSourceContainer>   (TextureContainer, VideoStreamContainer, etc.)
+ *   - Kakshya::Region / RegionGroup            (pixel sub-region with container)
+ *
+ * extract_structured_native handles all unwrapping transparently. Width and
+ * height are read from SPATIAL_X / SPATIAL_Y dimension roles in the
+ * DataStructureInfo, or from metadata keys "width" and "height" as fallback.
+ *
+ * OutputType is std::vector<DataVariant> carrying VisionResult::pixel_image
+ * as vector<float>, matching the standard analyzer pipeline contract.
+ * Structured results (boxes, contours, keypoints, tracks, gradient,
+ * components) are stored via store_current_analysis and retrieved with
+ * get_vision_analysis() / extract_scalar_vision().
+ *
+ * @code
+ * auto va = std::make_shared<StandardVisionAnalyzer>(sequence);
+ * va->apply_operation(pixel_datum);
+ * auto analysis = va->get_vision_analysis();
+ * double n = extract_scalar_vision(analysis, "box_count");
+ * @endcode
+ */
+template <ComputeData InputType = std::vector<Kakshya::DataVariant>,
+    ComputeData OutputType = std::vector<Kakshya::DataVariant>>
+class VisionAnalyzer
+    : public UniversalAnalyzer<InputType, OutputType> {
+public:
+    using input_type = Datum<InputType>;
+    using output_type = Datum<OutputType>;
+    using base_type = UniversalAnalyzer<InputType, OutputType>;
+
+    /**
+     * @brief Construct with the VisionSequence to execute each call.
+     * @param sequence Ordered VisionSteps describing the pipeline.
+     */
+    explicit VisionAnalyzer(Kinesis::Vision::VisionSequence sequence)
+        : m_sequence(std::move(sequence))
+    {
+    }
+
+    /**
+     * @brief Type-safe vision analysis.
+     * @param data Input datum carrying pixel data.
+     * @return VisionAnalysis directly.
+     */
+    VisionAnalysis analyze_vision(const input_type& data)
+    {
+        this->analyze_data(data);
+        return get_vision_analysis();
+    }
+
+    VisionAnalysis analyze_vision(const InputType& data)
+    {
+        return analyze_vision(input_type { data });
+    }
+
+    /**
+     * @brief Get the last VisionAnalysis result.
+     */
+    [[nodiscard]] VisionAnalysis get_vision_analysis() const
+    {
+        return safe_any_cast_or_throw<VisionAnalysis>(this->get_current_analysis());
+    }
+
+    /**
+     * @brief Replace the pipeline and reset inter-frame executor state.
+     *
+     * Not thread-safe relative to analyze_implementation. Call only when idle.
+     */
+    void set_sequence(Kinesis::Vision::VisionSequence sequence)
+    {
+        m_sequence = std::move(sequence);
+        m_executor.reset();
+    }
+
+    /**
+     * @brief Clear stored optical flow state.
+     *
+     * Call when the pixel source changes (camera switch, video seek).
+     */
+    void reset() { m_executor.reset(); }
+
+    [[nodiscard]] AnalysisType get_analysis_type() const override
+    {
+        return AnalysisType::SPATIAL;
+    }
+
+    [[nodiscard]] std::vector<std::string> get_available_methods() const override
+    {
+        return { "default" };
+    }
+
+protected:
+    [[nodiscard]] std::string get_analyzer_name() const override
+    {
+        return "VisionAnalyzer";
+    }
+
+    output_type analyze_implementation(const input_type& input) override
+    {
+        try {
+            auto [native_spans, structure_info] = OperationHelper::extract_structured_native(
+                const_cast<input_type&>(input));
+
+            if (native_spans.empty()) {
+                error<std::runtime_error>(
+                    Journal::Component::Yantra,
+                    Journal::Context::ComputeMatrix,
+                    std::source_location::current(),
+                    "VisionAnalyzer: no pixel data in input");
+            }
+
+            uint32_t w = 0;
+            uint32_t h = 0;
+            for (const auto& dim : structure_info.dimensions) {
+                if (dim.role == Kakshya::DataDimension::Role::SPATIAL_X) {
+                    w = static_cast<uint32_t>(dim.size);
+                } else if (dim.role == Kakshya::DataDimension::Role::SPATIAL_Y) {
+                    h = static_cast<uint32_t>(dim.size);
+                }
+            }
+            if (w == 0)
+                w = Kakshya::get_metadata_value<uint32_t>(input.metadata, "width").value_or(0);
+            if (h == 0)
+                h = Kakshya::get_metadata_value<uint32_t>(input.metadata, "height").value_or(0);
+
+            if (w == 0 || h == 0) {
+                error<std::runtime_error>(
+                    Journal::Component::Yantra,
+                    Journal::Context::ComputeMatrix,
+                    std::source_location::current(),
+                    "VisionAnalyzer: width/height not resolvable from dimensions or metadata");
+            }
+
+            auto frame = std::visit([&](const auto& span) -> std::span<const float> {
+                using ElemT = typename std::decay_t<decltype(span)>::value_type;
+                if constexpr (std::is_same_v<ElemT, float>) {
+                    return span;
+                } else {
+                    using VecT = std::vector<ElemT>;
+                    VecT tmp(span.begin(), span.end());
+                    Kakshya::DataVariant var(std::move(tmp));
+                    return Kakshya::as_normalised_float(var, m_float_storage);
+                }
+            },
+                native_spans[0]);
+
+            if (frame.empty()) {
+                error<std::runtime_error>(
+                    Journal::Component::Yantra,
+                    Journal::Context::ComputeMatrix,
+                    std::source_location::current(),
+                    "VisionAnalyzer: normalisation produced empty frame");
+            }
+
+            const Kinesis::Vision::VisionResult vr = m_executor.run(m_sequence, frame, w, h);
+
+            VisionAnalysis analysis;
+            analysis.pixel_image = vr.pixel_image;
+            analysis.w = vr.w;
+            analysis.h = vr.h;
+
+            std::visit([&](const auto& s) {
+                using T = std::decay_t<decltype(s)>;
+                if constexpr (std::is_same_v<T, Kinesis::Vision::GradientResult>) {
+                    analysis.frame.gradient = s;
+                } else if constexpr (std::is_same_v<T, Kinesis::Vision::ComponentResult>) {
+                    analysis.frame.components = s;
+                    analysis.frame.boxes = s.boxes;
+                } else if constexpr (std::is_same_v<T, std::vector<Kinesis::Vision::Contour>>) {
+                    analysis.frame.contours = s;
+                } else if constexpr (std::is_same_v<T, std::vector<Kinesis::Vision::Keypoint>>) {
+                    analysis.frame.keypoints = s;
+                } else if constexpr (std::is_same_v<T, std::vector<Kinesis::Vision::TrackResult>>) {
+                    analysis.frame.tracks = s;
+                }
+            },
+                vr.structured);
+
+            this->store_current_analysis(analysis);
+
+            return create_pipeline_output(input, vr, structure_info);
+
+        } catch (const std::exception& e) {
+            MF_ERROR(Journal::Component::Yantra, Journal::Context::ComputeMatrix,
+                "VisionAnalyzer: {}", e.what());
+            output_type err;
+            err.metadata = input.metadata;
+            err.metadata["error"] = std::string(e.what());
+            return err;
+        }
+    }
+
+private:
+    Kinesis::Vision::VisionSequence m_sequence;
+    Kinesis::Vision::VisionExecutor m_executor;
+    mutable std::vector<float> m_float_storage;
+
+    output_type create_pipeline_output(
+        const input_type& input,
+        const Kinesis::Vision::VisionResult& vr,
+        const DataStructureInfo& info)
+    {
+        std::vector<Kakshya::DataVariant> out_variants;
+        if (!vr.pixel_image.empty())
+            out_variants.emplace_back(vr.pixel_image);
+
+        output_type out = this->convert_result(
+            std::vector<std::vector<double>> {}, info);
+        out.data = OperationHelper::reconstruct_from_double<OutputType>({}, info);
+
+        if constexpr (std::is_same_v<OutputType, std::vector<Kakshya::DataVariant>>) {
+            out.data = std::move(out_variants);
+        }
+
+        out.dimensions = {
+            Kakshya::DataDimension::spatial_2d(vr.w, vr.h)
+        };
+        out.modality = Kakshya::DataModality::IMAGE_2D;
+        out.metadata = input.metadata;
+        out.metadata["source_analyzer"] = std::string("VisionAnalyzer");
+        out.metadata["vision_w"] = vr.w;
+        out.metadata["vision_h"] = vr.h;
+        return out;
+    }
+};
+
+// ============================================================================
+// Aliases
+// ============================================================================
+
+/// Standard: DataVariant pixels in, DataVariant pixel_image out.
+using StandardVisionAnalyzer = VisionAnalyzer<std::vector<Kakshya::DataVariant>,
+    std::vector<Kakshya::DataVariant>>;
+
+/// Container: any SignalSourceContainer in, DataVariant pixel_image out.
+using ContainerVisionAnalyzer = VisionAnalyzer<std::shared_ptr<Kakshya::SignalSourceContainer>,
+    std::vector<Kakshya::DataVariant>>;
+
+/// Region: pixel sub-region with container in, DataVariant pixel_image out.
+using RegionVisionAnalyzer = VisionAnalyzer<Kakshya::Region,
+    std::vector<Kakshya::DataVariant>>;
+
+} // namespace MayaFlux::Yantra


### PR DESCRIPTION
This PR introduces the first dedicated vision layer in MayaFlux.

MayaFlux has always been able to process image data. Textures could move through compute shaders, CPU algorithms could operate on pixel buffers, and image streams were already first-class data sources. What was missing was a native mechanism for extracting *structure* from images rather than merely transforming them.

This work establishes that layer.

The new Kinesis Vision stack introduces algorithms that convert pixels into meaningful observations: gradients, edges, connected regions, contours, keypoints, optical-flow tracks, and other structured results. Those observations are exposed through declarative vision pipelines, integrated into Kakshya processors, surfaced through Yantra analyzers, and delivered through the same coroutine and graph infrastructure used throughout MayaFlux.

The significance is not that MayaFlux can now process images (it already could). The significance is that image-derived information becomes graph-native data. A camera feed can produce keypoints, contours, motion tracks, or component detections that participate directly in scheduling, spatial simulation, rendering systems, automation, and analysis without custom bridging code or external vision frameworks.

Architecturally, this PR builds the complete CPU vision path:

* Vision algorithms and feature extraction primitives.
* Declarative `VisionSequence` pipeline construction.
* `VisionExecutor` runtime execution.
* Container and GPU-image processing integrations.
* Coroutine-native result delivery.
* Yantra analysis and structured result extraction.
* End-to-end validation from live camera input through graph execution.

This establishes vision as a distinct computational domain within MayaFlux: not image processing, but the extraction and propagation of information derived from images.

The GPU-resident vision path, where image data remains on the GPU from acquisition through analysis and rendering, will build on this foundation in the next development cycle.


### Architecture

#### Kinesis::Vision: pure algorithms

All vision algorithms live in `Kinesis::Vision` as pure functions. No MayaFlux
type dependencies. All inputs are `span<const float>` normalised to [0,1]. All
outputs are either `vector<float>` pixel buffers or typed structured result
types.

```cpp
// All of these are pure functions. No framework, no allocation policy.
vector<float>   rgba_to_gray(span<const float> rgba, uint32_t w, uint32_t h);
vector<float>   gaussian_blur(span<const float> gray, uint32_t w, uint32_t h, float sigma);
GradientResult  sobel(span<const float> gray, uint32_t w, uint32_t h);
vector<float>   harris_response(span<const float> gray, uint32_t w, uint32_t h, float k, float sigma);
vector<Keypoint> extract_peaks(span<const float> response, uint32_t w, uint32_t h, float threshold, uint32_t nms_radius);
vector<TrackResult> track_keypoints(span<const float> prev, span<const float> curr,
                                     uint32_t w, uint32_t h,
                                     span<const Keypoint> keypoints,
                                     const TrackKeypointsParams& params);
```

Algorithms delivered: PixelOps (colour space, threshold, normalisation),
Filter (separable convolution, Gaussian blur), Gradient (Sobel, Scharr, Canny),
Morphology (erode, dilate, open, close, gradient), ConnectedComponents
(two-pass union-find with BoundingBox per component), Contours (Moore
neighbourhood tracing, shoelace area, Euclidean perimeter), Harris corner
detection, Lucas-Kanade optical flow.

#### VisionSequence: declarative pipeline description

A vision pipeline is described as an ordered list of steps, each naming an op
and carrying its typed parameters. The description is a pure value type with
no execution logic.

```cpp
auto sequence = VisionSequence::Builder {}
    .rgba_to_gray()
    .harris_response(0.04F, 1.5F)
    .extract_peaks(0.1F, 8)
    .build();
```

`VisionExecutor` is the stateful dispatch engine that runs a sequence on one
frame. It holds the previous gray frame and keypoints for optical flow
continuity across calls. Everything else is stateless.

#### Integration layers

Three integration points, one per subsystem:

**Kakshya: VisionProcessor**

A `DataProcessor` that attaches to any pixel-carrying container
(`VideoStreamContainer`, `WindowContainer`, `TextureContainer`), runs the
sequence each `process()` call, and stores the `VisionResult` for polling or
coroutine delivery via `BroadcastSource<VisionResult>`.

```cpp
auto proc = std::make_shared<VisionProcessor>(sequence);
container->add_processor(proc);

// poll
auto& result = proc->get_result();

// coroutine delivery
co_await on_signal(proc->get_result_source());
```

**Buffers: ImageCVProcessor**

A `BufferProcessor` constrained by `GpuImageSource<T>`, operating directly on
GPU-resident images without the container abstraction layer. Downloads via
`download_and_normalise` into a persistent CPU staging buffer, runs the
sequence, and signals results. The download uses a persistent host-visible
`VKBuffer` (allocated once in `on_attach` at 4K RGBA worst case) passed to
`TextureLoom::download_data` to take the fenced path rather than `waitIdle`.

```cpp
auto vis = std::make_shared<ImageCVProcessor<VideoContainerBuffer>>(sequence);
add_processor(vis, tex, ProcessingToken::GRAPHICS_BACKEND);
```

**Yantra: VisionAnalyzer**

A `UniversalAnalyzer` subclass following the same pattern as `EnergyAnalyzer`
and `StatisticalAnalyzer`. Input is any `ComputeData` carrying pixel data:
`vector<DataVariant>`, `shared_ptr<SignalSourceContainer>`, `Region`,
`RegionGroup`. `OperationHelper::extract_structured_native` handles all
unwrapping transparently. Width and height are resolved from `SPATIAL_X` /
`SPATIAL_Y` dimension roles with metadata fallback.

```cpp
auto va = std::make_shared<StandardVisionAnalyzer>(sequence);
va->apply_operation(pixel_datum);
auto analysis = va->get_vision_analysis();
double n = extract_scalar_vision(analysis, "keypoint_count");
```

Structured results (boxes, contours, keypoints, tracks, gradient, components)
are flattened into `DetectionSummary` and stored via `store_current_analysis`.
The pipeline output is `vector<DataVariant>` carrying `VisionResult::pixel_image`
as `vector<float>` for downstream chaining.

### GPU kernel infrastructure: AsmGenerator

The GPU vision path requires the SPIR-V assembly emitter to handle all binding
modalities correctly. Four gaps existed; all are now closed.

**Gap 1: vector SSBO element types**

`emit_decorations` hardcoded `ArrayStride 4` for every SSBO binding regardless
of `GpuDataFormat`. `emit_types` hardcoded `OpTypeRuntimeArray %f32`.
`emit_elementwise_body` hardcoded scalar access chains and `OpFMul`.

A `VEC4_F32` pixel buffer SSBO produced structurally invalid SPIR-V: wrong
stride, wrong runtime array element type, scalar pointer through a vector
element.

After this PR, `ArrayStride` is derived from `gpu_data_format_bytes(b.format)`.
Vector type declarations are deduplicated. Access chains and loads use the
correct element type. Scalar PC operands are splatted to vector width via
`OpCompositeConstruct` before arithmetic. `Scale` on a vector SSBO emits
`OpVectorTimesScalar` rather than `OpFMul %f32`.

```
// Before: VEC4_F32 SSBO spec produced this (wrong)
OpDecorate %rta_sig ArrayStride 4
%rta_sig = OpTypeRuntimeArray %f32
%gep_sig = OpAccessChain %pf32_sig %buf_sig %c0u %i
%val_sig = OpLoad %f32 %gep_sig

// After: correct
OpDecorate %rta_sig ArrayStride 16
%v4f32   = OpTypeVector %f32 4
%rta_sig = OpTypeRuntimeArray %v4f32
%gep_sig = OpAccessChain %pelem_sig %buf_sig %c0u %i
%val_sig = OpLoad %v4f32 %gep_sig
%res     = OpVectorTimesScalar %v4f32 %val_sig %pc_gain
```

**Gap 2: dual-input IMAGE_2D ops**

`emit_image_body` resolved a single `img_in` pointer and fell through to
`CopyObject` for `Add`, `Multiply`, `Mix`, and `Sub`. Frame differencing,
blending, and compositing were unreachable through the assembly path.

After this PR, all Input/InOut IMAGE_2D bindings are collected into an ordered
vector. Each emits a named `OpImageRead` as `%raw_in0`, `%raw_in1`, and so on.
`StorageImageReadWithoutFormat` capability is emitted when any input image is
present. `Add`, `Multiply`, `Mix`, and `Sub` apply correctly per channel.
`KernelOp::Sub` was added to the enum to cover frame differencing.

**Gap 3: TEXTURE_2D sampled image bindings**

`emit_header`, `emit_decorations`, and `emit_types` silently skipped `TEXTURE_2D`
bindings. No `OpTypeSampledImage`, no combined image sampler variable, no
`OpImageSampleExplicitLod` was emitted.

After this PR, `TEXTURE_2D` variables appear in the `OpEntryPoint` interface.
`OpTypeSampler`, `OpTypeImage` (Sampled=1), `OpTypeSampledImage`, and per-binding
`OpVariable` are declared. UV coordinates are built from `GlobalInvocationID.xy`
divided by width/height push constant fields. `OpLoad` of the sampled image
followed by `OpImageSampleExplicitLod` is emitted per texture input.

**Gap 4: reduction body**

`emit_reduction_body` was a placeholder with no structured control flow. It used
`GlobalInvocationId` instead of `LocalInvocationId`, declared a single float
instead of a workgroup array, and referenced a stale pointer name. `KernelOp::Sum`
and `KernelOp::Max` produced assembler-rejected SPIR-V.

After this PR, `LocalInvocationId` is declared and decorated correctly. The
shared memory array is `OpTypeArray %f32 %c<local>u` in Workgroup storage. The
reduction loop uses `OpLoopMerge`, `OpPhi` carrying the stride variable across
iterations, `OpULessThan` as the active-thread guard, two `OpControlBarrier`
synchronisation points per iteration, and a final conditional write from thread 0.

### Validated end to end

The camera overlay test runs a Harris + peak extraction sequence on a live
1920x1080 feed and renders detected keypoints as green points overlaid on the
camera texture in the same window. The points land on geometrically correct
locations: window blind intersections, chair back edges, object corners.

```cpp
auto sequence = VisionSequence::Builder {}
    .rgba_to_gray()
    .harris_response(0.04F, 1.5F)
    .extract_peaks(0.1F, 8)
    .build();

auto vis = std::make_shared<ImageCVProcessor<VideoContainerBuffer>>(sequence);
add_processor(vis, tex, ProcessingToken::GRAPHICS_BACKEND);

schedule_metro(1 / 30.F, [&] {
    const auto& result = vis->get_result();
    if (const auto* kps = std::get_if<std::vector<Keypoint>>(&result.structured)) {
        std::vector<PointVertex> verts;
        for (const auto& kp : *kps)
            verts.push_back({
                .position = { kp.position.x * 2.F - 1.F,
                              -(kp.position.y * 2.F - 1.F), 0.F },
                .color    = { 0.F, 1.F, 0.2F },
                .size     = 6.F + kp.response * 12.F,
            });
        point_node->set_points(verts);
    }
}, "", ProcessingToken::FRAME_ACCURATE);
```

The current rate is CPU-bound at roughly 3fps on a full resolution frame. This
is expected and is the entire motivation for the GPU path. Every algorithm in
this PR has a direct compute shader equivalent. The AsmGenerator gaps closed
here are the precondition for that work.

### What comes next

The GPU vision path operates without any CPU download. Each `VisionStep` gains
an optional `GpuVisionBackend` descriptor. When present, `ImageCVProcessor`
dispatches a compute shader instead of calling the CPU function. Intermediate
results stay in GPU SSBOs or storage images and feed the next step directly.

Elementwise ops (`Threshold`, `NormalizeInplace`, `Scale`) map directly to
`ShaderSpec::Assemble` using existing `KernelOp` coverage. Structurally complex
ops (`RgbaToGray`, `GaussianBlur`, `Sobel`, `HarrisResponse`, `ExtractPeaks`)
are `.comp` files compiled by shaderc, living in `Portal/Shaders/Vision/`.
`MF_KERNEL` is not used internally; it is a user escape hatch.

The keypoint output from `ExtractPeaks` on GPU writes directly into an SSBO
via atomic counter. That SSBO feeds `PointCollectionNode` without any CPU
readback. The overlay that currently runs at 3fps will run at full camera rate
with zero CPU overhead.
