### PR TITLE
Volume: N-field lattice state, incompressible flow, and two rendering models

### DIFF
--- a/data/shaders/include/volume_common.glsl
+++ b/data/shaders/include/volume_common.glsl
@@ -1,0 +1,60 @@
+#ifndef VOLUME_COMMON_GLSL
+#define VOLUME_COMMON_GLSL
+
+uint volume_index(uvec3 cell, uvec3 dims)
+{
+    return cell.z * dims.x * dims.y + cell.y * dims.x + cell.x;
+}
+
+uint volume_index_clamped(ivec3 cell, uvec3 dims)
+{
+    ivec3 c = clamp(cell, ivec3(0), ivec3(dims) - 1);
+    return uint(c.z) * dims.x * dims.y + uint(c.y) * dims.x + uint(c.x);
+}
+
+bool volume_in_bounds(uvec3 cell, uvec3 dims)
+{
+    return cell.x < dims.x && cell.y < dims.y && cell.z < dims.z;
+}
+
+vec3 volume_backtrace(uvec3 cell, vec3 velocity, vec3 cell_size, float dt, uvec3 dims)
+{
+    vec3 origin = vec3(cell) + 0.5 - dt * velocity / cell_size;
+    return clamp(origin, vec3(0.5), vec3(dims) - 0.5);
+}
+
+void volume_trilinear_setup(vec3 p, uvec3 dims, out uint idx[8], out vec3 f)
+{
+    vec3 base = floor(p - 0.5);
+    f = p - 0.5 - base;
+    ivec3 b = ivec3(base);
+
+    idx[0] = volume_index_clamped(b + ivec3(0, 0, 0), dims);
+    idx[1] = volume_index_clamped(b + ivec3(1, 0, 0), dims);
+    idx[2] = volume_index_clamped(b + ivec3(0, 1, 0), dims);
+    idx[3] = volume_index_clamped(b + ivec3(1, 1, 0), dims);
+    idx[4] = volume_index_clamped(b + ivec3(0, 0, 1), dims);
+    idx[5] = volume_index_clamped(b + ivec3(1, 0, 1), dims);
+    idx[6] = volume_index_clamped(b + ivec3(0, 1, 1), dims);
+    idx[7] = volume_index_clamped(b + ivec3(1, 1, 1), dims);
+}
+
+float volume_blend8(float c[8], vec3 f)
+{
+    float x00 = mix(c[0], c[1], f.x);
+    float x10 = mix(c[2], c[3], f.x);
+    float x01 = mix(c[4], c[5], f.x);
+    float x11 = mix(c[6], c[7], f.x);
+    return mix(mix(x00, x10, f.y), mix(x01, x11, f.y), f.z);
+}
+
+vec4 volume_blend8(vec4 c[8], vec3 f)
+{
+    vec4 x00 = mix(c[0], c[1], f.x);
+    vec4 x10 = mix(c[2], c[3], f.x);
+    vec4 x01 = mix(c[4], c[5], f.x);
+    vec4 x11 = mix(c[6], c[7], f.x);
+    return mix(mix(x00, x10, f.y), mix(x01, x11, f.y), f.z);
+}
+
+#endif

--- a/data/shaders/include/volume_influx.glsl
+++ b/data/shaders/include/volume_influx.glsl
@@ -1,0 +1,63 @@
+#ifndef VOLUME_INFLUX_GLSL
+#define VOLUME_INFLUX_GLSL
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 4) in;
+
+layout(set = 0, binding = 0, std430) readonly buffer FieldIn {
+    float field_in[];
+};
+layout(set = 0, binding = 1, std430) writeonly buffer FieldOut {
+    float field_out[];
+};
+
+layout(push_constant) uniform PC {
+    uint width;
+    uint height;
+    uint depth;
+    uint pad0;
+    float cell_size_x;
+    float cell_size_y;
+    float cell_size_z;
+    float elapsed;
+    float center_x;
+    float center_y;
+    float center_z;
+    float radius;
+    float rate;
+    float time_step;
+    float falloff;
+    float pad1;
+    float bounds_min_x;
+    float bounds_min_y;
+    float bounds_min_z;
+    float pad2;
+} pc;
+
+float shape(vec3 p, float t);
+
+vec3 influx_center()
+{
+    return vec3(pc.center_x, pc.center_y, pc.center_z);
+}
+
+void main()
+{
+    uvec3 gid = gl_GlobalInvocationID;
+    uvec3 dims = uvec3(pc.width, pc.height, pc.depth);
+
+    if (!volume_in_bounds(gid, dims)) {
+        return;
+    }
+
+    uint index = volume_index(gid, dims);
+
+    vec3 cell = vec3(pc.cell_size_x, pc.cell_size_y, pc.cell_size_z);
+    vec3 lo = vec3(pc.bounds_min_x, pc.bounds_min_y, pc.bounds_min_z);
+    vec3 world = lo + (vec3(gid) + 0.5) * cell;
+
+    float s = shape(world, pc.elapsed);
+
+    field_out[index] = field_in[index] + s * pc.rate * pc.time_step;
+}
+
+#endif

--- a/data/shaders/mc_emit.comp
+++ b/data/shaders/mc_emit.comp
@@ -25,7 +25,8 @@ layout(push_constant) uniform PC {
     uint res_x;
     uint res_y;
     uint res_z;
-    uint color_mode;
+    uint pad0;
+    vec4 palette[3];
 } pc;
 
 float sample_grid(vec3 world_p)
@@ -94,7 +95,11 @@ void write_vertex(uint slot, vec3 pos, vec2 uv, vec3 normal, vec3 color)
 
 vec3 vertex_color(vec3 normal)
 {
-    return pc.color_mode == 0u ? vec3(1.0) : normal * 0.5 + 0.5;
+    vec3 a = abs(normal);
+    if (a.x >= a.y && a.x >= a.z) {
+        return pc.palette[0].rgb;
+    }
+    return a.y >= a.z ? pc.palette[1].rgb : pc.palette[2].rgb;
 }
 
 void main()

--- a/data/shaders/mc_emit.comp
+++ b/data/shaders/mc_emit.comp
@@ -25,7 +25,7 @@ layout(push_constant) uniform PC {
     uint res_x;
     uint res_y;
     uint res_z;
-    uint _pad;
+    uint color_mode;
 } pc;
 
 float sample_grid(vec3 world_p)
@@ -72,15 +72,15 @@ vec3 interp_edge(vec3 p0, vec3 p1, float v0, float v1)
     return abs(d) < 1e-7 ? (p0 + p1) * 0.5 : p0 + ((pc.iso_level - v0) / d) * (p1 - p0);
 }
 
-void write_vertex(uint slot, vec3 pos, vec2 uv, vec3 normal)
+void write_vertex(uint slot, vec3 pos, vec2 uv, vec3 normal, vec3 color)
 {
     uint base = slot * 15u;
     vertices[base + 0] = pos.x;
     vertices[base + 1] = pos.y;
     vertices[base + 2] = pos.z;
-    vertices[base + 3] = 1.0;
-    vertices[base + 4] = 1.0;
-    vertices[base + 5] = 1.0;
+    vertices[base + 3] = color.r;
+    vertices[base + 4] = color.g;
+    vertices[base + 5] = color.b;
     vertices[base + 6] = 0.0;
     vertices[base + 7] = uv.x;
     vertices[base + 8] = uv.y;
@@ -90,6 +90,11 @@ void write_vertex(uint slot, vec3 pos, vec2 uv, vec3 normal)
     vertices[base + 12] = 1.0;
     vertices[base + 13] = 0.0;
     vertices[base + 14] = 0.0;
+}
+
+vec3 vertex_color(vec3 normal)
+{
+    return pc.color_mode == 0u ? vec3(1.0) : normal * 0.5 + 0.5;
 }
 
 void main()
@@ -169,16 +174,20 @@ void main()
 
         vec3 p0 = ep[idx0], p1 = ep[idx1], p2 = ep[idx2];
 
+        vec3 n0 = compute_normal(p0);
+        vec3 n1 = compute_normal(p1);
+        vec3 n2 = compute_normal(p2);
+
         uint base = atomicAdd(vertex_count, 3u);
 
         write_vertex(base + 0u, p0,
             vec2((p0.x - pc.bounds_min.x) / extent.x, (p0.y - pc.bounds_min.y) / extent.y),
-            compute_normal(p0));
+            n0, vertex_color(n0));
         write_vertex(base + 1u, p1,
             vec2((p1.x - pc.bounds_min.x) / extent.x, (p1.y - pc.bounds_min.y) / extent.y),
-            compute_normal(p1));
+            n1, vertex_color(n1));
         write_vertex(base + 2u, p2,
             vec2((p2.x - pc.bounds_min.x) / extent.x, (p2.y - pc.bounds_min.y) / extent.y),
-            compute_normal(p2));
+            n2, vertex_color(n2));
     }
 }

--- a/data/shaders/mc_emit.comp
+++ b/data/shaders/mc_emit.comp
@@ -1,0 +1,184 @@
+#version 460
+
+layout(local_size_x = 64) in;
+
+layout(set = 0, binding = 0) readonly buffer SdfGrid {
+    float sdf[];
+};
+layout(set = 0, binding = 1) readonly buffer EdgeTable {
+    uint edge_table[];
+};
+layout(set = 0, binding = 2) readonly buffer TriTable {
+    int tri_table[];
+};
+layout(set = 0, binding = 3) writeonly buffer VertexOut {
+    float vertices[];
+};
+layout(set = 0, binding = 4) buffer AtomicCounter {
+    uint vertex_count;
+};
+
+layout(push_constant) uniform PC {
+    vec3 bounds_min;
+    float iso_level;
+    vec3 step;
+    uint res_x;
+    uint res_y;
+    uint res_z;
+    uint _pad;
+} pc;
+
+float sample_grid(vec3 world_p)
+{
+    vec3 local = (world_p - pc.bounds_min) / pc.step;
+    uint nx = pc.res_x + 1;
+    uint ny = pc.res_y + 1;
+
+    float fx = clamp(local.x, 0.0, float(pc.res_x));
+    float fy = clamp(local.y, 0.0, float(pc.res_y));
+    float fz = clamp(local.z, 0.0, float(pc.res_z));
+
+    uint ix0 = uint(fx);
+    uint ix1 = min(ix0 + 1, pc.res_x);
+    uint iy0 = uint(fy);
+    uint iy1 = min(iy0 + 1, pc.res_y);
+    uint iz0 = uint(fz);
+    uint iz1 = min(iz0 + 1, pc.res_z);
+
+    float tx = fract(fx), ty = fract(fy), tz = fract(fz);
+
+    #define S(xi,yi,zi) sdf[(xi) + nx*((yi) + ny*(zi))]
+    return mix(
+        mix(mix(S(ix0, iy0, iz0), S(ix1, iy0, iz0), tx), mix(S(ix0, iy1, iz0), S(ix1, iy1, iz0), tx), ty),
+        mix(mix(S(ix0, iy0, iz1), S(ix1, iy0, iz1), tx), mix(S(ix0, iy1, iz1), S(ix1, iy1, iz1), tx), ty),
+        tz);
+    #undef S
+}
+
+vec3 compute_normal(vec3 p)
+{
+    const float e = 1e-3;
+    vec3 g = vec3(
+            sample_grid(p + vec3(e, 0, 0)) - sample_grid(p - vec3(e, 0, 0)),
+            sample_grid(p + vec3(0, e, 0)) - sample_grid(p - vec3(0, e, 0)),
+            sample_grid(p + vec3(0, 0, e)) - sample_grid(p - vec3(0, 0, e)));
+    float len = length(g);
+    return len > 1e-7 ? g / len : vec3(0, 1, 0);
+}
+
+vec3 interp_edge(vec3 p0, vec3 p1, float v0, float v1)
+{
+    float d = v1 - v0;
+    return abs(d) < 1e-7 ? (p0 + p1) * 0.5 : p0 + ((pc.iso_level - v0) / d) * (p1 - p0);
+}
+
+void write_vertex(uint slot, vec3 pos, vec2 uv, vec3 normal)
+{
+    uint base = slot * 15u;
+    vertices[base + 0] = pos.x;
+    vertices[base + 1] = pos.y;
+    vertices[base + 2] = pos.z;
+    vertices[base + 3] = 1.0;
+    vertices[base + 4] = 1.0;
+    vertices[base + 5] = 1.0;
+    vertices[base + 6] = 0.0;
+    vertices[base + 7] = uv.x;
+    vertices[base + 8] = uv.y;
+    vertices[base + 9] = normal.x;
+    vertices[base + 10] = normal.y;
+    vertices[base + 11] = normal.z;
+    vertices[base + 12] = 1.0;
+    vertices[base + 13] = 0.0;
+    vertices[base + 14] = 0.0;
+}
+
+void main()
+{
+    const uint gid = gl_GlobalInvocationID.x;
+    const uint n_voxels = pc.res_x * pc.res_y * pc.res_z;
+    if (gid >= n_voxels)
+        return;
+
+    const uint ix = gid % pc.res_x;
+    const uint iy = (gid / pc.res_x) % pc.res_y;
+    const uint iz = gid / (pc.res_x * pc.res_y);
+    const uint nx = pc.res_x + 1;
+    const uint ny = pc.res_y + 1;
+
+    float v[8];
+    v[0] = sdf[ix + nx * (iy + ny * iz)];
+    v[1] = sdf[(ix + 1) + nx * (iy + ny * iz)];
+    v[2] = sdf[(ix + 1) + nx * ((iy + 1) + ny * iz)];
+    v[3] = sdf[ix + nx * ((iy + 1) + ny * iz)];
+    v[4] = sdf[ix + nx * (iy + ny * (iz + 1))];
+    v[5] = sdf[(ix + 1) + nx * (iy + ny * (iz + 1))];
+    v[6] = sdf[(ix + 1) + nx * ((iy + 1) + ny * (iz + 1))];
+    v[7] = sdf[ix + nx * ((iy + 1) + ny * (iz + 1))];
+
+    uint cube_idx = 0;
+    for (int k = 0; k < 8; ++k)
+        cube_idx |= uint(v[k] < pc.iso_level) << k;
+
+    uint edges = edge_table[cube_idx];
+    if (edges == 0u)
+        return;
+
+    float x0 = pc.bounds_min.x + float(ix) * pc.step.x;
+    float x1 = x0 + pc.step.x;
+    float y0 = pc.bounds_min.y + float(iy) * pc.step.y;
+    float y1 = y0 + pc.step.y;
+    float z0 = pc.bounds_min.z + float(iz) * pc.step.z;
+    float z1 = z0 + pc.step.z;
+
+    vec3 c[8] = {
+            vec3(x0, y0, z0),
+            vec3(x1, y0, z0),
+            vec3(x1, y1, z0),
+            vec3(x0, y1, z0),
+            vec3(x0, y0, z1),
+            vec3(x1, y0, z1),
+            vec3(x1, y1, z1),
+            vec3(x0, y1, z1)
+        };
+
+    vec3 ep[12];
+    if ((edges & 0x001u) != 0u) ep[0] = interp_edge(c[0], c[1], v[0], v[1]);
+    if ((edges & 0x002u) != 0u) ep[1] = interp_edge(c[1], c[2], v[1], v[2]);
+    if ((edges & 0x004u) != 0u) ep[2] = interp_edge(c[2], c[3], v[2], v[3]);
+    if ((edges & 0x008u) != 0u) ep[3] = interp_edge(c[3], c[0], v[3], v[0]);
+    if ((edges & 0x010u) != 0u) ep[4] = interp_edge(c[4], c[5], v[4], v[5]);
+    if ((edges & 0x020u) != 0u) ep[5] = interp_edge(c[5], c[6], v[5], v[6]);
+    if ((edges & 0x040u) != 0u) ep[6] = interp_edge(c[6], c[7], v[6], v[7]);
+    if ((edges & 0x080u) != 0u) ep[7] = interp_edge(c[7], c[4], v[7], v[4]);
+    if ((edges & 0x100u) != 0u) ep[8] = interp_edge(c[0], c[4], v[0], v[4]);
+    if ((edges & 0x200u) != 0u) ep[9] = interp_edge(c[1], c[5], v[1], v[5]);
+    if ((edges & 0x400u) != 0u) ep[10] = interp_edge(c[2], c[6], v[2], v[6]);
+    if ((edges & 0x800u) != 0u) ep[11] = interp_edge(c[3], c[7], v[3], v[7]);
+
+    const vec3 extent = vec3(
+            float(pc.res_x) * pc.step.x,
+            float(pc.res_y) * pc.step.y,
+            float(pc.res_z) * pc.step.z);
+
+    for (int t = 0; t < 5; ++t) {
+        int idx0 = tri_table[int(cube_idx) * 16 + t * 3 + 0];
+        if (idx0 == -1)
+            break;
+        int idx1 = tri_table[int(cube_idx) * 16 + t * 3 + 1];
+        int idx2 = tri_table[int(cube_idx) * 16 + t * 3 + 2];
+
+        vec3 p0 = ep[idx0], p1 = ep[idx1], p2 = ep[idx2];
+
+        uint base = atomicAdd(vertex_count, 3u);
+
+        write_vertex(base + 0u, p0,
+            vec2((p0.x - pc.bounds_min.x) / extent.x, (p0.y - pc.bounds_min.y) / extent.y),
+            compute_normal(p0));
+        write_vertex(base + 1u, p1,
+            vec2((p1.x - pc.bounds_min.x) / extent.x, (p1.y - pc.bounds_min.y) / extent.y),
+            compute_normal(p1));
+        write_vertex(base + 2u, p2,
+            vec2((p2.x - pc.bounds_min.x) / extent.x, (p2.y - pc.bounds_min.y) / extent.y),
+            compute_normal(p2));
+    }
+}

--- a/data/shaders/volume_advect_scalar.comp
+++ b/data/shaders/volume_advect_scalar.comp
@@ -1,0 +1,56 @@
+#version 460
+
+#include "include/volume_common.glsl"
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 4) in;
+
+layout(set = 0, binding = 0, std430) readonly buffer VelocityIn {
+    vec4 velocity_in[];
+};
+layout(set = 0, binding = 1, std430) readonly buffer CarriedIn {
+    float carried_in[];
+};
+layout(set = 0, binding = 2, std430) writeonly buffer CarriedOut {
+    float carried_out[];
+};
+
+layout(push_constant) uniform PC {
+    uint width;
+    uint height;
+    uint depth;
+    uint pad0;
+    float cell_size_x;
+    float cell_size_y;
+    float cell_size_z;
+    float time_step;
+    float dissipation;
+    float pad1;
+    float pad2;
+    float pad3;
+} pc;
+
+void main()
+{
+    uvec3 gid = gl_GlobalInvocationID;
+    uvec3 dims = uvec3(pc.width, pc.height, pc.depth);
+
+    if (!volume_in_bounds(gid, dims)) {
+        return;
+    }
+
+    uint index = volume_index(gid, dims);
+    vec3 cell_size = vec3(pc.cell_size_x, pc.cell_size_y, pc.cell_size_z);
+
+    vec3 origin = volume_backtrace(gid, velocity_in[index].xyz, cell_size, pc.time_step, dims);
+
+    uint idx[8];
+    vec3 f;
+    volume_trilinear_setup(origin, dims, idx, f);
+
+    float c[8];
+    for (int i = 0; i < 8; ++i) {
+        c[i] = carried_in[idx[i]];
+    }
+
+    carried_out[index] = volume_blend8(c, f) * pc.dissipation;
+}

--- a/data/shaders/volume_advect_vector.comp
+++ b/data/shaders/volume_advect_vector.comp
@@ -1,0 +1,56 @@
+#version 460
+
+#include "include/volume_common.glsl"
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 4) in;
+
+layout(set = 0, binding = 0, std430) readonly buffer VelocityIn {
+    vec4 velocity_in[];
+};
+layout(set = 0, binding = 1, std430) readonly buffer CarriedIn {
+    vec4 carried_in[];
+};
+layout(set = 0, binding = 2, std430) writeonly buffer CarriedOut {
+    vec4 carried_out[];
+};
+
+layout(push_constant) uniform PC {
+    uint width;
+    uint height;
+    uint depth;
+    uint pad0;
+    float cell_size_x;
+    float cell_size_y;
+    float cell_size_z;
+    float time_step;
+    float dissipation;
+    float pad1;
+    float pad2;
+    float pad3;
+} pc;
+
+void main()
+{
+    uvec3 gid = gl_GlobalInvocationID;
+    uvec3 dims = uvec3(pc.width, pc.height, pc.depth);
+
+    if (!volume_in_bounds(gid, dims)) {
+        return;
+    }
+
+    uint index = volume_index(gid, dims);
+    vec3 cell_size = vec3(pc.cell_size_x, pc.cell_size_y, pc.cell_size_z);
+
+    vec3 origin = volume_backtrace(gid, velocity_in[index].xyz, cell_size, pc.time_step, dims);
+
+    uint idx[8];
+    vec3 f;
+    volume_trilinear_setup(origin, dims, idx, f);
+
+    vec4 c[8];
+    for (int i = 0; i < 8; ++i) {
+        c[i] = carried_in[idx[i]];
+    }
+
+    carried_out[index] = volume_blend8(c, f) * pc.dissipation;
+}

--- a/data/shaders/volume_buoyancy.comp
+++ b/data/shaders/volume_buoyancy.comp
@@ -1,0 +1,57 @@
+#version 460
+
+#include "include/volume_common.glsl"
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 4) in;
+
+layout(set = 0, binding = 0, std430) readonly buffer TemperatureIn {
+    float temperature_in[];
+};
+layout(set = 0, binding = 1, std430) readonly buffer DensityIn {
+    float density_in[];
+};
+layout(set = 0, binding = 2, std430) readonly buffer VelocityIn {
+    vec4 velocity_in[];
+};
+layout(set = 0, binding = 3, std430) writeonly buffer VelocityOut {
+    vec4 velocity_out[];
+};
+
+layout(push_constant) uniform PC {
+    uint width;
+    uint height;
+    uint depth;
+    uint pad0;
+    float cell_size_x;
+    float cell_size_y;
+    float cell_size_z;
+    float time_step;
+    float direction_x;
+    float direction_y;
+    float direction_z;
+    float ambient;
+    float temperature_gain;
+    float density_gain;
+    float pad1;
+    float pad2;
+} pc;
+
+void main()
+{
+    uvec3 gid = gl_GlobalInvocationID;
+    uvec3 dims = uvec3(pc.width, pc.height, pc.depth);
+
+    if (!volume_in_bounds(gid, dims)) {
+        return;
+    }
+
+    uint index = volume_index(gid, dims);
+
+    float rise = pc.temperature_gain * (temperature_in[index] - pc.ambient);
+    float fall = pc.density_gain * density_in[index];
+
+    vec3 direction = vec3(pc.direction_x, pc.direction_y, pc.direction_z);
+    vec4 v = velocity_in[index];
+
+    velocity_out[index] = vec4(v.xyz + direction * ((rise - fall) * pc.time_step), v.w);
+}

--- a/data/shaders/volume_diffuse_vector.comp
+++ b/data/shaders/volume_diffuse_vector.comp
@@ -1,0 +1,73 @@
+#version 460
+
+#include "include/volume_common.glsl"
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 4) in;
+
+layout(set = 0, binding = 0, std430) buffer Source {
+    vec4 source[];
+};
+layout(set = 0, binding = 1, std430) buffer TargetA {
+    vec4 target_a[];
+};
+layout(set = 0, binding = 2, std430) buffer TargetB {
+    vec4 target_b[];
+};
+
+layout(push_constant) uniform PC {
+    uint width;
+    uint height;
+    uint depth;
+    uint flags;
+    float cell_size_x;
+    float cell_size_y;
+    float cell_size_z;
+    float coefficient;
+} pc;
+
+vec4 fetch(uint index, uint parity)
+{
+    return parity == 0u ? target_a[index] : target_b[index];
+}
+
+void main()
+{
+    uvec3 gid = gl_GlobalInvocationID;
+    uvec3 dims = uvec3(pc.width, pc.height, pc.depth);
+
+    if (!volume_in_bounds(gid, dims)) {
+        return;
+    }
+
+    ivec3 c = ivec3(gid);
+    uint index = volume_index(gid, dims);
+
+    uint parity = pc.flags & 1u;
+    bool first = (pc.flags & 2u) != 0u;
+
+    vec4 x0 = first ? fetch(index, parity) : source[index];
+    if (first) {
+        source[index] = x0;
+    }
+
+    vec4 x_pos = fetch(volume_index_clamped(c + ivec3(1, 0, 0), dims), parity);
+    vec4 x_neg = fetch(volume_index_clamped(c - ivec3(1, 0, 0), dims), parity);
+    vec4 y_pos = fetch(volume_index_clamped(c + ivec3(0, 1, 0), dims), parity);
+    vec4 y_neg = fetch(volume_index_clamped(c - ivec3(0, 1, 0), dims), parity);
+    vec4 z_pos = fetch(volume_index_clamped(c + ivec3(0, 0, 1), dims), parity);
+    vec4 z_neg = fetch(volume_index_clamped(c - ivec3(0, 0, 1), dims), parity);
+
+    float ix2 = 1.0 / (pc.cell_size_x * pc.cell_size_x);
+    float iy2 = 1.0 / (pc.cell_size_y * pc.cell_size_y);
+    float iz2 = 1.0 / (pc.cell_size_z * pc.cell_size_z);
+
+    vec4 accumulated = ix2 * (x_pos + x_neg) + iy2 * (y_pos + y_neg) + iz2 * (z_pos + z_neg);
+    vec4 result = (x0 + pc.coefficient * accumulated)
+            / (1.0 + 2.0 * pc.coefficient * (ix2 + iy2 + iz2));
+
+    if (parity == 0u) {
+        target_b[index] = result;
+    } else {
+        target_a[index] = result;
+    }
+}

--- a/data/shaders/volume_divergence.comp
+++ b/data/shaders/volume_divergence.comp
@@ -1,0 +1,48 @@
+#version 460
+
+#include "include/volume_common.glsl"
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 4) in;
+
+layout(set = 0, binding = 0, std430) readonly buffer VelocityIn {
+    vec4 velocity_in[];
+};
+layout(set = 0, binding = 1, std430) writeonly buffer DivergenceOut {
+    float divergence_out[];
+};
+
+layout(push_constant) uniform PC {
+    uint width;
+    uint height;
+    uint depth;
+    uint pad0;
+    float cell_size_x;
+    float cell_size_y;
+    float cell_size_z;
+    float pad1;
+} pc;
+
+void main()
+{
+    uvec3 gid = gl_GlobalInvocationID;
+    uvec3 dims = uvec3(pc.width, pc.height, pc.depth);
+
+    if (!volume_in_bounds(gid, dims)) {
+        return;
+    }
+
+    ivec3 c = ivec3(gid);
+
+    vec3 x_pos = velocity_in[volume_index_clamped(c + ivec3(1, 0, 0), dims)].xyz;
+    vec3 x_neg = velocity_in[volume_index_clamped(c - ivec3(1, 0, 0), dims)].xyz;
+    vec3 y_pos = velocity_in[volume_index_clamped(c + ivec3(0, 1, 0), dims)].xyz;
+    vec3 y_neg = velocity_in[volume_index_clamped(c - ivec3(0, 1, 0), dims)].xyz;
+    vec3 z_pos = velocity_in[volume_index_clamped(c + ivec3(0, 0, 1), dims)].xyz;
+    vec3 z_neg = velocity_in[volume_index_clamped(c - ivec3(0, 0, 1), dims)].xyz;
+
+    float d = (x_pos.x - x_neg.x) / (2.0 * pc.cell_size_x)
+            + (y_pos.y - y_neg.y) / (2.0 * pc.cell_size_y)
+            + (z_pos.z - z_neg.z) / (2.0 * pc.cell_size_z);
+
+    divergence_out[volume_index(gid, dims)] = d;
+}

--- a/data/shaders/volume_influx_blob.comp
+++ b/data/shaders/volume_influx_blob.comp
@@ -1,0 +1,11 @@
+#version 460
+
+#include "include/volume_common.glsl"
+#include "include/volume_influx.glsl"
+
+float shape(vec3 p, float t)
+{
+    vec3 d = p - influx_center();
+    float r2 = dot(d, d) / max(pc.radius * pc.radius, 1e-8);
+    return exp(-r2 * max(pc.falloff, 1e-4));
+}

--- a/data/shaders/volume_influx_ring.comp
+++ b/data/shaders/volume_influx_ring.comp
@@ -1,0 +1,12 @@
+#version 460
+
+#include "include/volume_common.glsl"
+#include "include/volume_influx.glsl"
+
+float shape(vec3 p, float t)
+{
+    vec3 d = p - influx_center();
+    float radial = length(d.xz) - pc.radius;
+    float band = radial * radial + d.y * d.y;
+    return exp(-band / max(pc.radius * pc.radius * 0.25, 1e-8) * max(pc.falloff, 1e-4));
+}

--- a/data/shaders/volume_pressure_jacobi.comp
+++ b/data/shaders/volume_pressure_jacobi.comp
@@ -1,0 +1,64 @@
+#version 460
+
+#include "include/volume_common.glsl"
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 4) in;
+
+layout(set = 0, binding = 0, std430) readonly buffer DivergenceIn {
+    float divergence_in[];
+};
+layout(set = 0, binding = 1, std430) buffer PressureA {
+    float pressure_a[];
+};
+layout(set = 0, binding = 2, std430) buffer PressureB {
+    float pressure_b[];
+};
+
+layout(push_constant) uniform PC {
+    uint width;
+    uint height;
+    uint depth;
+    uint parity;
+    float cell_size_x;
+    float cell_size_y;
+    float cell_size_z;
+    float pad0;
+} pc;
+
+float read_pressure(uint i)
+{
+    return pc.parity == 0u ? pressure_a[i] : pressure_b[i];
+}
+
+void main()
+{
+    uvec3 gid = gl_GlobalInvocationID;
+    uvec3 dims = uvec3(pc.width, pc.height, pc.depth);
+
+    if (!volume_in_bounds(gid, dims)) {
+        return;
+    }
+
+    ivec3 c = ivec3(gid);
+    uint index = volume_index(gid, dims);
+
+    float ix2 = 1.0 / (pc.cell_size_x * pc.cell_size_x);
+    float iy2 = 1.0 / (pc.cell_size_y * pc.cell_size_y);
+    float iz2 = 1.0 / (pc.cell_size_z * pc.cell_size_z);
+
+    float sum = ix2 * (read_pressure(volume_index_clamped(c + ivec3(1, 0, 0), dims))
+                + read_pressure(volume_index_clamped(c - ivec3(1, 0, 0), dims)))
+            + iy2 * (read_pressure(volume_index_clamped(c + ivec3(0, 1, 0), dims))
+                    + read_pressure(volume_index_clamped(c - ivec3(0, 1, 0), dims)))
+            + iz2 * (read_pressure(volume_index_clamped(c + ivec3(0, 0, 1), dims))
+                    + read_pressure(volume_index_clamped(c - ivec3(0, 0, 1), dims)));
+
+    float denom = 2.0 * (ix2 + iy2 + iz2);
+    float result = (sum - divergence_in[index]) / denom;
+
+    if (pc.parity == 0u) {
+        pressure_b[index] = result;
+    } else {
+        pressure_a[index] = result;
+    }
+}

--- a/data/shaders/volume_raymarch.frag
+++ b/data/shaders/volume_raymarch.frag
@@ -1,0 +1,110 @@
+#version 460
+
+#extension GL_GOOGLE_include_directive : enable
+
+#include "include/volume_common.glsl"
+
+layout(location = 0) in vec3 frag_position;
+layout(location = 1) flat in vec3 eye;
+
+layout(set = 1, binding = 0, std430) readonly buffer VolumeField {
+    float field[];
+};
+
+layout(push_constant) uniform PC {
+    uint width;
+    uint height;
+    uint depth;
+    uint max_steps;
+    float bounds_min_x;
+    float bounds_min_y;
+    float bounds_min_z;
+    float step_scale;
+    float cell_size_x;
+    float cell_size_y;
+    float cell_size_z;
+    float density_scale;
+    float cool_r;
+    float cool_g;
+    float cool_b;
+    float absorption;
+    float hot_r;
+    float hot_g;
+    float hot_b;
+    float emission;
+    float threshold;
+    float pad0;
+    float pad1;
+    float pad2;
+} pc;
+
+layout(location = 0) out vec4 out_color;
+
+float sample_field(vec3 p, uvec3 dims)
+{
+    uint idx[8];
+    vec3 f;
+    volume_trilinear_setup(p, dims, idx, f);
+
+    float c[8];
+    for (int i = 0; i < 8; ++i) {
+        c[i] = field[idx[i]];
+    }
+
+    return volume_blend8(c, f);
+}
+
+void main()
+{
+    uvec3 dims = uvec3(pc.width, pc.height, pc.depth);
+    vec3 cell = vec3(pc.cell_size_x, pc.cell_size_y, pc.cell_size_z);
+    vec3 lo = vec3(pc.bounds_min_x, pc.bounds_min_y, pc.bounds_min_z);
+    vec3 hi = lo + vec3(dims) * cell;
+
+    vec3 direction = normalize(frag_position - eye);
+    vec3 inv_dir = 1.0 / direction;
+
+    vec3 t_lo = (lo - eye) * inv_dir;
+    vec3 t_hi = (hi - eye) * inv_dir;
+    vec3 t_near = min(t_lo, t_hi);
+    vec3 t_far = max(t_lo, t_hi);
+
+    float enter = max(max(t_near.x, t_near.y), max(t_near.z, 0.0));
+    float exit = min(min(t_far.x, t_far.y), t_far.z);
+
+    if (exit <= enter) {
+        discard;
+    }
+
+    float step_length = min(min(cell.x, cell.y), cell.z) * pc.step_scale;
+    float span = exit - enter;
+    uint steps = min(pc.max_steps, uint(span / step_length) + 1u);
+
+    vec3 accumulated = vec3(0.0);
+    float transmittance = 1.0;
+
+    vec3 cool = vec3(pc.cool_r, pc.cool_g, pc.cool_b);
+    vec3 hot = vec3(pc.hot_r, pc.hot_g, pc.hot_b);
+
+    for (uint i = 0u; i < steps; ++i) {
+        float t = enter + (float(i) + 0.5) * step_length;
+        vec3 world = eye + direction * t;
+        vec3 lattice = (world - lo) / cell;
+
+        float density = sample_field(lattice, dims) * pc.density_scale;
+
+        if (density > pc.threshold) {
+            float alpha = 1.0 - exp(-density * pc.absorption * step_length);
+            vec3 emitted = mix(cool, hot, clamp(density, 0.0, 1.0)) * pc.emission * density;
+
+            accumulated += transmittance * alpha * emitted;
+            transmittance *= 1.0 - alpha;
+
+            if (transmittance < 0.01) {
+                break;
+            }
+        }
+    }
+
+    out_color = vec4(accumulated, 1.0 - transmittance);
+}

--- a/data/shaders/volume_raymarch.vert
+++ b/data/shaders/volume_raymarch.vert
@@ -1,0 +1,23 @@
+#version 460
+
+layout(location = 0) in vec3 in_position;
+layout(location = 1) in vec3 in_color;
+layout(location = 2) in float in_weight;
+layout(location = 3) in vec2 in_uv;
+layout(location = 4) in vec3 in_normal;
+layout(location = 5) in vec3 in_tangent;
+
+layout(set = 0, binding = 0) uniform ViewTransformBlock {
+    mat4 view;
+    mat4 projection;
+} pc;
+
+layout(location = 0) out vec3 out_position;
+layout(location = 1) flat out vec3 out_eye;
+
+void main()
+{
+    gl_Position = pc.projection * pc.view * vec4(in_position, 1.0);
+    out_position = in_position;
+    out_eye = -transpose(mat3(pc.view)) * vec3(pc.view[3]);
+}

--- a/data/shaders/volume_solenoidal.comp
+++ b/data/shaders/volume_solenoidal.comp
@@ -1,0 +1,54 @@
+#version 460
+
+#include "include/volume_common.glsl"
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 4) in;
+
+layout(set = 0, binding = 0, std430) readonly buffer PressureIn {
+    float pressure_in[];
+};
+layout(set = 0, binding = 1, std430) readonly buffer VelocityIn {
+    vec4 velocity_in[];
+};
+layout(set = 0, binding = 2, std430) writeonly buffer VelocityOut {
+    vec4 velocity_out[];
+};
+
+layout(push_constant) uniform PC {
+    uint width;
+    uint height;
+    uint depth;
+    uint pad0;
+    float cell_size_x;
+    float cell_size_y;
+    float cell_size_z;
+    float pad1;
+} pc;
+
+void main()
+{
+    uvec3 gid = gl_GlobalInvocationID;
+    uvec3 dims = uvec3(pc.width, pc.height, pc.depth);
+
+    if (!volume_in_bounds(gid, dims)) {
+        return;
+    }
+
+    ivec3 c = ivec3(gid);
+    uint index = volume_index(gid, dims);
+
+    float x_pos = pressure_in[volume_index_clamped(c + ivec3(1, 0, 0), dims)];
+    float x_neg = pressure_in[volume_index_clamped(c - ivec3(1, 0, 0), dims)];
+    float y_pos = pressure_in[volume_index_clamped(c + ivec3(0, 1, 0), dims)];
+    float y_neg = pressure_in[volume_index_clamped(c - ivec3(0, 1, 0), dims)];
+    float z_pos = pressure_in[volume_index_clamped(c + ivec3(0, 0, 1), dims)];
+    float z_neg = pressure_in[volume_index_clamped(c - ivec3(0, 0, 1), dims)];
+
+    vec3 gradient = vec3(
+            (x_pos - x_neg) / (2.0 * pc.cell_size_x),
+            (y_pos - y_neg) / (2.0 * pc.cell_size_y),
+            (z_pos - z_neg) / (2.0 * pc.cell_size_z));
+
+    vec4 v = velocity_in[index];
+    velocity_out[index] = vec4(v.xyz - gradient, v.w);
+}

--- a/data/shaders/volume_to_sdf_grid.comp
+++ b/data/shaders/volume_to_sdf_grid.comp
@@ -1,0 +1,60 @@
+#version 460
+
+#include "include/volume_common.glsl"
+
+layout(local_size_x = 64) in;
+
+layout(set = 0, binding = 0, std430) readonly buffer FieldIn {
+    float field_in[];
+};
+layout(set = 0, binding = 1, std430) writeonly buffer GridOut {
+    float grid_out[];
+};
+
+layout(push_constant) uniform PC {
+    uint width;
+    uint height;
+    uint depth;
+    uint pad0;
+    uint res_x;
+    uint res_y;
+    uint res_z;
+    float threshold;
+} pc;
+
+void main()
+{
+    uint idx = gl_GlobalInvocationID.x;
+
+    uint nx = pc.res_x + 1u;
+    uint ny = pc.res_y + 1u;
+    uint total = nx * ny * (pc.res_z + 1u);
+
+    if (idx >= total) {
+        return;
+    }
+
+    uint cx = idx % nx;
+    uint cy = (idx / nx) % ny;
+    uint cz = idx / (nx * ny);
+
+    uvec3 dims = uvec3(pc.width, pc.height, pc.depth);
+
+    vec3 corner = vec3(
+            float(cx) / float(pc.res_x) * float(pc.width),
+            float(cy) / float(pc.res_y) * float(pc.height),
+            float(cz) / float(pc.res_z) * float(pc.depth));
+
+    corner = clamp(corner, vec3(0.5), vec3(dims) - 0.5);
+
+    uint samples[8];
+    vec3 f;
+    volume_trilinear_setup(corner, dims, samples, f);
+
+    float c[8];
+    for (int i = 0; i < 8; ++i) {
+        c[i] = field_in[samples[i]];
+    }
+
+    grid_out[idx] = pc.threshold - volume_blend8(c, f);
+}

--- a/data/shaders/volume_wall.comp
+++ b/data/shaders/volume_wall.comp
@@ -1,0 +1,48 @@
+#version 460
+
+#include "include/volume_common.glsl"
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 4) in;
+
+layout(set = 0, binding = 0, std430) readonly buffer VelocityIn {
+    vec4 velocity_in[];
+};
+layout(set = 0, binding = 1, std430) writeonly buffer VelocityOut {
+    vec4 velocity_out[];
+};
+
+layout(push_constant) uniform PC {
+    uint width;
+    uint height;
+    uint depth;
+    uint pad0;
+    float cell_size_x;
+    float cell_size_y;
+    float cell_size_z;
+    float pad1;
+} pc;
+
+void main()
+{
+    uvec3 gid = gl_GlobalInvocationID;
+    uvec3 dims = uvec3(pc.width, pc.height, pc.depth);
+
+    if (!volume_in_bounds(gid, dims)) {
+        return;
+    }
+
+    uint index = volume_index(gid, dims);
+    vec4 v = velocity_in[index];
+
+    if (gid.x == 0u || gid.x == dims.x - 1u) {
+        v.x = 0.0;
+    }
+    if (gid.y == 0u || gid.y == dims.y - 1u) {
+        v.y = 0.0;
+    }
+    if (gid.z == 0u || gid.z == dims.z - 1u) {
+        v.z = 0.0;
+    }
+
+    velocity_out[index] = v;
+}

--- a/src/MayaFlux/Buffers/Shaders/ComputeProcessor.cpp
+++ b/src/MayaFlux/Buffers/Shaders/ComputeProcessor.cpp
@@ -180,6 +180,33 @@ std::array<uint32_t, 3> ComputeProcessor::calculate_dispatch_size(const std::sha
     }
 }
 
+void ComputeProcessor::set_iteration_count(uint32_t count)
+{
+    m_dispatch_config.iteration_count = std::max(1U, count);
+}
+
+bool ComputeProcessor::on_iteration(
+    Portal::Graphics::CommandBufferID,
+    const std::shared_ptr<VKBuffer>&,
+    uint32_t)
+{
+    return true;
+}
+
+void ComputeProcessor::on_iteration_barrier(
+    Portal::Graphics::CommandBufferID cmd_id,
+    const std::shared_ptr<VKBuffer>& buffer,
+    uint32_t)
+{
+    Portal::Graphics::get_shader_foundry().buffer_barrier(
+        cmd_id,
+        buffer->get_buffer(),
+        vk::AccessFlagBits::eShaderWrite,
+        vk::AccessFlagBits::eShaderRead | vk::AccessFlagBits::eShaderWrite,
+        vk::PipelineStageFlagBits::eComputeShader,
+        vk::PipelineStageFlagBits::eComputeShader);
+}
+
 void ComputeProcessor::execute_shader(const std::shared_ptr<VKBuffer>& buffer)
 {
     if (m_pipeline_id == Portal::Graphics::INVALID_COMPUTE_PIPELINE || m_descriptor_set_ids.empty()) {
@@ -229,14 +256,45 @@ void ComputeProcessor::execute_shader(const std::shared_ptr<VKBuffer>& buffer)
 
     on_before_execute(cmd_id, buffer);
 
-    const auto push_data = resolve_push_constants(buffer);
-    if (!push_data.empty()) {
-        compute_press.push_constants(
-            cmd_id, m_pipeline_id, push_data.data(), push_data.size());
-    }
+    const uint32_t iterations = std::max(1U, m_dispatch_config.iteration_count);
+    const auto dispatch_size = calculate_dispatch_size(buffer);
 
-    auto dispatch_size = calculate_dispatch_size(buffer);
-    compute_press.dispatch(cmd_id, dispatch_size[0], dispatch_size[1], dispatch_size[2]);
+    for (uint32_t i = 0; i < iterations; ++i) {
+        if (!on_iteration(cmd_id, buffer, i)) {
+            continue;
+        }
+
+        const auto& pc_bindings = buffer->get_pipeline_context().push_constant_bindings;
+
+        if (!pc_bindings.empty()) {
+            size_t required = 0;
+            for (const auto& pc : pc_bindings) {
+                required = std::max(required, static_cast<size_t>(pc.offset) + pc.data.size());
+            }
+
+            m_push_constant_scratch.assign(required, 0);
+
+            for (const auto& pc : pc_bindings) {
+                std::memcpy(m_push_constant_scratch.data() + pc.offset, pc.data.data(), pc.data.size());
+            }
+
+            compute_press.push_constants(
+                cmd_id, m_pipeline_id,
+                m_push_constant_scratch.data(),
+                m_push_constant_scratch.size());
+        } else if (!m_push_constant_data.empty()) {
+            compute_press.push_constants(
+                cmd_id, m_pipeline_id,
+                m_push_constant_data.data(),
+                m_push_constant_data.size());
+        }
+
+        compute_press.dispatch(cmd_id, dispatch_size[0], dispatch_size[1], dispatch_size[2]);
+
+        if (i + 1 < iterations) {
+            on_iteration_barrier(cmd_id, buffer, i);
+        }
+    }
 
     on_after_execute(cmd_id, buffer);
 
@@ -248,7 +306,7 @@ void ComputeProcessor::execute_shader(const std::shared_ptr<VKBuffer>& buffer)
         vk::PipelineStageFlagBits::eComputeShader,
         vk::PipelineStageFlagBits::eComputeShader | vk::PipelineStageFlagBits::eTransfer);
 
-    foundry.submit_and_wait(cmd_id);
+    submit_recorded(cmd_id, buffer);
 }
 
 void ComputeProcessor::cleanup()

--- a/src/MayaFlux/Buffers/Shaders/ComputeProcessor.hpp
+++ b/src/MayaFlux/Buffers/Shaders/ComputeProcessor.hpp
@@ -24,6 +24,7 @@ struct ShaderDispatchConfig {
     uint32_t group_count_x = 1;
     uint32_t group_count_y = 1;
     uint32_t group_count_z = 1;
+    uint32_t iteration_count = 1; ///< Dispatches recorded per execute cycle.
 
     std::function<std::array<uint32_t, 3>(const std::shared_ptr<VKBuffer>&)> custom_calculator;
 
@@ -137,6 +138,20 @@ public:
     void set_custom_dispatch(std::function<std::array<uint32_t, 3>(const std::shared_ptr<VKBuffer>&)> calculator);
 
     /**
+     * @brief Set how many dispatches are recorded per execute cycle.
+     * @param count Dispatch count. Values below 1 are clamped to 1.
+     *
+     * All iterations record into one command buffer and submit once.
+     * on_iteration runs before each; on_iteration_barrier runs between
+     * consecutive iterations. At the default of 1 the recorded command
+     * stream is identical to a single-dispatch cycle.
+     */
+    void set_iteration_count(uint32_t count);
+
+    /** @brief Dispatches recorded per execute cycle. */
+    [[nodiscard]] uint32_t get_iteration_count() const { return m_dispatch_config.iteration_count; }
+
+    /**
      * @brief Get current dispatch configuration
      */
     [[nodiscard]] const ShaderDispatchConfig& get_dispatch_config() const { return m_dispatch_config; }
@@ -157,6 +172,37 @@ protected:
      */
     virtual std::array<uint32_t, 3> calculate_dispatch_size(const std::shared_ptr<VKBuffer>& buffer);
 
+    /**
+     * @brief Called before each iteration's push constants and dispatch.
+     * @param cmd_id Command buffer being recorded into.
+     * @param buffer Buffer under processing.
+     * @param index Zero-based iteration index.
+     * @return False to skip this iteration's dispatch.
+     *
+     * The place to rewrite descriptor bindings for ping-pong resources and
+     * to update m_push_constant_data, since push constants are re-pushed
+     * after every successful return.
+     */
+    virtual bool on_iteration(
+        Portal::Graphics::CommandBufferID cmd_id,
+        const std::shared_ptr<VKBuffer>& buffer,
+        uint32_t index);
+
+    /**
+     * @brief Called after each iteration except the last.
+     * @param cmd_id Command buffer being recorded into.
+     * @param buffer Buffer under processing.
+     * @param index Zero-based index of the iteration just recorded.
+     *
+     * Default issues a compute-to-compute buffer_barrier on the attached
+     * buffer's own handle. Override when the hazard is on resources the
+     * attached buffer does not own, such as raw double-buffered state.
+     */
+    virtual void on_iteration_barrier(
+        Portal::Graphics::CommandBufferID cmd_id,
+        const std::shared_ptr<VKBuffer>& buffer,
+        uint32_t index);
+
     void initialize_pipeline(const std::shared_ptr<VKBuffer>& buffer) override;
 
     void initialize_descriptors(const std::shared_ptr<VKBuffer>& buffer) override;
@@ -165,6 +211,8 @@ protected:
 
 private:
     ShaderDispatchConfig m_dispatch_config;
+
+    std::vector<uint8_t> m_push_constant_scratch; ///< Coalesced push constant bindings, reused across iterations.
 
     void execute_shader(const std::shared_ptr<VKBuffer>& buffer) override;
 

--- a/src/MayaFlux/Buffers/Shaders/RenderProcessor.cpp
+++ b/src/MayaFlux/Buffers/Shaders/RenderProcessor.cpp
@@ -110,28 +110,36 @@ void RenderProcessor::enable_depth_test(Portal::Graphics::CompareOp compare_op)
     m_needs_pipeline_rebuild = true;
 }
 
-void RenderProcessor::set_view_transform(const Kinesis::ViewTransform& vt)
+void RenderProcessor::set_view_transform(
+    const Kinesis::ViewTransform& vt,
+    bool enable_depth,
+    Portal::Graphics::CullMode cull)
 {
     m_view_transform = vt;
     m_view_transform_source = nullptr;
     m_view_transform_active = true;
 
-    if (!m_depth_enabled) {
+    if (enable_depth && !m_depth_enabled) {
         enable_depth_test();
     }
-    m_cull_mode = Portal::Graphics::CullMode::BACK;
+
+    set_cull_mode(cull);
 }
 
-void RenderProcessor::set_view_transform_source(std::function<Kinesis::ViewTransform()> fn)
+void RenderProcessor::set_view_transform_source(
+    std::function<Kinesis::ViewTransform()> fn,
+    bool enable_depth,
+    Portal::Graphics::CullMode cull)
 {
     m_view_transform_source = std::move(fn);
     m_view_transform.reset();
     m_view_transform_active = true;
 
-    if (!m_depth_enabled) {
+    if (enable_depth && !m_depth_enabled) {
         enable_depth_test();
     }
-    m_cull_mode = Portal::Graphics::CullMode::BACK;
+
+    set_cull_mode(cull);
 }
 
 void RenderProcessor::bind_texture(

--- a/src/MayaFlux/Buffers/Shaders/RenderProcessor.hpp
+++ b/src/MayaFlux/Buffers/Shaders/RenderProcessor.hpp
@@ -161,20 +161,29 @@ public:
     /**
      * @brief Set static view transform (evaluated once)
      * @param vt View and projection matrices
-     *
-     * Automatically enables depth testing and configures push
-     * constant size for the 128-byte ViewTransform block.
+     * @param enable_depth Enable the depth test if it is not already on.
+     *        False leaves depth state untouched, which is what volume
+     *        proxy geometry wants: a box that writes depth occludes every
+     *        later volume drawn at the same geometry.
+     * @param cull Face culling mode. BACK suits opaque geometry. Volume
+     *        rendering rasterises back faces so the entry clip works from
+     *        inside the bounds.
      */
-    void set_view_transform(const Kinesis::ViewTransform& vt);
+    void set_view_transform(
+        const Kinesis::ViewTransform& vt,
+        bool enable_depth = true,
+        Portal::Graphics::CullMode cull = Portal::Graphics::CullMode::BACK);
 
     /**
      * @brief Set dynamic view transform source (evaluated every frame)
      * @param fn Callable returning ViewTransform, invoked each execute_shader
-     *
-     * Automatically enables depth testing and configures push
-     * constant size for the 128-byte ViewTransform block.
+     * @param enable_depth Enable the depth test if it is not already on.
+     * @param cull Face culling mode.
      */
-    void set_view_transform_source(std::function<Kinesis::ViewTransform()> fn);
+    void set_view_transform_source(
+        std::function<Kinesis::ViewTransform()> fn,
+        bool enable_depth = true,
+        Portal::Graphics::CullMode cull = Portal::Graphics::CullMode::BACK);
 
     /** @brief Get current static view transform, if set */
     const std::optional<Kinesis::ViewTransform>& get_view_transform() const { return m_view_transform; }

--- a/src/MayaFlux/Buffers/Shaders/SDFMeshProcessor.cpp
+++ b/src/MayaFlux/Buffers/Shaders/SDFMeshProcessor.cpp
@@ -109,9 +109,9 @@ void SDFMeshProcessor::set_iso_level(float iso_level)
     m_dirty = true;
 }
 
-void SDFMeshProcessor::set_normal_coloring(bool enabled)
+void SDFMeshProcessor::set_axis_palette(const glm::vec3& x, const glm::vec3& y, const glm::vec3& z)
 {
-    m_normal_coloring = enabled;
+    m_palette = { x, y, z };
     m_dirty = true;
 }
 
@@ -182,7 +182,12 @@ bool SDFMeshProcessor::on_before_execute(
         .res_x = m_res_x,
         .res_y = m_res_y,
         .res_z = m_res_z,
-        .color_mode = m_normal_coloring ? 1U : 0U,
+        ._pad = 0,
+        .palette = {
+            glm::vec4(m_palette[0], 1.0F),
+            glm::vec4(m_palette[1], 1.0F),
+            glm::vec4(m_palette[2], 1.0F),
+        },
     };
     set_push_constant_data(pc);
 

--- a/src/MayaFlux/Buffers/Shaders/SDFMeshProcessor.cpp
+++ b/src/MayaFlux/Buffers/Shaders/SDFMeshProcessor.cpp
@@ -109,6 +109,12 @@ void SDFMeshProcessor::set_iso_level(float iso_level)
     m_dirty = true;
 }
 
+void SDFMeshProcessor::set_normal_coloring(bool enabled)
+{
+    m_normal_coloring = enabled;
+    m_dirty = true;
+}
+
 // ============================================================================
 // ShaderProcessor hooks
 // ============================================================================
@@ -176,6 +182,7 @@ bool SDFMeshProcessor::on_before_execute(
         .res_x = m_res_x,
         .res_y = m_res_y,
         .res_z = m_res_z,
+        .color_mode = m_normal_coloring ? 1U : 0U,
     };
     set_push_constant_data(pc);
 

--- a/src/MayaFlux/Buffers/Shaders/SDFMeshProcessor.hpp
+++ b/src/MayaFlux/Buffers/Shaders/SDFMeshProcessor.hpp
@@ -100,17 +100,20 @@ public:
     [[nodiscard]] bool is_dirty() const { return m_dirty; }
 
     /**
-     * @brief Write the surface normal into the vertex color slot.
-     * @param enabled True to color by normal, false for flat white.
+     * @brief Color each triangle by the dominant axis of its surface normal.
+     * @param x Color for surfaces facing along X.
+     * @param y Color for surfaces facing along Y.
+     * @param z Color for surfaces facing along Z.
      *
-     * Coloring by normal makes the surface readable with an unlit fragment
-     * shader, since the geometry's shape is otherwise invisible against a
-     * uniform white. Takes effect next cycle.
+     * Selection is a hard choice rather than a blend, so the surface
+     * resolves into flat regions that switch as the geometry turns.
+     * Three identical colors give a flat surface, which is what the
+     * default reproduces. Takes effect next cycle.
      */
-    void set_normal_coloring(bool enabled);
+    void set_axis_palette(const glm::vec3& x, const glm::vec3& y, const glm::vec3& z);
 
-    /** @brief Whether vertices are colored by surface normal. */
-    [[nodiscard]] bool is_normal_coloring() const { return m_normal_coloring; }
+    /** @brief The three axis colors currently written into vertex color. */
+    [[nodiscard]] const std::array<glm::vec3, 3>& get_axis_palette() const { return m_palette; }
 
 protected:
     void on_attach(const std::shared_ptr<Buffer>& buffer) override;
@@ -132,7 +135,7 @@ private:
     float m_iso_level;
     bool m_dirty { true };
     bool m_owns_buffers { true }; ///< false in GPU-field mode; buffers owned by SdfPrepProcessor.
-    bool m_normal_coloring {}; ///< False preserves the flat white mc_emit has always written.
+    std::array<glm::vec3, 3> m_palette { glm::vec3(1.0F), glm::vec3(1.0F), glm::vec3(1.0F) };
 
     std::shared_ptr<VKBuffer> m_grid_buf;
     std::shared_ptr<VKBuffer> m_edge_buf;
@@ -146,8 +149,8 @@ private:
         uint32_t res_x;
         uint32_t res_y;
         uint32_t res_z;
-        uint32_t color_mode {}; ///< Zero writes white, non-zero writes the surface normal.
         uint32_t _pad {};
+        alignas(16) glm::vec4 palette[3] {}; ///< Axis-selected vertex colors, X then Y then Z.
     };
     static_assert(sizeof(McPC) % 16 == 0);
 

--- a/src/MayaFlux/Buffers/Shaders/SDFMeshProcessor.hpp
+++ b/src/MayaFlux/Buffers/Shaders/SDFMeshProcessor.hpp
@@ -99,6 +99,19 @@ public:
 
     [[nodiscard]] bool is_dirty() const { return m_dirty; }
 
+    /**
+     * @brief Write the surface normal into the vertex color slot.
+     * @param enabled True to color by normal, false for flat white.
+     *
+     * Coloring by normal makes the surface readable with an unlit fragment
+     * shader, since the geometry's shape is otherwise invisible against a
+     * uniform white. Takes effect next cycle.
+     */
+    void set_normal_coloring(bool enabled);
+
+    /** @brief Whether vertices are colored by surface normal. */
+    [[nodiscard]] bool is_normal_coloring() const { return m_normal_coloring; }
+
 protected:
     void on_attach(const std::shared_ptr<Buffer>& buffer) override;
     void on_descriptors_created() override;
@@ -119,6 +132,7 @@ private:
     float m_iso_level;
     bool m_dirty { true };
     bool m_owns_buffers { true }; ///< false in GPU-field mode; buffers owned by SdfPrepProcessor.
+    bool m_normal_coloring {}; ///< False preserves the flat white mc_emit has always written.
 
     std::shared_ptr<VKBuffer> m_grid_buf;
     std::shared_ptr<VKBuffer> m_edge_buf;
@@ -132,7 +146,8 @@ private:
         uint32_t res_x;
         uint32_t res_y;
         uint32_t res_z;
-        uint32_t _pad[2] {};
+        uint32_t color_mode {}; ///< Zero writes white, non-zero writes the surface normal.
+        uint32_t _pad {};
     };
     static_assert(sizeof(McPC) % 16 == 0);
 

--- a/src/MayaFlux/Buffers/Shaders/ShaderProcessor.cpp
+++ b/src/MayaFlux/Buffers/Shaders/ShaderProcessor.cpp
@@ -40,6 +40,13 @@ void ShaderProcessor::processing_function(const std::shared_ptr<Buffer>& buffer)
         return;
     }
 
+    if (m_deferred_submission) {
+        resolve_pending_dispatch(false);
+        if (is_dispatch_pending()) {
+            return;
+        }
+    }
+
     if (!on_before_execute(m_last_command_buffer, vk_buffer)) {
         MF_RT_DEBUG(Journal::Component::Buffers, Journal::Context::BufferProcessing,
             "on_before_execute() reported failure, skipping shader execution");
@@ -278,6 +285,66 @@ std::vector<uint8_t> ShaderProcessor::resolve_push_constants(const std::shared_p
 }
 
 //==============================================================================
+// Submission
+//==============================================================================
+
+void ShaderProcessor::set_deferred_submission(bool deferred)
+{
+    if (!deferred && is_dispatch_pending()) {
+        resolve_pending_dispatch(true);
+    }
+    m_deferred_submission = deferred;
+}
+
+bool ShaderProcessor::resolve_pending_dispatch(bool block)
+{
+    if (!is_dispatch_pending()) {
+        return false;
+    }
+
+    auto& foundry = Portal::Graphics::get_shader_foundry();
+
+    if (block) {
+        foundry.wait_for_fence(m_pending_fence);
+    } else if (!foundry.is_fence_signaled(m_pending_fence)) {
+        return false;
+    }
+
+    const auto fence = m_pending_fence;
+    auto buffer = m_pending_buffer;
+
+    m_pending_fence = Portal::Graphics::INVALID_FENCE;
+    m_pending_buffer.reset();
+
+    on_dispatch_complete(buffer);
+    foundry.release_fence(fence);
+
+    return true;
+}
+
+void ShaderProcessor::submit_recorded(
+    Portal::Graphics::CommandBufferID cmd_id,
+    const std::shared_ptr<VKBuffer>& buffer)
+{
+    auto& foundry = Portal::Graphics::get_shader_foundry();
+
+    if (!m_deferred_submission) {
+        foundry.submit_and_wait(cmd_id);
+        return;
+    }
+
+    m_pending_fence = foundry.submit_async(cmd_id);
+
+    if (m_pending_fence == Portal::Graphics::INVALID_FENCE) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "Deferred submission failed, no fence returned");
+        return;
+    }
+
+    m_pending_buffer = buffer;
+}
+
+//==============================================================================
 // Specialization Constants
 //==============================================================================
 
@@ -365,6 +432,7 @@ void ShaderProcessor::on_before_descriptors_create() { }
 void ShaderProcessor::on_descriptors_created() { }
 bool ShaderProcessor::on_before_execute(Portal::Graphics::CommandBufferID, const std::shared_ptr<VKBuffer>&) { return true; }
 void ShaderProcessor::on_after_execute(Portal::Graphics::CommandBufferID, const std::shared_ptr<VKBuffer>&) { }
+void ShaderProcessor::on_dispatch_complete(const std::shared_ptr<VKBuffer>&) { }
 
 //==============================================================================
 // Private Implementation
@@ -474,6 +542,7 @@ void ShaderProcessor::update_descriptors(const std::shared_ptr<VKBuffer>& buffer
 
 void ShaderProcessor::cleanup()
 {
+    resolve_pending_dispatch(true);
     auto& foundry = Portal::Graphics::get_shader_foundry();
     auto& compute_press = Portal::Graphics::get_compute_press();
 

--- a/src/MayaFlux/Buffers/Shaders/ShaderProcessor.cpp
+++ b/src/MayaFlux/Buffers/Shaders/ShaderProcessor.cpp
@@ -1,5 +1,7 @@
 #include "ShaderProcessor.hpp"
 
+#include "MayaFlux/Kakshya/NDData/DataAccess.hpp"
+
 namespace MayaFlux::Buffers {
 
 //==============================================================================
@@ -38,6 +40,10 @@ void ShaderProcessor::processing_function(const std::shared_ptr<Buffer>& buffer)
         MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
             "ShaderProcessor can only process VKBuffers");
         return;
+    }
+
+    if (!m_feeds.empty()) {
+        pump_feeds();
     }
 
     if (m_deferred_submission) {
@@ -197,6 +203,184 @@ bool ShaderProcessor::download_bound(
 
     download_from_gpu(buffer, data, size, staging);
     return true;
+}
+
+//==============================================================================
+// Feeds
+//==============================================================================
+
+void ShaderProcessor::feed(const std::string& name, FeedSource source)
+{
+    if (!source) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "feed: null source for '{}'", name);
+        return;
+    }
+
+    if (m_config.bindings.contains(name)) {
+        auto& entry = m_feeds[name];
+        entry.source = std::move(source);
+        entry.is_storage = true;
+        entry.offset = 0;
+        entry.size = 0;
+        entry.descriptor_name = name;
+        entry.buffer.reset();
+        entry.mismatch_logged = false;
+        return;
+    }
+
+    uint32_t offset = 0;
+    for (const auto& field : m_config.pc_fields) {
+        const size_t width = Kakshya::gpu_data_format_bytes(field.format);
+        if (field.name == name) {
+            auto& entry = m_feeds[name];
+            entry.source = std::move(source);
+            entry.is_storage = false;
+            entry.offset = offset;
+            entry.size = width;
+            entry.descriptor_name.clear();
+            entry.buffer.reset();
+            entry.mismatch_logged = false;
+            return;
+        }
+        offset += static_cast<uint32_t>(width);
+    }
+
+    MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+        "feed: '{}' matches no descriptor and no push constant field. "
+        "File-shader processors must supply an explicit offset.",
+        name);
+}
+
+void ShaderProcessor::feed(const std::string& name, FeedSource source, uint32_t offset, size_t size)
+{
+    if (!source) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "feed: null source for '{}'", name);
+        return;
+    }
+
+    if (size != sizeof(float) && size != sizeof(double)) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "feed: '{}' requests {} bytes, only 4 or 8 are written", name, size);
+        return;
+    }
+
+    auto& entry = m_feeds[name];
+    entry.source = std::move(source);
+    entry.is_storage = false;
+    entry.offset = offset;
+    entry.size = size;
+    entry.descriptor_name.clear();
+    entry.buffer.reset();
+    entry.mismatch_logged = false;
+}
+
+void ShaderProcessor::remove_feed(const std::string& name)
+{
+    auto it = m_feeds.find(name);
+    if (it == m_feeds.end()) {
+        return;
+    }
+
+    if (it->second.is_storage) {
+        unbind_buffer(it->second.descriptor_name);
+    }
+
+    m_feeds.erase(it);
+}
+
+bool ShaderProcessor::has_feed(const std::string& name) const
+{
+    return m_feeds.contains(name);
+}
+
+std::vector<std::string> ShaderProcessor::get_feed_names() const
+{
+    std::vector<std::string> names;
+    names.reserve(m_feeds.size());
+    for (const auto& [name, _] : m_feeds) {
+        names.push_back(name);
+    }
+    return names;
+}
+
+void ShaderProcessor::pump_feeds()
+{
+    for (auto& [name, entry] : m_feeds) {
+        FeedValue value = entry.source();
+
+        if (!entry.is_storage) {
+            const auto* scalar = std::get_if<double>(&value);
+            if (!scalar) {
+                if (!entry.mismatch_logged) {
+                    MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+                        "feed '{}' writes a push constant but returned a DataVariant", name);
+                    entry.mismatch_logged = true;
+                }
+                continue;
+            }
+
+            auto& data = get_push_constant_data();
+            const size_t required = entry.offset + entry.size;
+            if (data.size() < required) {
+                data.resize(required);
+            }
+
+            if (entry.size == sizeof(float)) {
+                const auto narrowed = static_cast<float>(*scalar);
+                std::memcpy(data.data() + entry.offset, &narrowed, sizeof(float));
+            } else {
+                std::memcpy(data.data() + entry.offset, scalar, sizeof(double));
+            }
+            continue;
+        }
+
+        auto* variant = std::get_if<Kakshya::DataVariant>(&value);
+        if (!variant) {
+            if (!entry.mismatch_logged) {
+                MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+                    "feed '{}' writes a storage descriptor but returned a double", name);
+                entry.mismatch_logged = true;
+            }
+            continue;
+        }
+
+        Kakshya::DataAccess accessor(*variant, {}, Kakshya::DataModality::UNKNOWN);
+        auto [ptr, bytes, format] = accessor.gpu_buffer();
+
+        if (!ptr || bytes == 0) {
+            MF_RT_WARN(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+                "feed '{}' produced no bytes", name);
+            continue;
+        }
+
+        if (!entry.buffer) {
+            entry.buffer = std::make_shared<VKBuffer>(
+                static_cast<size_t>(static_cast<float>(bytes) * 1.5F),
+                m_config.bindings.at(entry.descriptor_name).type == vk::DescriptorType::eUniformBuffer
+                    ? VKBuffer::Usage::UNIFORM
+                    : VKBuffer::Usage::HOST_STORAGE,
+                Kakshya::DataModality::UNKNOWN);
+
+            bind_buffer(entry.descriptor_name, entry.buffer);
+
+            MF_DEBUG(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+                "feed '{}' backing buffer created at {} bytes",
+                name, entry.buffer->get_size_bytes());
+        } else if (entry.buffer->get_size_bytes() < bytes) {
+            const size_t grown = bytes * 3 / 2;
+
+            MF_DEBUG(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+                "feed '{}' backing buffer resized {} to {} bytes",
+                name, entry.buffer->get_size_bytes(), grown);
+
+            entry.buffer->resize(grown, false);
+            m_needs_descriptor_rebuild = true;
+        }
+
+        upload_host_visible(entry.buffer, *variant);
+    }
 }
 
 //==============================================================================
@@ -553,6 +737,7 @@ void ShaderProcessor::cleanup()
 
     m_descriptor_set_ids.clear();
     m_bound_buffers.clear();
+    m_feeds.clear();
     m_initialized = false;
 }
 

--- a/src/MayaFlux/Buffers/Shaders/ShaderProcessor.hpp
+++ b/src/MayaFlux/Buffers/Shaders/ShaderProcessor.hpp
@@ -397,6 +397,38 @@ public:
     [[nodiscard]] virtual std::shared_ptr<VKBuffer> get_output_buffer() const { return m_last_processed_buffer; }
 
     /**
+     * @brief Submit asynchronously and resolve at the top of a later cycle.
+     * @param deferred True to submit via submit_async, false for submit_and_wait.
+     *
+     * Only meaningful for children that submit their own command buffers.
+     * Children that record without submitting, such as RenderProcessor,
+     * are unaffected. Switching back to synchronous while a submission is
+     * outstanding waits for and releases it first.
+     */
+    void set_deferred_submission(bool deferred);
+
+    /** @brief Whether this processor submits asynchronously. */
+    [[nodiscard]] bool is_deferred_submission() const { return m_deferred_submission; }
+
+    /** @brief True while an asynchronous submission is outstanding. */
+    [[nodiscard]] bool is_dispatch_pending() const
+    {
+        return m_pending_fence != Portal::Graphics::INVALID_FENCE;
+    }
+
+    /**
+     * @brief Resolve an outstanding asynchronous submission.
+     * @param block True to wait for the fence, false to return immediately
+     *        when it is not yet signaled.
+     * @return True if a submission was resolved by this call.
+     *
+     * On resolution invokes on_dispatch_complete, then release_fence, which
+     * also frees the associated command buffer. Invoked with block=false at
+     * the top of processing_function and with block=true from cleanup.
+     */
+    bool resolve_pending_dispatch(bool block);
+
+    /**
      * @brief Check if compute has been executed at least once
      * @return True if processing_function() has been called
      */
@@ -488,6 +520,29 @@ protected:
     virtual void on_after_execute(Portal::Graphics::CommandBufferID cmd_id, const std::shared_ptr<VKBuffer>& buffer);
 
     /**
+     * @brief Called once when an asynchronous submission is observed complete.
+     * @param buffer Buffer processed by the completed submission.
+     *
+     * The correct place for device-to-host readback under deferred
+     * submission, since on_after_execute runs at record time, before the
+     * GPU has executed anything. Never invoked under synchronous
+     * submission, where submit_and_wait already precedes the return.
+     */
+    virtual void on_dispatch_complete(const std::shared_ptr<VKBuffer>& buffer);
+
+    /**
+     * @brief Submit a recorded command buffer honoring the submission mode.
+     * @param cmd_id Command buffer to submit.
+     * @param buffer Buffer being processed. Retained until resolution when
+     *        deferred, so on_dispatch_complete receives the same instance.
+     *
+     * Synchronous submission calls submit_and_wait and returns. Deferred
+     * submission calls submit_async and stores the fence; a failed
+     * submission falls back to leaving nothing pending.
+     */
+    void submit_recorded(Portal::Graphics::CommandBufferID cmd_id, const std::shared_ptr<VKBuffer>& buffer);
+
+    /**
      * @brief Resolve logical descriptor set index to actual index
      * @param set Logical set index from ShaderBinding
      * @return Resolved set index, or std::nullopt if invalid
@@ -510,6 +565,10 @@ protected:
 
     std::unordered_map<std::string, std::shared_ptr<VKBuffer>> m_bound_buffers;
     std::shared_ptr<VKBuffer> m_last_processed_buffer;
+
+    bool m_deferred_submission {}; ///< False submits synchronously, preserving pre-existing behaviour.
+    Portal::Graphics::FenceID m_pending_fence { Portal::Graphics::INVALID_FENCE }; ///< Outstanding async submission, if any.
+    std::shared_ptr<VKBuffer> m_pending_buffer; ///< Buffer retained for the outstanding submission.
 
     std::vector<uint8_t> m_push_constant_data;
 

--- a/src/MayaFlux/Buffers/Shaders/ShaderProcessor.hpp
+++ b/src/MayaFlux/Buffers/Shaders/ShaderProcessor.hpp
@@ -55,6 +55,8 @@ struct ShaderConfig {
 
     size_t push_constant_size = 0;
 
+    std::vector<Portal::Graphics::PushConstantField> pc_fields; ///< Retained from a ShaderSpec so feeds can resolve a field name to an offset. Empty for file shaders.
+
     std::unordered_map<uint32_t, uint32_t> specialization_constants;
 
     ShaderConfig() = default;
@@ -65,6 +67,7 @@ struct ShaderConfig {
     ShaderConfig(const Portal::Graphics::ShaderSpec& spec)
         : shader_id(Portal::Graphics::get_shader_foundry().load_shader(spec))
         , push_constant_size(spec.push_constant_bytes)
+        , pc_fields(spec.pc_fields)
     {
     }
 };
@@ -216,6 +219,60 @@ public:
         download_from_gpu(buffer, data);
         return true;
     }
+
+    //==========================================================================
+    // Feeds
+    //==========================================================================
+
+    /**
+     * @brief What a feed callable returns.
+     *
+     * A double lands in the push constant block. A DataVariant lands in a
+     * storage descriptor. Which one an entry expects is fixed when it is
+     * registered by the name it resolves to.
+     */
+    using FeedValue = std::variant<double, Kakshya::DataVariant>;
+
+    /** @brief A callable pulled once per processing cycle. */
+    using FeedSource = std::function<FeedValue()>;
+
+    /**
+     * @brief Supply a shader input from a callable, resolved by name.
+     * @param name A name already declared on this shader: a descriptor in
+     *        config.bindings, or a push constant field from the ShaderSpec
+     *        this processor was constructed from.
+     * @param source Callable pulled each cycle. Returns a DataVariant for a
+     *        descriptor name, a double for a push constant field.
+     *
+     * Resolution happens once, here. Descriptor names take precedence; a
+     * name matching neither is an error and registers nothing. File-shader
+     * processors have no record of push constant field names, so their
+     * constant feeds must use the explicit overload.
+     */
+    void feed(const std::string& name, FeedSource source);
+
+    /**
+     * @brief Supply a push constant from a callable at an explicit offset.
+     * @param name Logical name, used for removal and error reporting. Need
+     *        not match anything on the shader.
+     * @param source Callable returning a double.
+     * @param offset Byte offset in the push constant block.
+     * @param size Byte width written. Four narrows to float, eight keeps
+     *        double. Other values are rejected.
+     *
+     * The form hand-written shaders need, since their push constant block
+     * is described nowhere the processor can read.
+     */
+    void feed(const std::string& name, FeedSource source, uint32_t offset, size_t size = sizeof(float));
+
+    /** @brief Remove a feed. Any buffer it created is released. */
+    void remove_feed(const std::string& name);
+
+    /** @brief Whether a feed of this name is registered. */
+    [[nodiscard]] bool has_feed(const std::string& name) const;
+
+    /** @brief Names of every registered feed. */
+    [[nodiscard]] std::vector<std::string> get_feed_names() const;
 
     //==========================================================================
     // Shader Management
@@ -450,6 +507,15 @@ protected:
      */
     [[nodiscard]] std::vector<uint8_t> resolve_push_constants(const std::shared_ptr<VKBuffer>& buffer) const;
 
+    /**
+     * @brief Pull every feed and write its result.
+     *
+     * Called at the top of processing_function, before descriptors are
+     * rebuilt, so a storage feed creating its buffer binds the same cycle.
+     * Callables run on whichever thread drives the chain.
+     */
+    void pump_feeds();
+
     //==========================================================================
     // Overridable Hooks for Specialized Processors
     //==========================================================================
@@ -603,6 +669,22 @@ private:
     //==========================================================================
     // Internal Implementation
     //==========================================================================
+
+    /**
+     * @struct Feed
+     * @brief One registered callable and where its result is written.
+     */
+    struct Feed {
+        FeedSource source;
+        bool is_storage {};
+        uint32_t offset {};
+        size_t size {};
+        std::string descriptor_name;
+        std::shared_ptr<VKBuffer> buffer;
+        bool mismatch_logged {};
+    };
+
+    std::unordered_map<std::string, Feed> m_feeds;
 
     void initialize_shader();
 };

--- a/src/MayaFlux/Buffers/Shaders/UVFieldProcessor.cpp
+++ b/src/MayaFlux/Buffers/Shaders/UVFieldProcessor.cpp
@@ -4,6 +4,7 @@
 
 #include "MayaFlux/Buffers/VKBuffer.hpp"
 #include "MayaFlux/Journal/Archivist.hpp"
+#include "MayaFlux/Kakshya/NDData/VertexFormats.hpp"
 #include "MayaFlux/Portal/Graphics/ShaderFoundry.hpp"
 
 namespace MayaFlux::Buffers {
@@ -134,7 +135,7 @@ bool UVFieldProcessor::on_before_execute(
         return false;
     }
 
-    m_pc.vertex_count = static_cast<uint32_t>(buffer->get_size_bytes() / 60U);
+    m_pc.vertex_count = static_cast<uint32_t>(buffer->get_size_bytes() / sizeof(Kakshya::MeshVertex));
     if (m_pc.vertex_count == 0) {
         return false;
     }

--- a/src/MayaFlux/Buffers/Shaders/UVFieldProcessor.hpp
+++ b/src/MayaFlux/Buffers/Shaders/UVFieldProcessor.hpp
@@ -32,7 +32,7 @@ enum class UVProjectionMode : uint8_t { ///< Backing type matches push constant 
  * is present, glm::vec3 colour (sampled from the image at the computed UV) at
  * byte offset 12.
  *
- * Push constant layout (uv_field.comp must match exactly, 80 bytes):
+ * Push constant layout (uv_field.comp must match exactly, 48 bytes):
  *   offset  0  uint  vertex_count
  *   offset  4  uint  mode          (UVProjectionMode)
  *   offset  8  uint  write_colour  (0 = UV only, 1 = also write sampled colour)
@@ -126,9 +126,6 @@ protected:
         const std::shared_ptr<VKBuffer>& buffer) override;
 
 private:
-    // -------------------------------------------------------------------------
-    // Push constant mirror (kept in sync with shader layout)
-    // -------------------------------------------------------------------------
     struct PushConstants {
         uint32_t vertex_count { 0 };
         uint32_t mode { static_cast<uint32_t>(UVProjectionMode::CARTESIAN) };

--- a/src/MayaFlux/Buffers/Staging/StagingUtils.cpp
+++ b/src/MayaFlux/Buffers/Staging/StagingUtils.cpp
@@ -126,12 +126,22 @@ void upload_back_buffer(
     size_t size,
     std::shared_ptr<VKBuffer>& staging)
 {
+    auto handle = upload_back_buffer_async(slot, data, size, staging);
+    resolve_transfer(handle);
+}
+
+TransferHandle upload_back_buffer_async(
+    const VKBufferResources::GenerationSlot& slot,
+    const void* data,
+    size_t size,
+    std::shared_ptr<VKBuffer>& staging)
+{
     if (!data || size == 0)
-        return;
+        return {};
 
     if (slot.mapped_ptr) {
         std::memcpy(slot.mapped_ptr, data, size);
-        return;
+        return {};
     }
 
     auto buffer_service = Registry::BackendRegistry::instance()
@@ -146,7 +156,7 @@ void upload_back_buffer(
             Journal::Component::Buffers,
             Journal::Context::BufferProcessing,
             std::source_location::current(),
-            "upload_back_buffer: BufferService unavailable");
+            "upload_back_buffer_async: BufferService unavailable");
     }
 
     if (!staging || staging->get_size_bytes() < size)
@@ -158,7 +168,7 @@ void upload_back_buffer(
             Journal::Component::Buffers,
             Journal::Context::BufferProcessing,
             std::source_location::current(),
-            "upload_back_buffer: staging buffer has no mapped pointer");
+            "upload_back_buffer_async: staging buffer has no mapped pointer");
     }
 
     std::memcpy(ptr, data, size);
@@ -176,11 +186,26 @@ void upload_back_buffer(
             Journal::Component::Buffers,
             Journal::Context::BufferProcessing,
             std::source_location::current(),
-            "upload_back_buffer: copy_buffer_fenced returned null");
+            "upload_back_buffer_async: copy_buffer_fenced returned null");
     }
 
-    buffer_service->wait_fenced(handle);
-    buffer_service->release_fenced(handle);
+    return handle;
+}
+
+void resolve_transfer(TransferHandle& handle)
+{
+    if (!handle)
+        return;
+
+    auto buffer_service = Registry::BackendRegistry::instance()
+                              .get_service<Registry::Service::BufferService>();
+
+    if (buffer_service && buffer_service->wait_fenced && buffer_service->release_fenced) {
+        buffer_service->wait_fenced(handle);
+        buffer_service->release_fenced(handle);
+    }
+
+    handle.reset();
 }
 
 void download_host_visible(const std::shared_ptr<VKBuffer>& source, const std::shared_ptr<VKBuffer>& target)

--- a/src/MayaFlux/Buffers/Staging/StagingUtils.cpp
+++ b/src/MayaFlux/Buffers/Staging/StagingUtils.cpp
@@ -120,6 +120,69 @@ void upload_device_local(const std::shared_ptr<VKBuffer>& target, const std::sha
         bytes, 0, 0);
 }
 
+void upload_back_buffer(
+    const VKBufferResources::GenerationSlot& slot,
+    const void* data,
+    size_t size,
+    std::shared_ptr<VKBuffer>& staging)
+{
+    if (!data || size == 0)
+        return;
+
+    if (slot.mapped_ptr) {
+        std::memcpy(slot.mapped_ptr, data, size);
+        return;
+    }
+
+    auto buffer_service = Registry::BackendRegistry::instance()
+                              .get_service<Registry::Service::BufferService>();
+
+    if (!buffer_service
+        || !buffer_service->execute_fenced
+        || !buffer_service->wait_fenced
+        || !buffer_service->release_fenced
+        || !buffer_service->flush_range) {
+        error<std::runtime_error>(
+            Journal::Component::Buffers,
+            Journal::Context::BufferProcessing,
+            std::source_location::current(),
+            "upload_back_buffer: BufferService unavailable");
+    }
+
+    if (!staging || staging->get_size_bytes() < size)
+        staging = create_staging_buffer(size);
+
+    void* ptr = staging->get_mapped_ptr();
+    if (!ptr) {
+        error<std::runtime_error>(
+            Journal::Component::Buffers,
+            Journal::Context::BufferProcessing,
+            std::source_location::current(),
+            "upload_back_buffer: staging buffer has no mapped pointer");
+    }
+
+    std::memcpy(ptr, data, size);
+
+    auto& resources = staging->get_buffer_resources();
+    buffer_service->flush_range(resources.memory, 0, size);
+
+    auto handle = buffer_service->copy_buffer_fenced(
+        static_cast<void*>(staging->get_buffer()),
+        static_cast<void*>(slot.buffer),
+        size, 0, 0);
+
+    if (!handle) {
+        error<std::runtime_error>(
+            Journal::Component::Buffers,
+            Journal::Context::BufferProcessing,
+            std::source_location::current(),
+            "upload_back_buffer: copy_buffer_fenced returned null");
+    }
+
+    buffer_service->wait_fenced(handle);
+    buffer_service->release_fenced(handle);
+}
+
 void download_host_visible(const std::shared_ptr<VKBuffer>& source, const std::shared_ptr<VKBuffer>& target)
 {
     auto& source_resources = source->get_buffer_resources();

--- a/src/MayaFlux/Buffers/Staging/StagingUtils.hpp
+++ b/src/MayaFlux/Buffers/Staging/StagingUtils.hpp
@@ -35,6 +35,25 @@ MAYAFLUX_API void upload_host_visible(const std::shared_ptr<VKBuffer>& target, c
 MAYAFLUX_API void upload_device_local(const std::shared_ptr<VKBuffer>& target, const std::shared_ptr<VKBuffer>& staging_buffer, const Kakshya::DataVariant& data);
 
 /**
+ * @brief Upload host memory into a raw back_buffers slot.
+ * @param slot Destination slot, typically from VKBuffer::get_back_buffer().
+ * @param data Source pointer, at least @p size bytes.
+ * @param size Byte count to copy.
+ * @param staging Persistent staging buffer for device-local slots. Ignored,
+ *        and may be null, when slot.mapped_ptr is already valid.
+ *
+ * Writes through slot.mapped_ptr directly when present (host-visible slot,
+ * no transfer). Otherwise copies into @p staging and records a fenced
+ * device-to-device copy into slot.buffer, mirroring download_back_buffer
+ * with the direction reversed.
+ */
+MAYAFLUX_API void upload_back_buffer(
+    const VKBufferResources::GenerationSlot& slot,
+    const void* data,
+    size_t size,
+    std::shared_ptr<VKBuffer>& staging);
+
+/**
  * @brief Download data from a host-visible buffer
  * @param source Source VKBuffer to download data from
  * @param target Target VKBuffer to store the downloaded data

--- a/src/MayaFlux/Buffers/Staging/StagingUtils.hpp
+++ b/src/MayaFlux/Buffers/Staging/StagingUtils.hpp
@@ -11,6 +11,11 @@ class AudioBuffer;
 inline constexpr float k_buffer_growth_factor = 1.5F;
 
 /**
+ * @brief Opaque handle to an in-flight transfer.
+ */
+using TransferHandle = std::shared_ptr<void>;
+
+/**
  * @brief Upload data to a host-visible buffer
  * @param target Target VKBuffer to upload data into
  * @param data DataVariant containing the data to upload
@@ -52,6 +57,36 @@ MAYAFLUX_API void upload_back_buffer(
     const void* data,
     size_t size,
     std::shared_ptr<VKBuffer>& staging);
+
+/**
+ * @brief Upload to a back_buffers slot without waiting for completion.
+ * @param slot Destination slot, typically from VKBuffer::get_back_buffer().
+ * @param data Source pointer, at least @p size bytes. Copied into staging
+ *        before returning, so the caller may free it immediately.
+ * @param size Byte count to copy.
+ * @param staging Persistent staging buffer, grown if too small.
+ * @return Handle to pass to resolve_transfer, or null for host-visible
+ *         slots where the write was a direct memcpy.
+ *
+ * The staging buffer is in use until the returned handle is resolved. Any
+ * further transfer through the same staging buffer must resolve this one
+ * first, or the copy source is overwritten mid-flight.
+ */
+MAYAFLUX_API TransferHandle upload_back_buffer_async(
+    const VKBufferResources::GenerationSlot& slot,
+    const void* data,
+    size_t size,
+    std::shared_ptr<VKBuffer>& staging);
+
+/**
+ * @brief Wait for a transfer and release its resources.
+ * @param handle Handle from upload_back_buffer_async. Nulled on return.
+ *
+ * No-op on a null handle. Blocks the calling thread until the fence
+ * signals, which is immediate when a frame or more has elapsed since
+ * submission.
+ */
+MAYAFLUX_API void resolve_transfer(TransferHandle& handle);
 
 /**
  * @brief Download data from a host-visible buffer

--- a/src/MayaFlux/Buffers/State/AdvectProcessor.cpp
+++ b/src/MayaFlux/Buffers/State/AdvectProcessor.cpp
@@ -2,6 +2,11 @@
 
 namespace MayaFlux::Buffers {
 
+namespace {
+    constexpr size_t k_dissipation_offset = 32;
+    constexpr size_t k_param_size = 48;
+}
+
 std::vector<VolumeFieldProcessor::FieldBinding> AdvectProcessor::make_bindings(
     const std::string& velocity_field, const std::string& carried_field)
 {
@@ -36,15 +41,15 @@ AdvectProcessor::AdvectProcessor(
 
 void AdvectProcessor::on_volume_ready()
 {
-    reserve_param_size(sizeof(AdvectParams));
+    reserve_param_size(k_param_size);
     write_lattice_params();
     write_tail();
 }
 
 void AdvectProcessor::write_tail()
 {
-    const float tail[2] { m_time_step, m_dissipation };
-    write_param_tail(offsetof(AdvectParams, time_step), tail, sizeof(tail));
+    write_lattice_word7(m_time_step);
+    write_param_tail(k_dissipation_offset, &m_dissipation, sizeof(float));
 }
 
 void AdvectProcessor::set_time_step(float dt)

--- a/src/MayaFlux/Buffers/State/AdvectProcessor.cpp
+++ b/src/MayaFlux/Buffers/State/AdvectProcessor.cpp
@@ -1,188 +1,66 @@
 #include "AdvectProcessor.hpp"
-#include "VolumeGridBuffer.hpp"
 
 namespace MayaFlux::Buffers {
 
-namespace {
-    constexpr uint32_t k_workgroup_x = 8;
-    constexpr uint32_t k_workgroup_y = 8;
-    constexpr uint32_t k_workgroup_z = 4;
+std::vector<VolumeFieldProcessor::FieldBinding> AdvectProcessor::make_bindings(
+    const std::string& velocity_field, const std::string& carried_field)
+{
+    return {
+        { .name = "velocity_in", .binding = 0, .field = velocity_field, .access = FieldAccess::READ },
+        { .name = "carried_in", .binding = 1, .field = carried_field, .access = FieldAccess::READ },
+        { .name = "carried_out", .binding = 2, .field = carried_field, .access = FieldAccess::WRITE },
+    };
 }
 
 AdvectProcessor::AdvectProcessor(
     std::string velocity_field,
     std::string carried_field,
     const std::string& shader_path)
-    : ComputeProcessor(shader_path, k_workgroup_x)
+    : VolumeFieldProcessor(make_bindings(velocity_field, carried_field), shader_path)
     , m_velocity_field(std::move(velocity_field))
     , m_carried_field(std::move(carried_field))
 {
-    m_config.bindings["velocity_in"] = ShaderBinding(0, 0, vk::DescriptorType::eStorageBuffer);
-    m_config.bindings["carried_in"] = ShaderBinding(0, 1, vk::DescriptorType::eStorageBuffer);
-    m_config.bindings["carried_out"] = ShaderBinding(0, 2, vk::DescriptorType::eStorageBuffer);
+    add_swap_field(m_carried_field);
 }
 
 AdvectProcessor::AdvectProcessor(
     std::string velocity_field,
     std::string carried_field,
     const Portal::Graphics::ShaderSpec& spec)
-    : ComputeProcessor(spec)
+    : VolumeFieldProcessor(make_bindings(velocity_field, carried_field), spec)
     , m_velocity_field(std::move(velocity_field))
     , m_carried_field(std::move(carried_field))
 {
-    m_config.bindings["velocity_in"] = ShaderBinding(0, 0, vk::DescriptorType::eStorageBuffer);
-    m_config.bindings["carried_in"] = ShaderBinding(0, 1, vk::DescriptorType::eStorageBuffer);
-    m_config.bindings["carried_out"] = ShaderBinding(0, 2, vk::DescriptorType::eStorageBuffer);
+    add_swap_field(m_carried_field);
+}
+
+void AdvectProcessor::on_volume_ready()
+{
+    reserve_param_size(sizeof(AdvectParams));
+    write_lattice_params();
+    write_tail();
+}
+
+void AdvectProcessor::write_tail()
+{
+    const float tail[2] { m_time_step, m_dissipation };
+    write_param_tail(offsetof(AdvectParams, time_step), tail, sizeof(tail));
 }
 
 void AdvectProcessor::set_time_step(float dt)
 {
     m_time_step = dt;
-    if (m_volume) {
-        write_params();
+    if (get_volume()) {
+        write_tail();
     }
 }
 
 void AdvectProcessor::set_dissipation(float dissipation)
 {
     m_dissipation = dissipation;
-    if (m_volume) {
-        write_params();
+    if (get_volume()) {
+        write_tail();
     }
-}
-
-void AdvectProcessor::on_attach(const std::shared_ptr<Buffer>& buffer)
-{
-    ComputeProcessor::on_attach(buffer);
-
-    m_volume = std::dynamic_pointer_cast<VolumeGridBuffer>(buffer);
-    if (!m_volume) {
-        return;
-    }
-
-    if (!m_volume->has_field(m_velocity_field)) {
-        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
-            "AdvectProcessor: volume has no field '{}'", m_velocity_field);
-        m_volume.reset();
-        return;
-    }
-
-    if (!m_volume->has_field(m_carried_field)) {
-        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
-            "AdvectProcessor: volume has no field '{}'", m_carried_field);
-        m_volume.reset();
-        return;
-    }
-
-    if (m_volume->read_handle(m_carried_field) == m_volume->write_handle(m_carried_field)) {
-        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
-            "AdvectProcessor: carried field '{}' is not double-buffered; "
-            "semi-Lagrangian advection reads and writes the same field",
-            m_carried_field);
-        m_volume.reset();
-        return;
-    }
-
-    set_workgroup_size(k_workgroup_x, k_workgroup_y, k_workgroup_z);
-    set_dispatch_mode(ShaderDispatchConfig::DispatchMode::MANUAL);
-    set_manual_dispatch(
-        (m_volume->get_width() + k_workgroup_x - 1) / k_workgroup_x,
-        (m_volume->get_height() + k_workgroup_y - 1) / k_workgroup_y,
-        (m_volume->get_depth() + k_workgroup_z - 1) / k_workgroup_z);
-
-    write_params();
-}
-
-void AdvectProcessor::write_params()
-{
-    if (m_config.push_constant_size < sizeof(AdvectParams)) {
-        set_push_constant_size(sizeof(AdvectParams));
-    }
-
-    auto& data = get_push_constant_data();
-    if (data.size() < m_config.push_constant_size) {
-        data.resize(m_config.push_constant_size);
-    }
-
-    const glm::vec3 cell = m_volume->get_cell_size();
-
-    const AdvectParams params {
-        .width = m_volume->get_width(),
-        .height = m_volume->get_height(),
-        .depth = m_volume->get_depth(),
-        .pad0 = 0,
-        .cell_size_x = cell.x,
-        .cell_size_y = cell.y,
-        .cell_size_z = cell.z,
-        .time_step = m_time_step,
-        .dissipation = m_dissipation,
-        .pad1 = 0.0F,
-        .pad2 = 0.0F,
-        .pad3 = 0.0F,
-    };
-
-    std::memcpy(data.data(), &params, sizeof(AdvectParams));
-}
-
-void AdvectProcessor::write_field_descriptors()
-{
-    if (!m_volume || m_descriptor_set_ids.empty()) {
-        return;
-    }
-
-    auto& foundry = Portal::Graphics::get_shader_foundry();
-
-    foundry.update_descriptor_buffer(
-        m_descriptor_set_ids[0], 0, vk::DescriptorType::eStorageBuffer,
-        m_volume->read_handle(m_velocity_field), 0,
-        m_volume->get_field_bytes(m_velocity_field));
-
-    foundry.update_descriptor_buffer(
-        m_descriptor_set_ids[0], 1, vk::DescriptorType::eStorageBuffer,
-        m_volume->read_handle(m_carried_field), 0,
-        m_volume->get_field_bytes(m_carried_field));
-
-    foundry.update_descriptor_buffer(
-        m_descriptor_set_ids[0], 2, vk::DescriptorType::eStorageBuffer,
-        m_volume->write_handle(m_carried_field), 0,
-        m_volume->get_field_bytes(m_carried_field));
-}
-
-void AdvectProcessor::on_descriptors_created()
-{
-    write_field_descriptors();
-}
-
-void AdvectProcessor::processing_function(const std::shared_ptr<Buffer>& buffer)
-{
-    if (m_volume && are_descriptors_ready()) {
-        write_field_descriptors();
-    }
-
-    ComputeProcessor::processing_function(buffer);
-
-    if (m_volume) {
-        m_volume->swap_field(m_carried_field);
-    }
-}
-
-bool AdvectProcessor::on_before_execute(
-    Portal::Graphics::CommandBufferID /*cmd_id*/,
-    const std::shared_ptr<VKBuffer>& buffer)
-{
-    return m_volume && std::dynamic_pointer_cast<VolumeGridBuffer>(buffer) != nullptr;
-}
-
-void AdvectProcessor::on_after_execute(
-    Portal::Graphics::CommandBufferID /*cmd_id*/,
-    const std::shared_ptr<VKBuffer>& buffer)
-{
-    auto volume = std::dynamic_pointer_cast<VolumeGridBuffer>(buffer);
-    if (!volume) {
-        return;
-    }
-
-    volume->swap_field(m_carried_field);
 }
 
 } // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/AdvectProcessor.cpp
+++ b/src/MayaFlux/Buffers/State/AdvectProcessor.cpp
@@ -1,0 +1,188 @@
+#include "AdvectProcessor.hpp"
+#include "VolumeGridBuffer.hpp"
+
+namespace MayaFlux::Buffers {
+
+namespace {
+    constexpr uint32_t k_workgroup_x = 8;
+    constexpr uint32_t k_workgroup_y = 8;
+    constexpr uint32_t k_workgroup_z = 4;
+}
+
+AdvectProcessor::AdvectProcessor(
+    std::string velocity_field,
+    std::string carried_field,
+    const std::string& shader_path)
+    : ComputeProcessor(shader_path, k_workgroup_x)
+    , m_velocity_field(std::move(velocity_field))
+    , m_carried_field(std::move(carried_field))
+{
+    m_config.bindings["velocity_in"] = ShaderBinding(0, 0, vk::DescriptorType::eStorageBuffer);
+    m_config.bindings["carried_in"] = ShaderBinding(0, 1, vk::DescriptorType::eStorageBuffer);
+    m_config.bindings["carried_out"] = ShaderBinding(0, 2, vk::DescriptorType::eStorageBuffer);
+}
+
+AdvectProcessor::AdvectProcessor(
+    std::string velocity_field,
+    std::string carried_field,
+    const Portal::Graphics::ShaderSpec& spec)
+    : ComputeProcessor(spec)
+    , m_velocity_field(std::move(velocity_field))
+    , m_carried_field(std::move(carried_field))
+{
+    m_config.bindings["velocity_in"] = ShaderBinding(0, 0, vk::DescriptorType::eStorageBuffer);
+    m_config.bindings["carried_in"] = ShaderBinding(0, 1, vk::DescriptorType::eStorageBuffer);
+    m_config.bindings["carried_out"] = ShaderBinding(0, 2, vk::DescriptorType::eStorageBuffer);
+}
+
+void AdvectProcessor::set_time_step(float dt)
+{
+    m_time_step = dt;
+    if (m_volume) {
+        write_params();
+    }
+}
+
+void AdvectProcessor::set_dissipation(float dissipation)
+{
+    m_dissipation = dissipation;
+    if (m_volume) {
+        write_params();
+    }
+}
+
+void AdvectProcessor::on_attach(const std::shared_ptr<Buffer>& buffer)
+{
+    ComputeProcessor::on_attach(buffer);
+
+    m_volume = std::dynamic_pointer_cast<VolumeGridBuffer>(buffer);
+    if (!m_volume) {
+        return;
+    }
+
+    if (!m_volume->has_field(m_velocity_field)) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "AdvectProcessor: volume has no field '{}'", m_velocity_field);
+        m_volume.reset();
+        return;
+    }
+
+    if (!m_volume->has_field(m_carried_field)) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "AdvectProcessor: volume has no field '{}'", m_carried_field);
+        m_volume.reset();
+        return;
+    }
+
+    if (m_volume->read_handle(m_carried_field) == m_volume->write_handle(m_carried_field)) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "AdvectProcessor: carried field '{}' is not double-buffered; "
+            "semi-Lagrangian advection reads and writes the same field",
+            m_carried_field);
+        m_volume.reset();
+        return;
+    }
+
+    set_workgroup_size(k_workgroup_x, k_workgroup_y, k_workgroup_z);
+    set_dispatch_mode(ShaderDispatchConfig::DispatchMode::MANUAL);
+    set_manual_dispatch(
+        (m_volume->get_width() + k_workgroup_x - 1) / k_workgroup_x,
+        (m_volume->get_height() + k_workgroup_y - 1) / k_workgroup_y,
+        (m_volume->get_depth() + k_workgroup_z - 1) / k_workgroup_z);
+
+    write_params();
+}
+
+void AdvectProcessor::write_params()
+{
+    if (m_config.push_constant_size < sizeof(AdvectParams)) {
+        set_push_constant_size(sizeof(AdvectParams));
+    }
+
+    auto& data = get_push_constant_data();
+    if (data.size() < m_config.push_constant_size) {
+        data.resize(m_config.push_constant_size);
+    }
+
+    const glm::vec3 cell = m_volume->get_cell_size();
+
+    const AdvectParams params {
+        .width = m_volume->get_width(),
+        .height = m_volume->get_height(),
+        .depth = m_volume->get_depth(),
+        .pad0 = 0,
+        .cell_size_x = cell.x,
+        .cell_size_y = cell.y,
+        .cell_size_z = cell.z,
+        .time_step = m_time_step,
+        .dissipation = m_dissipation,
+        .pad1 = 0.0F,
+        .pad2 = 0.0F,
+        .pad3 = 0.0F,
+    };
+
+    std::memcpy(data.data(), &params, sizeof(AdvectParams));
+}
+
+void AdvectProcessor::write_field_descriptors()
+{
+    if (!m_volume || m_descriptor_set_ids.empty()) {
+        return;
+    }
+
+    auto& foundry = Portal::Graphics::get_shader_foundry();
+
+    foundry.update_descriptor_buffer(
+        m_descriptor_set_ids[0], 0, vk::DescriptorType::eStorageBuffer,
+        m_volume->read_handle(m_velocity_field), 0,
+        m_volume->get_field_bytes(m_velocity_field));
+
+    foundry.update_descriptor_buffer(
+        m_descriptor_set_ids[0], 1, vk::DescriptorType::eStorageBuffer,
+        m_volume->read_handle(m_carried_field), 0,
+        m_volume->get_field_bytes(m_carried_field));
+
+    foundry.update_descriptor_buffer(
+        m_descriptor_set_ids[0], 2, vk::DescriptorType::eStorageBuffer,
+        m_volume->write_handle(m_carried_field), 0,
+        m_volume->get_field_bytes(m_carried_field));
+}
+
+void AdvectProcessor::on_descriptors_created()
+{
+    write_field_descriptors();
+}
+
+void AdvectProcessor::processing_function(const std::shared_ptr<Buffer>& buffer)
+{
+    if (m_volume && are_descriptors_ready()) {
+        write_field_descriptors();
+    }
+
+    ComputeProcessor::processing_function(buffer);
+
+    if (m_volume) {
+        m_volume->swap_field(m_carried_field);
+    }
+}
+
+bool AdvectProcessor::on_before_execute(
+    Portal::Graphics::CommandBufferID /*cmd_id*/,
+    const std::shared_ptr<VKBuffer>& buffer)
+{
+    return m_volume && std::dynamic_pointer_cast<VolumeGridBuffer>(buffer) != nullptr;
+}
+
+void AdvectProcessor::on_after_execute(
+    Portal::Graphics::CommandBufferID /*cmd_id*/,
+    const std::shared_ptr<VKBuffer>& buffer)
+{
+    auto volume = std::dynamic_pointer_cast<VolumeGridBuffer>(buffer);
+    if (!volume) {
+        return;
+    }
+
+    volume->swap_field(m_carried_field);
+}
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/AdvectProcessor.hpp
+++ b/src/MayaFlux/Buffers/State/AdvectProcessor.hpp
@@ -1,15 +1,13 @@
 #pragma once
 
-#include "MayaFlux/Buffers/Shaders/ComputeProcessor.hpp"
+#include "VolumeFieldProcessor.hpp"
 
 namespace MayaFlux::Buffers {
 
-class VolumeGridBuffer;
-
 /**
  * @class AdvectProcessor
- * @brief ComputeProcessor carrying one field of a VolumeGridBuffer along
- *        that volume's velocity field by semi-Lagrangian backtrace.
+ * @brief VolumeFieldProcessor carrying one field along a velocity field
+ *        by semi-Lagrangian backtrace.
  *
  * Each cell traces its centre backward through the velocity field by one
  * time step, samples the carried field trilinearly at the arrival point,
@@ -22,16 +20,8 @@ class VolumeGridBuffer;
  * step. Naming a scalar carries density, temperature, or any other
  * passively transported quantity.
  *
- * Descriptor bindings for all three slots (velocity read, carried read,
- * carried write) are written directly via
- * ShaderFoundry::update_descriptor_buffer, since VolumeGridBuffer's field
- * storage consists of raw handle pairs with no VKBuffer wrapper. The
- * write happens in processing_function, before execute_shader binds the
- * descriptor set into the command buffer.
- *
- * The carried field is swapped after dispatch, so a subsequent stage
- * reading that field observes the advected values. A field named for both
- * velocity and carrier is swapped once.
+ * The carried field is registered for swap, so a subsequent stage reading
+ * that field observes the advected values.
  *
  * Usage:
  * @code
@@ -41,16 +31,15 @@ class VolumeGridBuffer;
  * chain->add_processor(carry, volume);
  * @endcode
  */
-class MAYAFLUX_API AdvectProcessor : public ComputeProcessor {
+class MAYAFLUX_API AdvectProcessor : public VolumeFieldProcessor {
 public:
     /**
      * @struct AdvectParams
      * @brief Push constant block the advection shader receives.
      *
-     * Lattice dimensions occupy the leading fields, matching the
-     * convention RelaxationStepProcessor::GridExtent establishes for 2D
-     * rules, extended to three axes. Explicit padding keeps cell_size on
-     * a 16-byte boundary for std430 vec3 alignment.
+     * The leading eight words are VolumeFieldProcessor::LatticeParams and
+     * are written by the base. This declaration exists to fix the offsets
+     * of the two fields past that prefix.
      */
     struct AdvectParams {
         uint32_t width;
@@ -70,7 +59,7 @@ public:
     /**
      * @brief Construct an advection stage.
      * @param velocity_field Name of the field traced through. Must have
-     *        stride sizeof(glm::vec4) and be double-buffered.
+     *        stride sizeof(glm::vec4).
      * @param carried_field Name of the field transported. May equal
      *        @p velocity_field for self-advection. Must be double-buffered.
      * @param shader_path Path to the compute shader implementing the trace.
@@ -113,80 +102,31 @@ public:
 
 protected:
     /**
-     * @brief Size the dispatch to the lattice and write the parameter
-     *        block, once the attached volume's dimensions are known.
-     * @param buffer The attached buffer, expected to be a VolumeGridBuffer.
+     * @brief Reserve the full parameter block and write the step and
+     *        dissipation words.
      */
-    void on_attach(const std::shared_ptr<Buffer>& buffer) override;
-
-    /**
-     * @brief Write the three field descriptors for the current slot
-     *        assignment.
-     *
-     * Called after descriptor set creation. The per-cycle write happens in
-     * processing_function; this covers the first cycle, before which no
-     * processing_function call has occurred against a ready descriptor set.
-     */
-    void on_descriptors_created() override;
-
-    /**
-     * @brief Reject buffers that are not VolumeGridBuffer.
-     * @param cmd_id Command buffer this cycle's dispatch will be recorded into.
-     * @param buffer The attached buffer, received as VKBuffer.
-     * @return True if the attached buffer is a VolumeGridBuffer.
-     */
-    bool on_before_execute(Portal::Graphics::CommandBufferID cmd_id, const std::shared_ptr<VKBuffer>& buffer) override;
-
-    /**
-     * @brief Swap the carried field's slots so downstream stages observe
-     *        the advected values.
-     * @param cmd_id Command buffer the dispatch was recorded into.
-     * @param buffer The attached buffer, received as VKBuffer.
-     */
-    void on_after_execute(Portal::Graphics::CommandBufferID cmd_id, const std::shared_ptr<VKBuffer>& buffer) override;
-
-    /**
-     * @brief Write the field descriptors for this cycle's slot assignment,
-     *        run the normal shader processing path, then swap the carried
-     *        field's slots.
-     *
-     * The descriptor write must precede execute_shader's
-     * vkCmdBindDescriptorSets. Writing from on_before_execute updates a set
-     * the driver has already consumed, freezing the bindings at whatever
-     * on_descriptors_created wrote.
-     *
-     * The swap is here rather than in on_after_execute because a slot
-     * exchange is not idempotent and on_after_execute is invoked more than
-     * once per cycle.
-     */
-    void processing_function(const std::shared_ptr<Buffer>& buffer) override;
+    void on_volume_ready() override;
 
 private:
     /**
-     * @brief Issue direct ShaderFoundry descriptor writes for the velocity
-     *        read slot, the carried read slot, and the carried write slot.
+     * @brief Write time step and dissipation past the shared prefix.
      */
-    void write_field_descriptors();
+    void write_tail();
 
     /**
-     * @brief Size the push constant block to at least AdvectParams and
-     *        write the attached volume's lattice dimensions and cell size.
-     *
-     * Called from on_attach, the first point at which the volume's extent
-     * is known, and again whenever set_time_step or set_dissipation
-     * changes a parameter. A ShaderSpec-constructed processor already
-     * carries spec.push_constant_bytes in m_config; that size is preserved
-     * and only the leading AdvectParams fields are written.
+     * @brief Build the binding table for the two field names.
+     * @param velocity_field Field traced through.
+     * @param carried_field Field transported.
+     * @return Table binding velocity read, carried read, and carried write.
      */
-    void write_params();
+    static std::vector<FieldBinding> make_bindings(
+        const std::string& velocity_field, const std::string& carried_field);
 
     std::string m_velocity_field;
     std::string m_carried_field;
 
     float m_time_step { 1.0F / 60.0F };
     float m_dissipation { 1.0F };
-
-    std::shared_ptr<VolumeGridBuffer> m_volume; ///< The attached volume, cached for descriptor writes and slot swaps.
 };
 
 } // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/AdvectProcessor.hpp
+++ b/src/MayaFlux/Buffers/State/AdvectProcessor.hpp
@@ -1,0 +1,192 @@
+#pragma once
+
+#include "MayaFlux/Buffers/Shaders/ComputeProcessor.hpp"
+
+namespace MayaFlux::Buffers {
+
+class VolumeGridBuffer;
+
+/**
+ * @class AdvectProcessor
+ * @brief ComputeProcessor carrying one field of a VolumeGridBuffer along
+ *        that volume's velocity field by semi-Lagrangian backtrace.
+ *
+ * Each cell traces its centre backward through the velocity field by one
+ * time step, samples the carried field trilinearly at the arrival point,
+ * and writes the result to its own index in the carried field's write
+ * slot. Out-of-bounds arrivals clamp to the lattice edge.
+ *
+ * Constructed against two field names: the velocity field to trace
+ * through, and the field to carry. Naming the same field for both gives
+ * velocity self-advection, which is the first stage of an incompressible
+ * step. Naming a scalar carries density, temperature, or any other
+ * passively transported quantity.
+ *
+ * Descriptor bindings for all three slots (velocity read, carried read,
+ * carried write) are written directly via
+ * ShaderFoundry::update_descriptor_buffer, since VolumeGridBuffer's field
+ * storage consists of raw handle pairs with no VKBuffer wrapper. The
+ * write happens in processing_function, before execute_shader binds the
+ * descriptor set into the command buffer.
+ *
+ * The carried field is swapped after dispatch, so a subsequent stage
+ * reading that field observes the advected values. A field named for both
+ * velocity and carrier is swapped once.
+ *
+ * Usage:
+ * @code
+ * auto self = std::make_shared<AdvectProcessor>("velocity", "velocity", spec);
+ * auto carry = std::make_shared<AdvectProcessor>("velocity", "density", spec);
+ * chain->add_processor(self, volume);
+ * chain->add_processor(carry, volume);
+ * @endcode
+ */
+class MAYAFLUX_API AdvectProcessor : public ComputeProcessor {
+public:
+    /**
+     * @struct AdvectParams
+     * @brief Push constant block the advection shader receives.
+     *
+     * Lattice dimensions occupy the leading fields, matching the
+     * convention RelaxationStepProcessor::GridExtent establishes for 2D
+     * rules, extended to three axes. Explicit padding keeps cell_size on
+     * a 16-byte boundary for std430 vec3 alignment.
+     */
+    struct AdvectParams {
+        uint32_t width;
+        uint32_t height;
+        uint32_t depth;
+        uint32_t pad0;
+        float cell_size_x;
+        float cell_size_y;
+        float cell_size_z;
+        float time_step;
+        float dissipation;
+        float pad1;
+        float pad2;
+        float pad3;
+    };
+
+    /**
+     * @brief Construct an advection stage.
+     * @param velocity_field Name of the field traced through. Must have
+     *        stride sizeof(glm::vec4) and be double-buffered.
+     * @param carried_field Name of the field transported. May equal
+     *        @p velocity_field for self-advection. Must be double-buffered.
+     * @param shader_path Path to the compute shader implementing the trace.
+     */
+    AdvectProcessor(
+        std::string velocity_field,
+        std::string carried_field,
+        const std::string& shader_path);
+
+    /**
+     * @brief Construct an advection stage from a generated ShaderSpec.
+     * @param velocity_field Name of the field traced through.
+     * @param carried_field Name of the field transported.
+     * @param spec ShaderSpec implementing the trace.
+     */
+    AdvectProcessor(
+        std::string velocity_field,
+        std::string carried_field,
+        const Portal::Graphics::ShaderSpec& spec);
+
+    /**
+     * @brief Set the integration step passed to the shader each cycle.
+     * @param dt Seconds per step. Takes effect next cycle.
+     */
+    void set_time_step(float dt);
+
+    /**
+     * @brief Set the multiplicative decay applied to the carried value.
+     * @param dissipation Factor in [0, 1]. One preserves the quantity;
+     *        values below one bleed it off over time, which suits smoke
+     *        density and temperature. Takes effect next cycle.
+     */
+    void set_dissipation(float dissipation);
+
+    /** @brief Name of the field this stage traces through. */
+    [[nodiscard]] const std::string& get_velocity_field() const { return m_velocity_field; }
+
+    /** @brief Name of the field this stage transports. */
+    [[nodiscard]] const std::string& get_carried_field() const { return m_carried_field; }
+
+protected:
+    /**
+     * @brief Size the dispatch to the lattice and write the parameter
+     *        block, once the attached volume's dimensions are known.
+     * @param buffer The attached buffer, expected to be a VolumeGridBuffer.
+     */
+    void on_attach(const std::shared_ptr<Buffer>& buffer) override;
+
+    /**
+     * @brief Write the three field descriptors for the current slot
+     *        assignment.
+     *
+     * Called after descriptor set creation. The per-cycle write happens in
+     * processing_function; this covers the first cycle, before which no
+     * processing_function call has occurred against a ready descriptor set.
+     */
+    void on_descriptors_created() override;
+
+    /**
+     * @brief Reject buffers that are not VolumeGridBuffer.
+     * @param cmd_id Command buffer this cycle's dispatch will be recorded into.
+     * @param buffer The attached buffer, received as VKBuffer.
+     * @return True if the attached buffer is a VolumeGridBuffer.
+     */
+    bool on_before_execute(Portal::Graphics::CommandBufferID cmd_id, const std::shared_ptr<VKBuffer>& buffer) override;
+
+    /**
+     * @brief Swap the carried field's slots so downstream stages observe
+     *        the advected values.
+     * @param cmd_id Command buffer the dispatch was recorded into.
+     * @param buffer The attached buffer, received as VKBuffer.
+     */
+    void on_after_execute(Portal::Graphics::CommandBufferID cmd_id, const std::shared_ptr<VKBuffer>& buffer) override;
+
+    /**
+     * @brief Write the field descriptors for this cycle's slot assignment,
+     *        run the normal shader processing path, then swap the carried
+     *        field's slots.
+     *
+     * The descriptor write must precede execute_shader's
+     * vkCmdBindDescriptorSets. Writing from on_before_execute updates a set
+     * the driver has already consumed, freezing the bindings at whatever
+     * on_descriptors_created wrote.
+     *
+     * The swap is here rather than in on_after_execute because a slot
+     * exchange is not idempotent and on_after_execute is invoked more than
+     * once per cycle.
+     */
+    void processing_function(const std::shared_ptr<Buffer>& buffer) override;
+
+private:
+    /**
+     * @brief Issue direct ShaderFoundry descriptor writes for the velocity
+     *        read slot, the carried read slot, and the carried write slot.
+     */
+    void write_field_descriptors();
+
+    /**
+     * @brief Size the push constant block to at least AdvectParams and
+     *        write the attached volume's lattice dimensions and cell size.
+     *
+     * Called from on_attach, the first point at which the volume's extent
+     * is known, and again whenever set_time_step or set_dissipation
+     * changes a parameter. A ShaderSpec-constructed processor already
+     * carries spec.push_constant_bytes in m_config; that size is preserved
+     * and only the leading AdvectParams fields are written.
+     */
+    void write_params();
+
+    std::string m_velocity_field;
+    std::string m_carried_field;
+
+    float m_time_step { 1.0F / 60.0F };
+    float m_dissipation { 1.0F };
+
+    std::shared_ptr<VolumeGridBuffer> m_volume; ///< The attached volume, cached for descriptor writes and slot swaps.
+};
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/BuoyancyProcessor.cpp
+++ b/src/MayaFlux/Buffers/State/BuoyancyProcessor.cpp
@@ -1,0 +1,137 @@
+#include "BuoyancyProcessor.hpp"
+
+namespace MayaFlux::Buffers {
+
+namespace {
+    constexpr size_t k_tail_offset = 32;
+    constexpr size_t k_param_size = 64;
+
+    /**
+     * @struct BuoyancyTail
+     * @brief The parameter words past the shared lattice prefix.
+     */
+    struct BuoyancyTail {
+        float direction_x;
+        float direction_y;
+        float direction_z;
+        float ambient;
+        float temperature_gain;
+        float density_gain;
+        float pad1;
+        float pad2;
+    };
+
+    static_assert(k_tail_offset + sizeof(BuoyancyTail) == k_param_size);
+}
+
+std::vector<VolumeFieldProcessor::FieldBinding> BuoyancyProcessor::make_bindings(
+    const std::string& temperature_field,
+    const std::string& density_field,
+    const std::string& velocity_field)
+{
+    return {
+        { .name = "temperature_in", .binding = 0, .field = temperature_field, .access = FieldAccess::READ },
+        { .name = "density_in", .binding = 1, .field = density_field, .access = FieldAccess::READ },
+        { .name = "velocity_in", .binding = 2, .field = velocity_field, .access = FieldAccess::READ },
+        { .name = "velocity_out", .binding = 3, .field = velocity_field, .access = FieldAccess::WRITE },
+    };
+}
+
+BuoyancyProcessor::BuoyancyProcessor(
+    std::string temperature_field,
+    std::string density_field,
+    std::string velocity_field,
+    const glm::vec3& direction,
+    const std::string& shader_path)
+    : VolumeFieldProcessor(
+          make_bindings(temperature_field, density_field, velocity_field), shader_path)
+    , m_temperature_field(std::move(temperature_field))
+    , m_density_field(std::move(density_field))
+    , m_velocity_field(std::move(velocity_field))
+    , m_direction(direction)
+{
+    add_swap_field(m_velocity_field);
+}
+
+BuoyancyProcessor::BuoyancyProcessor(
+    std::string temperature_field,
+    std::string density_field,
+    std::string velocity_field,
+    const glm::vec3& direction,
+    const Portal::Graphics::ShaderSpec& spec)
+    : VolumeFieldProcessor(
+          make_bindings(temperature_field, density_field, velocity_field), spec)
+    , m_temperature_field(std::move(temperature_field))
+    , m_density_field(std::move(density_field))
+    , m_velocity_field(std::move(velocity_field))
+    , m_direction(direction)
+{
+    add_swap_field(m_velocity_field);
+}
+
+void BuoyancyProcessor::on_volume_ready()
+{
+    reserve_param_size(k_param_size);
+    write_lattice_params();
+    write_tail();
+}
+
+void BuoyancyProcessor::write_tail()
+{
+    write_lattice_word7(m_time_step);
+
+    const BuoyancyTail tail {
+        .direction_x = m_direction.x,
+        .direction_y = m_direction.y,
+        .direction_z = m_direction.z,
+        .ambient = m_ambient,
+        .temperature_gain = m_temperature_gain,
+        .density_gain = m_density_gain,
+        .pad1 = 0.0F,
+        .pad2 = 0.0F,
+    };
+
+    write_param_tail(k_tail_offset, &tail, sizeof(tail));
+}
+
+void BuoyancyProcessor::set_time_step(float dt)
+{
+    m_time_step = dt;
+    if (get_volume()) {
+        write_tail();
+    }
+}
+
+void BuoyancyProcessor::set_direction(const glm::vec3& direction)
+{
+    m_direction = direction;
+    if (get_volume()) {
+        write_tail();
+    }
+}
+
+void BuoyancyProcessor::set_ambient(float ambient)
+{
+    m_ambient = ambient;
+    if (get_volume()) {
+        write_tail();
+    }
+}
+
+void BuoyancyProcessor::set_temperature_gain(float gain)
+{
+    m_temperature_gain = gain;
+    if (get_volume()) {
+        write_tail();
+    }
+}
+
+void BuoyancyProcessor::set_density_gain(float gain)
+{
+    m_density_gain = gain;
+    if (get_volume()) {
+        write_tail();
+    }
+}
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/BuoyancyProcessor.hpp
+++ b/src/MayaFlux/Buffers/State/BuoyancyProcessor.hpp
@@ -1,0 +1,172 @@
+#pragma once
+
+#include "VolumeFieldProcessor.hpp"
+
+namespace MayaFlux::Buffers {
+
+/**
+ * @class BuoyancyProcessor
+ * @brief VolumeFieldProcessor accumulating a Boussinesq body force into a
+ *        velocity field from a temperature field and a density field.
+ *
+ * Each cell adds dt * (temperature_gain * (T - ambient) - density_gain * d)
+ * scaled by the direction vector into its own velocity, writing the write
+ * slot and swapping. No neighbourhood is read, so the stencil is local and
+ * the boundary needs no special case.
+ *
+ * The direction vector carries both axis and magnitude: passing
+ * (0, 9.81, 0) and unit gains is equivalent to passing (0, 1, 0) and gains
+ * of 9.81. Nothing in the stage assumes an up axis.
+ *
+ * Naming the same field for temperature and density is valid and gives a
+ * single-quantity buoyancy: set the gain for the unwanted term to zero.
+ * The stage does not require a distinct temperature field to exist.
+ *
+ * Placement is after advection and before divergence. Running it after the
+ * pressure solve injects divergence the solve has already removed.
+ */
+class MAYAFLUX_API BuoyancyProcessor : public VolumeFieldProcessor {
+public:
+    /**
+     * @struct BuoyancyParams
+     * @brief Push constant block the buoyancy shader receives.
+     *
+     * The leading eight words are the shared lattice prefix and are written
+     * by the base. This declaration exists to fix the offsets of the fields
+     * past that prefix.
+     */
+    struct BuoyancyParams {
+        uint32_t width;
+        uint32_t height;
+        uint32_t depth;
+        uint32_t pad0;
+        float cell_size_x;
+        float cell_size_y;
+        float cell_size_z;
+        float time_step;
+        float direction_x;
+        float direction_y;
+        float direction_z;
+        float ambient;
+        float temperature_gain;
+        float density_gain;
+        float pad1;
+        float pad2;
+    };
+
+    static_assert(sizeof(BuoyancyParams) % 16 == 0);
+
+    /**
+     * @brief Construct a buoyancy stage.
+     * @param temperature_field Name of the scalar field driving rise. Must
+     *        have stride sizeof(float).
+     * @param density_field Name of the scalar field driving fall. Must have
+     *        stride sizeof(float). May equal @p temperature_field.
+     * @param velocity_field Name of the field accumulated into. Must have
+     *        stride sizeof(glm::vec4) and be double-buffered.
+     * @param direction Force axis and magnitude in world units.
+     * @param shader_path Path to the compute shader.
+     */
+    BuoyancyProcessor(
+        std::string temperature_field,
+        std::string density_field,
+        std::string velocity_field,
+        const glm::vec3& direction,
+        const std::string& shader_path);
+
+    /**
+     * @brief Construct a buoyancy stage from a generated ShaderSpec.
+     * @param temperature_field Name of the scalar field driving rise.
+     * @param density_field Name of the scalar field driving fall.
+     * @param velocity_field Name of the field accumulated into.
+     * @param direction Force axis and magnitude in world units.
+     * @param spec ShaderSpec implementing the accumulate.
+     */
+    BuoyancyProcessor(
+        std::string temperature_field,
+        std::string density_field,
+        std::string velocity_field,
+        const glm::vec3& direction,
+        const Portal::Graphics::ShaderSpec& spec);
+
+    /**
+     * @brief Set the integration step passed to the shader each cycle.
+     * @param dt Seconds per step. Match the advection stage's step.
+     */
+    void set_time_step(float dt);
+
+    /**
+     * @brief Set the force axis and magnitude.
+     * @param direction World-space vector. Not normalized.
+     */
+    void set_direction(const glm::vec3& direction);
+
+    /**
+     * @brief Set the temperature at which the rise term vanishes.
+     * @param ambient Reference temperature. Cells below it sink.
+     */
+    void set_ambient(float ambient);
+
+    /**
+     * @brief Set the coefficient on the temperature difference.
+     * @param gain Multiplier. Zero disables the rise term.
+     */
+    void set_temperature_gain(float gain);
+
+    /**
+     * @brief Set the coefficient on the density value.
+     * @param gain Multiplier. Zero disables the fall term.
+     */
+    void set_density_gain(float gain);
+
+    /** @brief Seconds per step. */
+    [[nodiscard]] float get_time_step() const { return m_time_step; }
+
+    /** @brief Force axis and magnitude. */
+    [[nodiscard]] const glm::vec3& get_direction() const { return m_direction; }
+
+    /** @brief Name of the field driving rise. */
+    [[nodiscard]] const std::string& get_temperature_field() const { return m_temperature_field; }
+
+    /** @brief Name of the field driving fall. */
+    [[nodiscard]] const std::string& get_density_field() const { return m_density_field; }
+
+    /** @brief Name of the field accumulated into. */
+    [[nodiscard]] const std::string& get_velocity_field() const { return m_velocity_field; }
+
+protected:
+    /**
+     * @brief Raise the parameter block and write the tail.
+     */
+    void on_volume_ready() override;
+
+private:
+    /**
+     * @brief Build the binding table for the three field names.
+     * @param temperature_field Field driving rise.
+     * @param density_field Field driving fall.
+     * @param velocity_field Field accumulated into, bound in both slots.
+     * @return Table binding both scalars read and both velocity slots.
+     */
+    static std::vector<FieldBinding> make_bindings(
+        const std::string& temperature_field,
+        const std::string& density_field,
+        const std::string& velocity_field);
+
+    /**
+     * @brief Write every parameter past the shared prefix.
+     */
+    void write_tail();
+
+    std::string m_temperature_field;
+    std::string m_density_field;
+    std::string m_velocity_field;
+
+    glm::vec3 m_direction { 0.0F, 1.0F, 0.0F };
+    float m_time_step { 1.0F / 60.0F };
+    float m_ambient { 0.0F };
+    float m_temperature_gain { 1.0F };
+    float m_density_gain { 0.0F };
+};
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/DiffuseProcessor.cpp
+++ b/src/MayaFlux/Buffers/State/DiffuseProcessor.cpp
@@ -1,0 +1,103 @@
+#include "DiffuseProcessor.hpp"
+#include "VolumeGridBuffer.hpp"
+
+namespace MayaFlux::Buffers {
+
+std::vector<VolumeFieldProcessor::FieldBinding> DiffuseProcessor::make_bindings(
+    const std::string& target_field, const std::string& scratch_field)
+{
+    return {
+        { .name = "source", .binding = 0, .field = scratch_field, .access = FieldAccess::WRITE },
+        { .name = "target_a", .binding = 1, .field = target_field, .access = FieldAccess::READ },
+        { .name = "target_b", .binding = 2, .field = target_field, .access = FieldAccess::WRITE },
+    };
+}
+
+DiffuseProcessor::DiffuseProcessor(
+    std::string target_field,
+    std::string scratch_field,
+    const std::string& shader_path,
+    uint32_t iterations)
+    : VolumeFieldProcessor(make_bindings(target_field, scratch_field), shader_path)
+    , m_target_field(std::move(target_field))
+    , m_scratch_field(std::move(scratch_field))
+{
+    add_swap_field(m_target_field);
+    set_iteration_count(iterations);
+}
+
+DiffuseProcessor::DiffuseProcessor(
+    std::string target_field,
+    std::string scratch_field,
+    const Portal::Graphics::ShaderSpec& spec,
+    uint32_t iterations)
+    : VolumeFieldProcessor(make_bindings(target_field, scratch_field), spec)
+    , m_target_field(std::move(target_field))
+    , m_scratch_field(std::move(scratch_field))
+{
+    add_swap_field(m_target_field);
+    set_iteration_count(iterations);
+}
+
+void DiffuseProcessor::on_volume_ready()
+{
+    write_coefficient();
+}
+
+void DiffuseProcessor::write_coefficient()
+{
+    write_lattice_word7(m_rate * m_time_step);
+}
+
+void DiffuseProcessor::set_rate(float rate)
+{
+    m_rate = rate;
+    if (get_volume()) {
+        write_coefficient();
+    }
+}
+
+void DiffuseProcessor::set_time_step(float dt)
+{
+    m_time_step = dt;
+    if (get_volume()) {
+        write_coefficient();
+    }
+}
+
+bool DiffuseProcessor::wants_swap() const
+{
+    return (get_iteration_count() % 2) == 1;
+}
+
+bool DiffuseProcessor::on_iteration(
+    Portal::Graphics::CommandBufferID /*cmd_id*/,
+    const std::shared_ptr<VKBuffer>& /*buffer*/,
+    uint32_t index)
+{
+    write_lattice_word3((index % 2) | (index == 0 ? 2U : 0U));
+    return true;
+}
+
+void DiffuseProcessor::on_iteration_barrier(
+    Portal::Graphics::CommandBufferID cmd_id,
+    const std::shared_ptr<VKBuffer>& /*buffer*/,
+    uint32_t /*index*/)
+{
+    const auto& volume = get_volume();
+    if (!volume) {
+        return;
+    }
+
+    auto& foundry = Portal::Graphics::get_shader_foundry();
+
+    const auto src = vk::AccessFlagBits::eShaderWrite;
+    const auto dst = vk::AccessFlagBits::eShaderRead | vk::AccessFlagBits::eShaderWrite;
+    const auto stage = vk::PipelineStageFlagBits::eComputeShader;
+
+    foundry.buffer_barrier(cmd_id, volume->read_handle(m_target_field), src, dst, stage, stage);
+    foundry.buffer_barrier(cmd_id, volume->write_handle(m_target_field), src, dst, stage, stage);
+    foundry.buffer_barrier(cmd_id, volume->write_handle(m_scratch_field), src, dst, stage, stage);
+}
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/DiffuseProcessor.hpp
+++ b/src/MayaFlux/Buffers/State/DiffuseProcessor.hpp
@@ -1,0 +1,140 @@
+#pragma once
+
+#include "VolumeFieldProcessor.hpp"
+
+namespace MayaFlux::Buffers {
+
+/**
+ * @class DiffuseProcessor
+ * @brief VolumeFieldProcessor spreading a field into its neighbourhood by
+ *        implicit Jacobi iteration.
+ *
+ * Solves the backward Euler form rather than stepping the heat equation
+ * forward, so the result is stable at any coefficient. The explicit form
+ * diverges once the coefficient exceeds a sixth of the squared cell
+ * spacing, which at a sixty-fourth-of-a-unit lattice is reached by
+ * ordinary viscosities.
+ *
+ * Applied to velocity this is viscosity. Applied to a scalar it blurs
+ * density or temperature, which softens the filaments first-order
+ * advection leaves behind.
+ *
+ * Requires a scratch field alongside the target. Jacobi needs the
+ * pre-diffusion values on every pass, and the two target slots are both
+ * consumed by the ping-pong, so the first pass copies what it reads into
+ * the scratch and later passes read it from there. The scratch is bound
+ * once, unqualified, and must have the same stride as the target. It may
+ * be single-buffered and is never swapped.
+ *
+ * Shares PressureProcessor's parity arrangement: both target slots bound
+ * simultaneously, the pass's read and write selected by a push constant
+ * word, since a descriptor set bound into an open command buffer cannot
+ * be rewritten mid-recording.
+ */
+class MAYAFLUX_API DiffuseProcessor : public VolumeFieldProcessor {
+public:
+    /**
+     * @brief Construct a diffusion stage.
+     * @param target_field Name of the field diffused. Must be double-buffered.
+     * @param scratch_field Name of a field of matching stride holding the
+     *        pre-diffusion values across passes. Not swapped, may be
+     *        single-buffered, and its contents are overwritten every cycle.
+     * @param shader_path Path to the compute shader.
+     * @param iterations Jacobi passes per cycle. Values below 1 clamp to 1.
+     */
+    DiffuseProcessor(
+        std::string target_field,
+        std::string scratch_field,
+        const std::string& shader_path,
+        uint32_t iterations = 20);
+
+    /**
+     * @brief Construct a diffusion stage from a generated ShaderSpec.
+     * @param target_field Name of the field diffused.
+     * @param scratch_field Name of the scratch field.
+     * @param spec ShaderSpec implementing one Jacobi pass.
+     * @param iterations Jacobi passes per cycle.
+     */
+    DiffuseProcessor(
+        std::string target_field,
+        std::string scratch_field,
+        const Portal::Graphics::ShaderSpec& spec,
+        uint32_t iterations = 20);
+
+    /**
+     * @brief Set the diffusion rate.
+     * @param rate Viscosity for velocity, or a blur rate for a scalar.
+     *        Zero leaves the field unchanged. Takes effect next cycle.
+     */
+    void set_rate(float rate);
+
+    /**
+     * @brief Set the integration step.
+     * @param dt Seconds per step. Takes effect next cycle.
+     */
+    void set_time_step(float dt);
+
+    /** @brief Name of the field this stage diffuses. */
+    [[nodiscard]] const std::string& get_target_field() const { return m_target_field; }
+
+    /** @brief Name of the field holding pre-diffusion values across passes. */
+    [[nodiscard]] const std::string& get_scratch_field() const { return m_scratch_field; }
+
+protected:
+    /**
+     * @brief Write the coefficient into the shared prefix.
+     */
+    void on_volume_ready() override;
+
+    /**
+     * @brief Write this pass's parity and first-pass flag.
+     * @param cmd_id Command buffer being recorded into.
+     * @param buffer Buffer under processing.
+     * @param index Zero-based iteration index.
+     * @return Always true. Every pass dispatches.
+     */
+    bool on_iteration(
+        Portal::Graphics::CommandBufferID cmd_id,
+        const std::shared_ptr<VKBuffer>& buffer,
+        uint32_t index) override;
+
+    /**
+     * @brief Barrier both target slots and the scratch between passes.
+     * @param cmd_id Command buffer being recorded into.
+     * @param buffer Buffer under processing.
+     * @param index Zero-based index of the pass just recorded.
+     */
+    void on_iteration_barrier(
+        Portal::Graphics::CommandBufferID cmd_id,
+        const std::shared_ptr<VKBuffer>& buffer,
+        uint32_t index) override;
+
+    /**
+     * @brief Swap only when the pass count leaves the result in the write slot.
+     * @return True when the iteration count is odd.
+     */
+    [[nodiscard]] bool wants_swap() const override;
+
+private:
+    /**
+     * @brief Write the product of rate and time step into word seven.
+     */
+    void write_coefficient();
+
+    /**
+     * @brief Build the binding table for the two field names.
+     * @param target_field Field diffused, bound in both slots.
+     * @param scratch_field Field holding pre-diffusion values.
+     * @return Table binding the scratch and both target slots.
+     */
+    static std::vector<FieldBinding> make_bindings(
+        const std::string& target_field, const std::string& scratch_field);
+
+    std::string m_target_field;
+    std::string m_scratch_field;
+
+    float m_rate { 0.0F };
+    float m_time_step { 1.0F / 60.0F };
+};
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/DivergenceProcessor.cpp
+++ b/src/MayaFlux/Buffers/State/DivergenceProcessor.cpp
@@ -1,0 +1,136 @@
+#include "DivergenceProcessor.hpp"
+#include "VolumeGridBuffer.hpp"
+
+namespace MayaFlux::Buffers {
+
+namespace {
+    constexpr uint32_t k_workgroup_x = 8;
+    constexpr uint32_t k_workgroup_y = 8;
+    constexpr uint32_t k_workgroup_z = 4;
+}
+
+DivergenceProcessor::DivergenceProcessor(
+    std::string velocity_field,
+    std::string divergence_field,
+    const std::string& shader_path)
+    : ComputeProcessor(shader_path, k_workgroup_x)
+    , m_velocity_field(std::move(velocity_field))
+    , m_divergence_field(std::move(divergence_field))
+{
+    m_config.bindings["velocity_in"] = ShaderBinding(0, 0, vk::DescriptorType::eStorageBuffer);
+    m_config.bindings["divergence_out"] = ShaderBinding(0, 1, vk::DescriptorType::eStorageBuffer);
+}
+
+DivergenceProcessor::DivergenceProcessor(
+    std::string velocity_field,
+    std::string divergence_field,
+    const Portal::Graphics::ShaderSpec& spec)
+    : ComputeProcessor(spec)
+    , m_velocity_field(std::move(velocity_field))
+    , m_divergence_field(std::move(divergence_field))
+{
+    m_config.bindings["velocity_in"] = ShaderBinding(0, 0, vk::DescriptorType::eStorageBuffer);
+    m_config.bindings["divergence_out"] = ShaderBinding(0, 1, vk::DescriptorType::eStorageBuffer);
+}
+
+void DivergenceProcessor::on_attach(const std::shared_ptr<Buffer>& buffer)
+{
+    ComputeProcessor::on_attach(buffer);
+
+    m_volume = std::dynamic_pointer_cast<VolumeGridBuffer>(buffer);
+    if (!m_volume) {
+        return;
+    }
+
+    if (!m_volume->has_field(m_velocity_field)) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "DivergenceProcessor: volume has no field '{}'", m_velocity_field);
+        m_volume.reset();
+        return;
+    }
+
+    if (!m_volume->has_field(m_divergence_field)) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "DivergenceProcessor: volume has no field '{}'", m_divergence_field);
+        m_volume.reset();
+        return;
+    }
+
+    set_workgroup_size(k_workgroup_x, k_workgroup_y, k_workgroup_z);
+    set_dispatch_mode(ShaderDispatchConfig::DispatchMode::MANUAL);
+    set_manual_dispatch(
+        (m_volume->get_width() + k_workgroup_x - 1) / k_workgroup_x,
+        (m_volume->get_height() + k_workgroup_y - 1) / k_workgroup_y,
+        (m_volume->get_depth() + k_workgroup_z - 1) / k_workgroup_z);
+
+    write_params();
+}
+
+void DivergenceProcessor::write_params()
+{
+    if (m_config.push_constant_size < sizeof(DivergenceParams)) {
+        set_push_constant_size(sizeof(DivergenceParams));
+    }
+
+    auto& data = get_push_constant_data();
+    if (data.size() < m_config.push_constant_size) {
+        data.resize(m_config.push_constant_size);
+    }
+
+    const glm::vec3 cell = m_volume->get_cell_size();
+
+    const DivergenceParams params {
+        .width = m_volume->get_width(),
+        .height = m_volume->get_height(),
+        .depth = m_volume->get_depth(),
+        .pad0 = 0,
+        .cell_size_x = cell.x,
+        .cell_size_y = cell.y,
+        .cell_size_z = cell.z,
+        .pad1 = 0.0F,
+    };
+
+    std::memcpy(data.data(), &params, sizeof(DivergenceParams));
+}
+
+void DivergenceProcessor::write_field_descriptors()
+{
+    if (!m_volume || m_descriptor_set_ids.empty()) {
+        return;
+    }
+
+    auto& foundry = Portal::Graphics::get_shader_foundry();
+
+    foundry.update_descriptor_buffer(
+        m_descriptor_set_ids[0], 0, vk::DescriptorType::eStorageBuffer,
+        m_volume->read_handle(m_velocity_field), 0,
+        m_volume->get_field_bytes(m_velocity_field));
+
+    foundry.update_descriptor_buffer(
+        m_descriptor_set_ids[0], 1, vk::DescriptorType::eStorageBuffer,
+        m_volume->write_handle(m_divergence_field), 0,
+        m_volume->get_field_bytes(m_divergence_field));
+}
+
+void DivergenceProcessor::on_descriptors_created()
+{
+    write_field_descriptors();
+}
+
+void DivergenceProcessor::processing_function(const std::shared_ptr<Buffer>& buffer)
+{
+    if (m_volume && are_descriptors_ready()) {
+        write_field_descriptors();
+    }
+
+    ComputeProcessor::processing_function(buffer);
+}
+
+bool DivergenceProcessor::on_before_execute(
+    Portal::Graphics::CommandBufferID /*cmd_id*/,
+    const std::shared_ptr<VKBuffer>& buffer)
+{
+    return m_volume && std::dynamic_pointer_cast<VolumeGridBuffer>(buffer) != nullptr;
+}
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/DivergenceProcessor.cpp
+++ b/src/MayaFlux/Buffers/State/DivergenceProcessor.cpp
@@ -1,136 +1,34 @@
 #include "DivergenceProcessor.hpp"
-#include "VolumeGridBuffer.hpp"
 
 namespace MayaFlux::Buffers {
 
-namespace {
-    constexpr uint32_t k_workgroup_x = 8;
-    constexpr uint32_t k_workgroup_y = 8;
-    constexpr uint32_t k_workgroup_z = 4;
+std::vector<VolumeFieldProcessor::FieldBinding> DivergenceProcessor::make_bindings(
+    const std::string& velocity_field, const std::string& divergence_field)
+{
+    return {
+        { .name = "velocity_in", .binding = 0, .field = velocity_field, .access = FieldAccess::READ },
+        { .name = "divergence_out", .binding = 1, .field = divergence_field, .access = FieldAccess::WRITE },
+    };
 }
 
 DivergenceProcessor::DivergenceProcessor(
     std::string velocity_field,
     std::string divergence_field,
     const std::string& shader_path)
-    : ComputeProcessor(shader_path, k_workgroup_x)
+    : VolumeFieldProcessor(make_bindings(velocity_field, divergence_field), shader_path)
     , m_velocity_field(std::move(velocity_field))
     , m_divergence_field(std::move(divergence_field))
 {
-    m_config.bindings["velocity_in"] = ShaderBinding(0, 0, vk::DescriptorType::eStorageBuffer);
-    m_config.bindings["divergence_out"] = ShaderBinding(0, 1, vk::DescriptorType::eStorageBuffer);
 }
 
 DivergenceProcessor::DivergenceProcessor(
     std::string velocity_field,
     std::string divergence_field,
     const Portal::Graphics::ShaderSpec& spec)
-    : ComputeProcessor(spec)
+    : VolumeFieldProcessor(make_bindings(velocity_field, divergence_field), spec)
     , m_velocity_field(std::move(velocity_field))
     , m_divergence_field(std::move(divergence_field))
 {
-    m_config.bindings["velocity_in"] = ShaderBinding(0, 0, vk::DescriptorType::eStorageBuffer);
-    m_config.bindings["divergence_out"] = ShaderBinding(0, 1, vk::DescriptorType::eStorageBuffer);
-}
-
-void DivergenceProcessor::on_attach(const std::shared_ptr<Buffer>& buffer)
-{
-    ComputeProcessor::on_attach(buffer);
-
-    m_volume = std::dynamic_pointer_cast<VolumeGridBuffer>(buffer);
-    if (!m_volume) {
-        return;
-    }
-
-    if (!m_volume->has_field(m_velocity_field)) {
-        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
-            "DivergenceProcessor: volume has no field '{}'", m_velocity_field);
-        m_volume.reset();
-        return;
-    }
-
-    if (!m_volume->has_field(m_divergence_field)) {
-        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
-            "DivergenceProcessor: volume has no field '{}'", m_divergence_field);
-        m_volume.reset();
-        return;
-    }
-
-    set_workgroup_size(k_workgroup_x, k_workgroup_y, k_workgroup_z);
-    set_dispatch_mode(ShaderDispatchConfig::DispatchMode::MANUAL);
-    set_manual_dispatch(
-        (m_volume->get_width() + k_workgroup_x - 1) / k_workgroup_x,
-        (m_volume->get_height() + k_workgroup_y - 1) / k_workgroup_y,
-        (m_volume->get_depth() + k_workgroup_z - 1) / k_workgroup_z);
-
-    write_params();
-}
-
-void DivergenceProcessor::write_params()
-{
-    if (m_config.push_constant_size < sizeof(DivergenceParams)) {
-        set_push_constant_size(sizeof(DivergenceParams));
-    }
-
-    auto& data = get_push_constant_data();
-    if (data.size() < m_config.push_constant_size) {
-        data.resize(m_config.push_constant_size);
-    }
-
-    const glm::vec3 cell = m_volume->get_cell_size();
-
-    const DivergenceParams params {
-        .width = m_volume->get_width(),
-        .height = m_volume->get_height(),
-        .depth = m_volume->get_depth(),
-        .pad0 = 0,
-        .cell_size_x = cell.x,
-        .cell_size_y = cell.y,
-        .cell_size_z = cell.z,
-        .pad1 = 0.0F,
-    };
-
-    std::memcpy(data.data(), &params, sizeof(DivergenceParams));
-}
-
-void DivergenceProcessor::write_field_descriptors()
-{
-    if (!m_volume || m_descriptor_set_ids.empty()) {
-        return;
-    }
-
-    auto& foundry = Portal::Graphics::get_shader_foundry();
-
-    foundry.update_descriptor_buffer(
-        m_descriptor_set_ids[0], 0, vk::DescriptorType::eStorageBuffer,
-        m_volume->read_handle(m_velocity_field), 0,
-        m_volume->get_field_bytes(m_velocity_field));
-
-    foundry.update_descriptor_buffer(
-        m_descriptor_set_ids[0], 1, vk::DescriptorType::eStorageBuffer,
-        m_volume->write_handle(m_divergence_field), 0,
-        m_volume->get_field_bytes(m_divergence_field));
-}
-
-void DivergenceProcessor::on_descriptors_created()
-{
-    write_field_descriptors();
-}
-
-void DivergenceProcessor::processing_function(const std::shared_ptr<Buffer>& buffer)
-{
-    if (m_volume && are_descriptors_ready()) {
-        write_field_descriptors();
-    }
-
-    ComputeProcessor::processing_function(buffer);
-}
-
-bool DivergenceProcessor::on_before_execute(
-    Portal::Graphics::CommandBufferID /*cmd_id*/,
-    const std::shared_ptr<VKBuffer>& buffer)
-{
-    return m_volume && std::dynamic_pointer_cast<VolumeGridBuffer>(buffer) != nullptr;
 }
 
 } // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/DivergenceProcessor.hpp
+++ b/src/MayaFlux/Buffers/State/DivergenceProcessor.hpp
@@ -1,52 +1,30 @@
 #pragma once
 
-#include "MayaFlux/Buffers/Shaders/ComputeProcessor.hpp"
+#include "VolumeFieldProcessor.hpp"
 
 namespace MayaFlux::Buffers {
 
-class VolumeGridBuffer;
-
 /**
  * @class DivergenceProcessor
- * @brief ComputeProcessor computing the divergence of a VolumeGridBuffer's
- *        velocity field into a scalar field of the same volume.
+ * @brief VolumeFieldProcessor computing the divergence of a vector field
+ *        into a scalar field by central differences.
  *
  * Central differences on the six axis neighbours, clamped at the lattice
- * boundary. The result is the right-hand side of the pressure Poisson
- * equation, consumed by the pressure solve that follows.
+ * boundary, which gives boundary cells a one-sided estimate. The result
+ * is the right-hand side of the pressure Poisson equation, and read
+ * directly it is also the residual probe for a completed incompressible
+ * chain.
  *
- * The target field is expected to be single-buffered: it is fully
- * rewritten every cycle from the velocity field alone, so no history is
- * carried and no slot swap occurs. Declaring it double-buffered is not an
- * error, but the write slot would then be read by nothing.
+ * The output field is written but never read by this stage, so it may be
+ * single-buffered and is not swapped.
  *
- * Descriptor bindings are written directly via
- * ShaderFoundry::update_descriptor_buffer, since VolumeGridBuffer's field
- * storage consists of raw handle pairs with no VKBuffer wrapper. The
- * write happens in processing_function, before execute_shader binds the
- * descriptor set into the command buffer.
+ * The collocated stencil decouples odd and even cells in principle. If
+ * high-frequency noise appears in the downstream pressure field, the fix
+ * is a staggered velocity layout, which changes indexing rather than
+ * class structure.
  */
-class MAYAFLUX_API DivergenceProcessor : public ComputeProcessor {
+class MAYAFLUX_API DivergenceProcessor : public VolumeFieldProcessor {
 public:
-    /**
-     * @struct DivergenceParams
-     * @brief Push constant block the divergence shader receives.
-     *
-     * Lattice dimensions occupy the leading fields, matching the
-     * convention AdvectProcessor::AdvectParams establishes for volume
-     * stages. Explicit padding keeps the block 16-byte aligned.
-     */
-    struct DivergenceParams {
-        uint32_t width;
-        uint32_t height;
-        uint32_t depth;
-        uint32_t pad0;
-        float cell_size_x;
-        float cell_size_y;
-        float cell_size_z;
-        float pad1;
-    };
-
     /**
      * @brief Construct a divergence stage.
      * @param velocity_field Name of the field differentiated. Must have
@@ -77,54 +55,18 @@ public:
     /** @brief Name of the field this stage writes. */
     [[nodiscard]] const std::string& get_divergence_field() const { return m_divergence_field; }
 
-protected:
-    /**
-     * @brief Size the dispatch to the lattice and write the parameter
-     *        block, once the attached volume's dimensions are known.
-     * @param buffer The attached buffer, expected to be a VolumeGridBuffer.
-     */
-    void on_attach(const std::shared_ptr<Buffer>& buffer) override;
-
-    /**
-     * @brief Write the two field descriptors for the current slot
-     *        assignment.
-     */
-    void on_descriptors_created() override;
-
-    /**
-     * @brief Reject buffers that are not VolumeGridBuffer.
-     * @param cmd_id Command buffer this cycle's dispatch will be recorded into.
-     * @param buffer The attached buffer, received as VKBuffer.
-     * @return True if the attached buffer is a VolumeGridBuffer.
-     */
-    bool on_before_execute(Portal::Graphics::CommandBufferID cmd_id, const std::shared_ptr<VKBuffer>& buffer) override;
-
-    /**
-     * @brief Write the field descriptors for this cycle's slot assignment,
-     *        then run the normal shader processing path.
-     *
-     * The velocity field's read slot changes whenever an upstream stage
-     * swaps it, so the binding is rewritten every cycle rather than once.
-     */
-    void processing_function(const std::shared_ptr<Buffer>& buffer) override;
-
 private:
     /**
-     * @brief Issue direct ShaderFoundry descriptor writes for the velocity
-     *        read slot and the divergence write slot.
+     * @brief Build the binding table for the two field names.
+     * @param velocity_field Field differentiated.
+     * @param divergence_field Field written.
+     * @return Table binding velocity read and divergence write.
      */
-    void write_field_descriptors();
-
-    /**
-     * @brief Size the push constant block to at least DivergenceParams and
-     *        write the attached volume's lattice dimensions and cell size.
-     */
-    void write_params();
+    static std::vector<FieldBinding> make_bindings(
+        const std::string& velocity_field, const std::string& divergence_field);
 
     std::string m_velocity_field;
     std::string m_divergence_field;
-
-    std::shared_ptr<VolumeGridBuffer> m_volume; ///< The attached volume, cached for descriptor writes.
 };
 
 } // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/DivergenceProcessor.hpp
+++ b/src/MayaFlux/Buffers/State/DivergenceProcessor.hpp
@@ -1,0 +1,130 @@
+#pragma once
+
+#include "MayaFlux/Buffers/Shaders/ComputeProcessor.hpp"
+
+namespace MayaFlux::Buffers {
+
+class VolumeGridBuffer;
+
+/**
+ * @class DivergenceProcessor
+ * @brief ComputeProcessor computing the divergence of a VolumeGridBuffer's
+ *        velocity field into a scalar field of the same volume.
+ *
+ * Central differences on the six axis neighbours, clamped at the lattice
+ * boundary. The result is the right-hand side of the pressure Poisson
+ * equation, consumed by the pressure solve that follows.
+ *
+ * The target field is expected to be single-buffered: it is fully
+ * rewritten every cycle from the velocity field alone, so no history is
+ * carried and no slot swap occurs. Declaring it double-buffered is not an
+ * error, but the write slot would then be read by nothing.
+ *
+ * Descriptor bindings are written directly via
+ * ShaderFoundry::update_descriptor_buffer, since VolumeGridBuffer's field
+ * storage consists of raw handle pairs with no VKBuffer wrapper. The
+ * write happens in processing_function, before execute_shader binds the
+ * descriptor set into the command buffer.
+ */
+class MAYAFLUX_API DivergenceProcessor : public ComputeProcessor {
+public:
+    /**
+     * @struct DivergenceParams
+     * @brief Push constant block the divergence shader receives.
+     *
+     * Lattice dimensions occupy the leading fields, matching the
+     * convention AdvectProcessor::AdvectParams establishes for volume
+     * stages. Explicit padding keeps the block 16-byte aligned.
+     */
+    struct DivergenceParams {
+        uint32_t width;
+        uint32_t height;
+        uint32_t depth;
+        uint32_t pad0;
+        float cell_size_x;
+        float cell_size_y;
+        float cell_size_z;
+        float pad1;
+    };
+
+    /**
+     * @brief Construct a divergence stage.
+     * @param velocity_field Name of the field differentiated. Must have
+     *        stride sizeof(glm::vec4).
+     * @param divergence_field Name of the scalar field written. Must have
+     *        stride sizeof(float).
+     * @param shader_path Path to the compute shader.
+     */
+    DivergenceProcessor(
+        std::string velocity_field,
+        std::string divergence_field,
+        const std::string& shader_path);
+
+    /**
+     * @brief Construct a divergence stage from a generated ShaderSpec.
+     * @param velocity_field Name of the field differentiated.
+     * @param divergence_field Name of the scalar field written.
+     * @param spec ShaderSpec implementing the stencil.
+     */
+    DivergenceProcessor(
+        std::string velocity_field,
+        std::string divergence_field,
+        const Portal::Graphics::ShaderSpec& spec);
+
+    /** @brief Name of the field this stage differentiates. */
+    [[nodiscard]] const std::string& get_velocity_field() const { return m_velocity_field; }
+
+    /** @brief Name of the field this stage writes. */
+    [[nodiscard]] const std::string& get_divergence_field() const { return m_divergence_field; }
+
+protected:
+    /**
+     * @brief Size the dispatch to the lattice and write the parameter
+     *        block, once the attached volume's dimensions are known.
+     * @param buffer The attached buffer, expected to be a VolumeGridBuffer.
+     */
+    void on_attach(const std::shared_ptr<Buffer>& buffer) override;
+
+    /**
+     * @brief Write the two field descriptors for the current slot
+     *        assignment.
+     */
+    void on_descriptors_created() override;
+
+    /**
+     * @brief Reject buffers that are not VolumeGridBuffer.
+     * @param cmd_id Command buffer this cycle's dispatch will be recorded into.
+     * @param buffer The attached buffer, received as VKBuffer.
+     * @return True if the attached buffer is a VolumeGridBuffer.
+     */
+    bool on_before_execute(Portal::Graphics::CommandBufferID cmd_id, const std::shared_ptr<VKBuffer>& buffer) override;
+
+    /**
+     * @brief Write the field descriptors for this cycle's slot assignment,
+     *        then run the normal shader processing path.
+     *
+     * The velocity field's read slot changes whenever an upstream stage
+     * swaps it, so the binding is rewritten every cycle rather than once.
+     */
+    void processing_function(const std::shared_ptr<Buffer>& buffer) override;
+
+private:
+    /**
+     * @brief Issue direct ShaderFoundry descriptor writes for the velocity
+     *        read slot and the divergence write slot.
+     */
+    void write_field_descriptors();
+
+    /**
+     * @brief Size the push constant block to at least DivergenceParams and
+     *        write the attached volume's lattice dimensions and cell size.
+     */
+    void write_params();
+
+    std::string m_velocity_field;
+    std::string m_divergence_field;
+
+    std::shared_ptr<VolumeGridBuffer> m_volume; ///< The attached volume, cached for descriptor writes.
+};
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/InfluxProcessor.cpp
+++ b/src/MayaFlux/Buffers/State/InfluxProcessor.cpp
@@ -1,0 +1,147 @@
+#include "InfluxProcessor.hpp"
+
+#include "VolumeGridBuffer.hpp"
+
+namespace MayaFlux::Buffers {
+
+namespace {
+    constexpr size_t k_tail_offset = 32;
+    constexpr size_t k_param_size = 80;
+
+    /**
+     * @struct InfluxTail
+     * @brief The parameter words past the shared lattice prefix.
+     */
+    struct InfluxTail {
+        float center_x;
+        float center_y;
+        float center_z;
+        float radius;
+        float rate;
+        float time_step;
+        float falloff;
+        float pad1;
+        float bounds_min_x;
+        float bounds_min_y;
+        float bounds_min_z;
+        float pad2;
+    };
+
+    static_assert(k_tail_offset + sizeof(InfluxTail) == k_param_size);
+}
+
+std::vector<VolumeFieldProcessor::FieldBinding> InfluxProcessor::make_bindings(
+    const std::string& field)
+{
+    return {
+        { .name = "field_in", .binding = 0, .field = field, .access = FieldAccess::READ },
+        { .name = "field_out", .binding = 1, .field = field, .access = FieldAccess::WRITE },
+    };
+}
+
+InfluxProcessor::InfluxProcessor(std::string field, const std::string& shader_path)
+    : VolumeFieldProcessor(make_bindings(field), shader_path)
+    , m_field(std::move(field))
+{
+    add_swap_field(m_field);
+}
+
+InfluxProcessor::InfluxProcessor(std::string field, const Portal::Graphics::ShaderSpec& spec)
+    : VolumeFieldProcessor(make_bindings(field), spec)
+    , m_field(std::move(field))
+{
+    add_swap_field(m_field);
+}
+
+void InfluxProcessor::on_volume_ready()
+{
+    reserve_param_size(k_param_size);
+    write_lattice_params();
+    write_tail();
+}
+
+void InfluxProcessor::write_tail()
+{
+    write_lattice_word7(m_elapsed);
+
+    const glm::vec3 lo = get_volume()
+        ? get_volume()->get_lattice().bounds.min
+        : glm::vec3(0.0F);
+
+    const InfluxTail tail {
+        .center_x = m_center.x,
+        .center_y = m_center.y,
+        .center_z = m_center.z,
+        .radius = m_radius,
+        .rate = m_rate,
+        .time_step = m_time_step,
+        .falloff = m_falloff,
+        .pad1 = 0.0F,
+        .bounds_min_x = lo.x,
+        .bounds_min_y = lo.y,
+        .bounds_min_z = lo.z,
+        .pad2 = 0.0F,
+    };
+
+    write_param_tail(k_tail_offset, &tail, sizeof(tail));
+}
+
+void InfluxProcessor::processing_function(const std::shared_ptr<Buffer>& buffer)
+{
+    if (get_volume()) {
+        m_elapsed += m_time_step;
+        write_lattice_word7(m_elapsed);
+    }
+
+    VolumeFieldProcessor::processing_function(buffer);
+}
+
+void InfluxProcessor::restart()
+{
+    m_elapsed = 0.0F;
+    if (get_volume()) {
+        write_lattice_word7(m_elapsed);
+    }
+}
+
+void InfluxProcessor::set_center(const glm::vec3& center)
+{
+    m_center = center;
+    if (get_volume()) {
+        write_tail();
+    }
+}
+
+void InfluxProcessor::set_radius(float radius)
+{
+    m_radius = radius;
+    if (get_volume()) {
+        write_tail();
+    }
+}
+
+void InfluxProcessor::set_rate(float rate)
+{
+    m_rate = rate;
+    if (get_volume()) {
+        write_tail();
+    }
+}
+
+void InfluxProcessor::set_time_step(float dt)
+{
+    m_time_step = dt;
+    if (get_volume()) {
+        write_tail();
+    }
+}
+
+void InfluxProcessor::set_falloff(float falloff)
+{
+    m_falloff = falloff;
+    if (get_volume()) {
+        write_tail();
+    }
+}
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/InfluxProcessor.hpp
+++ b/src/MayaFlux/Buffers/State/InfluxProcessor.hpp
@@ -1,0 +1,158 @@
+#pragma once
+
+#include "VolumeFieldProcessor.hpp"
+
+namespace MayaFlux::Buffers {
+
+/**
+ * @class InfluxProcessor
+ * @brief VolumeFieldProcessor adding a shaped contribution into a field
+ *        every cycle.
+ *
+ * The shape lives in the shader. Each concrete shader defines
+ * `float shape(vec3 p, float t)` over world position and elapsed time,
+ * includes volume_influx.glsl for the parameter block and the dispatch,
+ * and is selected by constructor argument. There is no mode word.
+ *
+ * Every cell adds shape * rate * time_step into the field. Nothing here
+ * removes anything: a chain with an influx stage and dissipation of
+ * exactly one grows without bound. Rate and the carrier's dissipation are
+ * a pair and want setting together.
+ *
+ * Elapsed time advances by time_step each cycle and is passed to the
+ * shape function, so a shader can vary its own geometry over time without
+ * the caller driving it. Time is the shared prefix's trailing word.
+ *
+ * Parameter offsets past the prefix, for feed():
+ *   32 center x, 36 center y, 40 center z, 44 radius,
+ *   48 rate, 52 time step, 56 falloff.
+ * The three bounds words at 64 are lattice-derived and not feedable.
+ */
+class MAYAFLUX_API InfluxProcessor : public VolumeFieldProcessor {
+public:
+    /**
+     * @struct InfluxParams
+     * @brief Push constant block the influx shaders receive.
+     *
+     * The leading eight words are the shared lattice prefix, written by
+     * the base. This declaration fixes the offsets of everything after.
+     */
+    struct InfluxParams {
+        uint32_t width;
+        uint32_t height;
+        uint32_t depth;
+        uint32_t pad0;
+        float cell_size_x;
+        float cell_size_y;
+        float cell_size_z;
+        float elapsed;
+        float center_x;
+        float center_y;
+        float center_z;
+        float radius;
+        float rate;
+        float time_step;
+        float falloff;
+        float pad1;
+        float bounds_min_x;
+        float bounds_min_y;
+        float bounds_min_z;
+        float pad2;
+    };
+
+    static_assert(sizeof(InfluxParams) == 80);
+    static_assert(sizeof(InfluxParams) % 16 == 0);
+
+    /**
+     * @brief Construct an influx stage.
+     * @param field Name of the field added into. Must be double-buffered.
+     *        Stride may be sizeof(float) or sizeof(glm::vec4) depending on
+     *        which shader is supplied.
+     * @param shader_path Path to a shader defining shape().
+     */
+    InfluxProcessor(std::string field, const std::string& shader_path);
+
+    /**
+     * @brief Construct an influx stage from a generated ShaderSpec.
+     * @param field Name of the field added into.
+     * @param spec ShaderSpec defining shape() and including the dispatch.
+     */
+    InfluxProcessor(std::string field, const Portal::Graphics::ShaderSpec& spec);
+
+    /**
+     * @brief Set the shape's world-space centre.
+     * @param center Position. Interpretation is the shader's.
+     */
+    void set_center(const glm::vec3& center);
+
+    /**
+     * @brief Set the shape's characteristic size.
+     * @param radius World units. Interpretation is the shader's.
+     */
+    void set_radius(float radius);
+
+    /**
+     * @brief Set the amount added per unit time at shape value one.
+     * @param rate Multiplier. Zero disables the stage without removing it.
+     */
+    void set_rate(float rate);
+
+    /**
+     * @brief Set the integration step. Match the advection stage's step.
+     * @param dt Seconds per cycle. Also the increment applied to elapsed time.
+     */
+    void set_time_step(float dt);
+
+    /**
+     * @brief Set the shape's edge softness.
+     * @param falloff Interpretation is the shader's. Zero is a hard edge
+     *        in shaders that honour it.
+     */
+    void set_falloff(float falloff);
+
+    /**
+     * @brief Reset elapsed time to zero.
+     *
+     * Restarts any time-varying geometry the shader implements. Does not
+     * touch the field.
+     */
+    void restart();
+
+    /** @brief Seconds since construction or the last restart. */
+    [[nodiscard]] float get_elapsed() const { return m_elapsed; }
+
+    /** @brief Name of the field added into. */
+    [[nodiscard]] const std::string& get_field() const { return m_field; }
+
+    void processing_function(const std::shared_ptr<Buffer>& buffer) override;
+
+protected:
+    /**
+     * @brief Raise the parameter block and write everything past the prefix.
+     */
+    void on_volume_ready() override;
+
+private:
+    /**
+     * @brief Build the binding table for the field name.
+     * @param field Field bound in both slots.
+     * @return Table binding the read slot and the write slot.
+     */
+    static std::vector<FieldBinding> make_bindings(const std::string& field);
+
+    /**
+     * @brief Write every parameter past the shared prefix.
+     */
+    void write_tail();
+
+    std::string m_field;
+
+    glm::vec3 m_center { 0.0F };
+    float m_radius { 0.15F };
+    float m_rate { 1.0F };
+    float m_time_step { 1.0F / 60.0F };
+    float m_falloff { 1.0F };
+    float m_elapsed { 0.0F };
+};
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/PressureProcessor.cpp
+++ b/src/MayaFlux/Buffers/State/PressureProcessor.cpp
@@ -1,0 +1,201 @@
+#include "PressureProcessor.hpp"
+#include "VolumeGridBuffer.hpp"
+
+namespace MayaFlux::Buffers {
+
+namespace {
+    constexpr uint32_t k_workgroup_x = 8;
+    constexpr uint32_t k_workgroup_y = 8;
+    constexpr uint32_t k_workgroup_z = 4;
+    constexpr size_t k_parity_offset = offsetof(PressureProcessor::PressureParams, parity);
+}
+
+PressureProcessor::PressureProcessor(
+    std::string divergence_field,
+    std::string pressure_field,
+    const std::string& shader_path,
+    uint32_t iterations)
+    : ComputeProcessor(shader_path, k_workgroup_x)
+    , m_divergence_field(std::move(divergence_field))
+    , m_pressure_field(std::move(pressure_field))
+{
+    m_config.bindings["divergence_in"] = ShaderBinding(0, 0, vk::DescriptorType::eStorageBuffer);
+    m_config.bindings["pressure_a"] = ShaderBinding(0, 1, vk::DescriptorType::eStorageBuffer);
+    m_config.bindings["pressure_b"] = ShaderBinding(0, 2, vk::DescriptorType::eStorageBuffer);
+
+    set_iteration_count(iterations);
+}
+
+PressureProcessor::PressureProcessor(
+    std::string divergence_field,
+    std::string pressure_field,
+    const Portal::Graphics::ShaderSpec& spec,
+    uint32_t iterations)
+    : ComputeProcessor(spec)
+    , m_divergence_field(std::move(divergence_field))
+    , m_pressure_field(std::move(pressure_field))
+{
+    m_config.bindings["divergence_in"] = ShaderBinding(0, 0, vk::DescriptorType::eStorageBuffer);
+    m_config.bindings["pressure_a"] = ShaderBinding(0, 1, vk::DescriptorType::eStorageBuffer);
+    m_config.bindings["pressure_b"] = ShaderBinding(0, 2, vk::DescriptorType::eStorageBuffer);
+
+    set_iteration_count(iterations);
+}
+
+void PressureProcessor::on_attach(const std::shared_ptr<Buffer>& buffer)
+{
+    ComputeProcessor::on_attach(buffer);
+
+    m_volume = std::dynamic_pointer_cast<VolumeGridBuffer>(buffer);
+    if (!m_volume) {
+        return;
+    }
+
+    if (!m_volume->has_field(m_divergence_field)) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "PressureProcessor: volume has no field '{}'", m_divergence_field);
+        m_volume.reset();
+        return;
+    }
+
+    if (!m_volume->has_field(m_pressure_field)) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "PressureProcessor: volume has no field '{}'", m_pressure_field);
+        m_volume.reset();
+        return;
+    }
+
+    if (m_volume->read_handle(m_pressure_field) == m_volume->write_handle(m_pressure_field)) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "PressureProcessor: pressure field '{}' is not double-buffered; "
+            "Jacobi iteration requires two slots",
+            m_pressure_field);
+        m_volume.reset();
+        return;
+    }
+
+    set_workgroup_size(k_workgroup_x, k_workgroup_y, k_workgroup_z);
+    set_dispatch_mode(ShaderDispatchConfig::DispatchMode::MANUAL);
+    set_manual_dispatch(
+        (m_volume->get_width() + k_workgroup_x - 1) / k_workgroup_x,
+        (m_volume->get_height() + k_workgroup_y - 1) / k_workgroup_y,
+        (m_volume->get_depth() + k_workgroup_z - 1) / k_workgroup_z);
+
+    write_params();
+}
+
+void PressureProcessor::write_params()
+{
+    if (m_config.push_constant_size < sizeof(PressureParams)) {
+        set_push_constant_size(sizeof(PressureParams));
+    }
+
+    auto& data = get_push_constant_data();
+    if (data.size() < m_config.push_constant_size) {
+        data.resize(m_config.push_constant_size);
+    }
+
+    const glm::vec3 cell = m_volume->get_cell_size();
+
+    const PressureParams params {
+        .width = m_volume->get_width(),
+        .height = m_volume->get_height(),
+        .depth = m_volume->get_depth(),
+        .parity = 0,
+        .cell_size_x = cell.x,
+        .cell_size_y = cell.y,
+        .cell_size_z = cell.z,
+        .pad0 = 0.0F,
+    };
+
+    std::memcpy(data.data(), &params, sizeof(PressureParams));
+}
+
+void PressureProcessor::write_parity(uint32_t parity)
+{
+    auto& data = get_push_constant_data();
+    if (data.size() < k_parity_offset + sizeof(uint32_t)) {
+        return;
+    }
+
+    std::memcpy(data.data() + k_parity_offset, &parity, sizeof(uint32_t));
+}
+
+void PressureProcessor::write_field_descriptors()
+{
+    if (!m_volume || m_descriptor_set_ids.empty()) {
+        return;
+    }
+
+    auto& foundry = Portal::Graphics::get_shader_foundry();
+    const size_t bytes = m_volume->get_field_bytes(m_pressure_field);
+
+    foundry.update_descriptor_buffer(
+        m_descriptor_set_ids[0], 0, vk::DescriptorType::eStorageBuffer,
+        m_volume->read_handle(m_divergence_field), 0,
+        m_volume->get_field_bytes(m_divergence_field));
+
+    foundry.update_descriptor_buffer(
+        m_descriptor_set_ids[0], 1, vk::DescriptorType::eStorageBuffer,
+        m_volume->read_handle(m_pressure_field), 0, bytes);
+
+    foundry.update_descriptor_buffer(
+        m_descriptor_set_ids[0], 2, vk::DescriptorType::eStorageBuffer,
+        m_volume->write_handle(m_pressure_field), 0, bytes);
+}
+
+void PressureProcessor::on_descriptors_created()
+{
+    write_field_descriptors();
+}
+
+void PressureProcessor::processing_function(const std::shared_ptr<Buffer>& buffer)
+{
+    if (m_volume && are_descriptors_ready()) {
+        write_field_descriptors();
+    }
+
+    ComputeProcessor::processing_function(buffer);
+
+    if (m_volume && (get_iteration_count() % 2) == 1) {
+        m_volume->swap_field(m_pressure_field);
+    }
+}
+
+bool PressureProcessor::on_before_execute(
+    Portal::Graphics::CommandBufferID /*cmd_id*/,
+    const std::shared_ptr<VKBuffer>& buffer)
+{
+    return m_volume && std::dynamic_pointer_cast<VolumeGridBuffer>(buffer) != nullptr;
+}
+
+bool PressureProcessor::on_iteration(
+    Portal::Graphics::CommandBufferID /*cmd_id*/,
+    const std::shared_ptr<VKBuffer>& /*buffer*/,
+    uint32_t index)
+{
+    write_parity(index % 2);
+    return true;
+}
+
+void PressureProcessor::on_iteration_barrier(
+    Portal::Graphics::CommandBufferID cmd_id,
+    const std::shared_ptr<VKBuffer>& /*buffer*/,
+    uint32_t /*index*/)
+{
+    if (!m_volume) {
+        return;
+    }
+
+    auto& foundry = Portal::Graphics::get_shader_foundry();
+    const size_t bytes = m_volume->get_field_bytes(m_pressure_field);
+
+    const auto src = vk::AccessFlagBits::eShaderWrite;
+    const auto dst = vk::AccessFlagBits::eShaderRead | vk::AccessFlagBits::eShaderWrite;
+    const auto stage = vk::PipelineStageFlagBits::eComputeShader;
+
+    foundry.buffer_barrier(cmd_id, m_volume->read_handle(m_pressure_field), src, dst, stage, stage);
+    foundry.buffer_barrier(cmd_id, m_volume->write_handle(m_pressure_field), src, dst, stage, stage);
+}
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/PressureProcessor.cpp
+++ b/src/MayaFlux/Buffers/State/PressureProcessor.cpp
@@ -3,11 +3,14 @@
 
 namespace MayaFlux::Buffers {
 
-namespace {
-    constexpr uint32_t k_workgroup_x = 8;
-    constexpr uint32_t k_workgroup_y = 8;
-    constexpr uint32_t k_workgroup_z = 4;
-    constexpr size_t k_parity_offset = offsetof(PressureProcessor::PressureParams, parity);
+std::vector<VolumeFieldProcessor::FieldBinding> PressureProcessor::make_bindings(
+    const std::string& divergence_field, const std::string& pressure_field)
+{
+    return {
+        { .name = "divergence_in", .binding = 0, .field = divergence_field, .access = FieldAccess::READ },
+        { .name = "pressure_a", .binding = 1, .field = pressure_field, .access = FieldAccess::READ },
+        { .name = "pressure_b", .binding = 2, .field = pressure_field, .access = FieldAccess::WRITE },
+    };
 }
 
 PressureProcessor::PressureProcessor(
@@ -15,14 +18,11 @@ PressureProcessor::PressureProcessor(
     std::string pressure_field,
     const std::string& shader_path,
     uint32_t iterations)
-    : ComputeProcessor(shader_path, k_workgroup_x)
+    : VolumeFieldProcessor(make_bindings(divergence_field, pressure_field), shader_path)
     , m_divergence_field(std::move(divergence_field))
     , m_pressure_field(std::move(pressure_field))
 {
-    m_config.bindings["divergence_in"] = ShaderBinding(0, 0, vk::DescriptorType::eStorageBuffer);
-    m_config.bindings["pressure_a"] = ShaderBinding(0, 1, vk::DescriptorType::eStorageBuffer);
-    m_config.bindings["pressure_b"] = ShaderBinding(0, 2, vk::DescriptorType::eStorageBuffer);
-
+    add_swap_field(m_pressure_field);
     set_iteration_count(iterations);
 }
 
@@ -31,142 +31,17 @@ PressureProcessor::PressureProcessor(
     std::string pressure_field,
     const Portal::Graphics::ShaderSpec& spec,
     uint32_t iterations)
-    : ComputeProcessor(spec)
+    : VolumeFieldProcessor(make_bindings(divergence_field, pressure_field), spec)
     , m_divergence_field(std::move(divergence_field))
     , m_pressure_field(std::move(pressure_field))
 {
-    m_config.bindings["divergence_in"] = ShaderBinding(0, 0, vk::DescriptorType::eStorageBuffer);
-    m_config.bindings["pressure_a"] = ShaderBinding(0, 1, vk::DescriptorType::eStorageBuffer);
-    m_config.bindings["pressure_b"] = ShaderBinding(0, 2, vk::DescriptorType::eStorageBuffer);
-
+    add_swap_field(m_pressure_field);
     set_iteration_count(iterations);
 }
 
-void PressureProcessor::on_attach(const std::shared_ptr<Buffer>& buffer)
+bool PressureProcessor::wants_swap() const
 {
-    ComputeProcessor::on_attach(buffer);
-
-    m_volume = std::dynamic_pointer_cast<VolumeGridBuffer>(buffer);
-    if (!m_volume) {
-        return;
-    }
-
-    if (!m_volume->has_field(m_divergence_field)) {
-        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
-            "PressureProcessor: volume has no field '{}'", m_divergence_field);
-        m_volume.reset();
-        return;
-    }
-
-    if (!m_volume->has_field(m_pressure_field)) {
-        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
-            "PressureProcessor: volume has no field '{}'", m_pressure_field);
-        m_volume.reset();
-        return;
-    }
-
-    if (m_volume->read_handle(m_pressure_field) == m_volume->write_handle(m_pressure_field)) {
-        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
-            "PressureProcessor: pressure field '{}' is not double-buffered; "
-            "Jacobi iteration requires two slots",
-            m_pressure_field);
-        m_volume.reset();
-        return;
-    }
-
-    set_workgroup_size(k_workgroup_x, k_workgroup_y, k_workgroup_z);
-    set_dispatch_mode(ShaderDispatchConfig::DispatchMode::MANUAL);
-    set_manual_dispatch(
-        (m_volume->get_width() + k_workgroup_x - 1) / k_workgroup_x,
-        (m_volume->get_height() + k_workgroup_y - 1) / k_workgroup_y,
-        (m_volume->get_depth() + k_workgroup_z - 1) / k_workgroup_z);
-
-    write_params();
-}
-
-void PressureProcessor::write_params()
-{
-    if (m_config.push_constant_size < sizeof(PressureParams)) {
-        set_push_constant_size(sizeof(PressureParams));
-    }
-
-    auto& data = get_push_constant_data();
-    if (data.size() < m_config.push_constant_size) {
-        data.resize(m_config.push_constant_size);
-    }
-
-    const glm::vec3 cell = m_volume->get_cell_size();
-
-    const PressureParams params {
-        .width = m_volume->get_width(),
-        .height = m_volume->get_height(),
-        .depth = m_volume->get_depth(),
-        .parity = 0,
-        .cell_size_x = cell.x,
-        .cell_size_y = cell.y,
-        .cell_size_z = cell.z,
-        .pad0 = 0.0F,
-    };
-
-    std::memcpy(data.data(), &params, sizeof(PressureParams));
-}
-
-void PressureProcessor::write_parity(uint32_t parity)
-{
-    auto& data = get_push_constant_data();
-    if (data.size() < k_parity_offset + sizeof(uint32_t)) {
-        return;
-    }
-
-    std::memcpy(data.data() + k_parity_offset, &parity, sizeof(uint32_t));
-}
-
-void PressureProcessor::write_field_descriptors()
-{
-    if (!m_volume || m_descriptor_set_ids.empty()) {
-        return;
-    }
-
-    auto& foundry = Portal::Graphics::get_shader_foundry();
-    const size_t bytes = m_volume->get_field_bytes(m_pressure_field);
-
-    foundry.update_descriptor_buffer(
-        m_descriptor_set_ids[0], 0, vk::DescriptorType::eStorageBuffer,
-        m_volume->read_handle(m_divergence_field), 0,
-        m_volume->get_field_bytes(m_divergence_field));
-
-    foundry.update_descriptor_buffer(
-        m_descriptor_set_ids[0], 1, vk::DescriptorType::eStorageBuffer,
-        m_volume->read_handle(m_pressure_field), 0, bytes);
-
-    foundry.update_descriptor_buffer(
-        m_descriptor_set_ids[0], 2, vk::DescriptorType::eStorageBuffer,
-        m_volume->write_handle(m_pressure_field), 0, bytes);
-}
-
-void PressureProcessor::on_descriptors_created()
-{
-    write_field_descriptors();
-}
-
-void PressureProcessor::processing_function(const std::shared_ptr<Buffer>& buffer)
-{
-    if (m_volume && are_descriptors_ready()) {
-        write_field_descriptors();
-    }
-
-    ComputeProcessor::processing_function(buffer);
-
-    if (m_volume && (get_iteration_count() % 2) == 1) {
-        m_volume->swap_field(m_pressure_field);
-    }
-}
-
-bool PressureProcessor::on_before_execute(
-    Portal::Graphics::CommandBufferID /*cmd_id*/,
-    const std::shared_ptr<VKBuffer>& buffer)
-{
-    return m_volume && std::dynamic_pointer_cast<VolumeGridBuffer>(buffer) != nullptr;
+    return (get_iteration_count() % 2) == 1;
 }
 
 bool PressureProcessor::on_iteration(
@@ -174,7 +49,7 @@ bool PressureProcessor::on_iteration(
     const std::shared_ptr<VKBuffer>& /*buffer*/,
     uint32_t index)
 {
-    write_parity(index % 2);
+    write_lattice_word3(index % 2);
     return true;
 }
 
@@ -183,19 +58,19 @@ void PressureProcessor::on_iteration_barrier(
     const std::shared_ptr<VKBuffer>& /*buffer*/,
     uint32_t /*index*/)
 {
-    if (!m_volume) {
+    const auto& volume = get_volume();
+    if (!volume) {
         return;
     }
 
     auto& foundry = Portal::Graphics::get_shader_foundry();
-    const size_t bytes = m_volume->get_field_bytes(m_pressure_field);
 
     const auto src = vk::AccessFlagBits::eShaderWrite;
     const auto dst = vk::AccessFlagBits::eShaderRead | vk::AccessFlagBits::eShaderWrite;
     const auto stage = vk::PipelineStageFlagBits::eComputeShader;
 
-    foundry.buffer_barrier(cmd_id, m_volume->read_handle(m_pressure_field), src, dst, stage, stage);
-    foundry.buffer_barrier(cmd_id, m_volume->write_handle(m_pressure_field), src, dst, stage, stage);
+    foundry.buffer_barrier(cmd_id, volume->read_handle(m_pressure_field), src, dst, stage, stage);
+    foundry.buffer_barrier(cmd_id, volume->write_handle(m_pressure_field), src, dst, stage, stage);
 }
 
 } // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/PressureProcessor.hpp
+++ b/src/MayaFlux/Buffers/State/PressureProcessor.hpp
@@ -1,56 +1,32 @@
 #pragma once
 
-#include "MayaFlux/Buffers/Shaders/ComputeProcessor.hpp"
+#include "VolumeFieldProcessor.hpp"
 
 namespace MayaFlux::Buffers {
 
-class VolumeGridBuffer;
-
 /**
  * @class PressureProcessor
- * @brief ComputeProcessor solving the pressure Poisson equation over a
- *        VolumeGridBuffer by Jacobi iteration.
+ * @brief VolumeFieldProcessor solving the pressure Poisson equation by
+ *        Jacobi iteration.
  *
  * Records every iteration into one command buffer via
- * ComputeProcessor::iteration_count, so a sixty-pass solve costs one
- * submission rather than sixty. Between consecutive passes a
+ * ComputeProcessor::iteration_count, so a forty-pass solve costs one
+ * submission rather than forty. Between consecutive passes a
  * compute-to-compute barrier is issued on both pressure slots, since the
  * attached volume's own handle is not what the passes touch.
  *
  * Both pressure slots are bound simultaneously rather than ping-ponged
  * through descriptor updates: a descriptor set bound into an open command
  * buffer cannot be rewritten mid-recording. Which slot a pass reads and
- * which it writes is carried in the parity field of the push constant
- * block, re-pushed before every dispatch.
+ * which it writes is carried in word three of the shared parameter
+ * prefix, re-pushed before every dispatch.
  *
  * After an odd iteration count the result sits in the slot that started
  * as the write target, so the pressure field is swapped once. After an
- * even count it sits where it started and no swap occurs.
- *
- * The pressure field must be double-buffered. The divergence field is
- * read only and may be single-buffered.
+ * even count it sits where it started and wants_swap returns false.
  */
-class MAYAFLUX_API PressureProcessor : public ComputeProcessor {
+class MAYAFLUX_API PressureProcessor : public VolumeFieldProcessor {
 public:
-    /**
-     * @struct PressureParams
-     * @brief Push constant block the Jacobi shader receives.
-     *
-     * Lattice dimensions occupy the leading fields, matching the
-     * convention AdvectProcessor::AdvectParams establishes for volume
-     * stages, with parity replacing that block's padding word.
-     */
-    struct PressureParams {
-        uint32_t width;
-        uint32_t height;
-        uint32_t depth;
-        uint32_t parity;
-        float cell_size_x;
-        float cell_size_y;
-        float cell_size_z;
-        float pad0;
-    };
-
     /**
      * @brief Construct a pressure solve stage.
      * @param divergence_field Name of the scalar field read as the
@@ -87,28 +63,7 @@ public:
 
 protected:
     /**
-     * @brief Size the dispatch to the lattice and write the parameter
-     *        block, once the attached volume's dimensions are known.
-     * @param buffer The attached buffer, expected to be a VolumeGridBuffer.
-     */
-    void on_attach(const std::shared_ptr<Buffer>& buffer) override;
-
-    /**
-     * @brief Write the three field descriptors for the current slot
-     *        assignment.
-     */
-    void on_descriptors_created() override;
-
-    /**
-     * @brief Reject buffers that are not VolumeGridBuffer.
-     * @param cmd_id Command buffer this cycle's dispatches will be recorded into.
-     * @param buffer The attached buffer, received as VKBuffer.
-     * @return True if the attached buffer is a VolumeGridBuffer.
-     */
-    bool on_before_execute(Portal::Graphics::CommandBufferID cmd_id, const std::shared_ptr<VKBuffer>& buffer) override;
-
-    /**
-     * @brief Write this pass's read/write parity into the push constant block.
+     * @brief Write this pass's read/write parity into the parameter block.
      * @param cmd_id Command buffer being recorded into.
      * @param buffer Buffer under processing.
      * @param index Zero-based iteration index.
@@ -134,39 +89,23 @@ protected:
         uint32_t index) override;
 
     /**
-     * @brief Write the field descriptors for this cycle's slot assignment,
-     *        run the normal shader processing path, then swap the pressure
-     *        field when the iteration count is odd.
-     *
-     * The swap is here rather than in on_after_execute because a slot
-     * exchange is not idempotent and on_after_execute is invoked more than
-     * once per cycle.
+     * @brief Swap only when the pass count leaves the result in the write slot.
+     * @return True when the iteration count is odd.
      */
-    void processing_function(const std::shared_ptr<Buffer>& buffer) override;
+    [[nodiscard]] bool wants_swap() const override;
 
 private:
     /**
-     * @brief Issue direct ShaderFoundry descriptor writes for the
-     *        divergence read slot and both pressure slots.
+     * @brief Build the binding table for the two field names.
+     * @param divergence_field Field read as the right-hand side.
+     * @param pressure_field Field solved, bound in both slots.
+     * @return Table binding divergence read and both pressure slots.
      */
-    void write_field_descriptors();
-
-    /**
-     * @brief Size the push constant block to at least PressureParams and
-     *        write the attached volume's lattice dimensions and cell size.
-     */
-    void write_params();
-
-    /**
-     * @brief Write the parity word of the staged push constant block.
-     * @param parity Zero to read slot A and write slot B, one for the reverse.
-     */
-    void write_parity(uint32_t parity);
+    static std::vector<FieldBinding> make_bindings(
+        const std::string& divergence_field, const std::string& pressure_field);
 
     std::string m_divergence_field;
     std::string m_pressure_field;
-
-    std::shared_ptr<VolumeGridBuffer> m_volume; ///< The attached volume, cached for descriptor writes and the slot swap.
 };
 
 } // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/PressureProcessor.hpp
+++ b/src/MayaFlux/Buffers/State/PressureProcessor.hpp
@@ -1,0 +1,172 @@
+#pragma once
+
+#include "MayaFlux/Buffers/Shaders/ComputeProcessor.hpp"
+
+namespace MayaFlux::Buffers {
+
+class VolumeGridBuffer;
+
+/**
+ * @class PressureProcessor
+ * @brief ComputeProcessor solving the pressure Poisson equation over a
+ *        VolumeGridBuffer by Jacobi iteration.
+ *
+ * Records every iteration into one command buffer via
+ * ComputeProcessor::iteration_count, so a sixty-pass solve costs one
+ * submission rather than sixty. Between consecutive passes a
+ * compute-to-compute barrier is issued on both pressure slots, since the
+ * attached volume's own handle is not what the passes touch.
+ *
+ * Both pressure slots are bound simultaneously rather than ping-ponged
+ * through descriptor updates: a descriptor set bound into an open command
+ * buffer cannot be rewritten mid-recording. Which slot a pass reads and
+ * which it writes is carried in the parity field of the push constant
+ * block, re-pushed before every dispatch.
+ *
+ * After an odd iteration count the result sits in the slot that started
+ * as the write target, so the pressure field is swapped once. After an
+ * even count it sits where it started and no swap occurs.
+ *
+ * The pressure field must be double-buffered. The divergence field is
+ * read only and may be single-buffered.
+ */
+class MAYAFLUX_API PressureProcessor : public ComputeProcessor {
+public:
+    /**
+     * @struct PressureParams
+     * @brief Push constant block the Jacobi shader receives.
+     *
+     * Lattice dimensions occupy the leading fields, matching the
+     * convention AdvectProcessor::AdvectParams establishes for volume
+     * stages, with parity replacing that block's padding word.
+     */
+    struct PressureParams {
+        uint32_t width;
+        uint32_t height;
+        uint32_t depth;
+        uint32_t parity;
+        float cell_size_x;
+        float cell_size_y;
+        float cell_size_z;
+        float pad0;
+    };
+
+    /**
+     * @brief Construct a pressure solve stage.
+     * @param divergence_field Name of the scalar field read as the
+     *        right-hand side. Must have stride sizeof(float).
+     * @param pressure_field Name of the scalar field solved. Must have
+     *        stride sizeof(float) and be double-buffered.
+     * @param shader_path Path to the compute shader.
+     * @param iterations Jacobi passes per cycle. Values below 1 clamp to 1.
+     */
+    PressureProcessor(
+        std::string divergence_field,
+        std::string pressure_field,
+        const std::string& shader_path,
+        uint32_t iterations = 40);
+
+    /**
+     * @brief Construct a pressure solve stage from a generated ShaderSpec.
+     * @param divergence_field Name of the scalar field read.
+     * @param pressure_field Name of the scalar field solved.
+     * @param spec ShaderSpec implementing one Jacobi pass.
+     * @param iterations Jacobi passes per cycle.
+     */
+    PressureProcessor(
+        std::string divergence_field,
+        std::string pressure_field,
+        const Portal::Graphics::ShaderSpec& spec,
+        uint32_t iterations = 40);
+
+    /** @brief Name of the field read as the right-hand side. */
+    [[nodiscard]] const std::string& get_divergence_field() const { return m_divergence_field; }
+
+    /** @brief Name of the field solved. */
+    [[nodiscard]] const std::string& get_pressure_field() const { return m_pressure_field; }
+
+protected:
+    /**
+     * @brief Size the dispatch to the lattice and write the parameter
+     *        block, once the attached volume's dimensions are known.
+     * @param buffer The attached buffer, expected to be a VolumeGridBuffer.
+     */
+    void on_attach(const std::shared_ptr<Buffer>& buffer) override;
+
+    /**
+     * @brief Write the three field descriptors for the current slot
+     *        assignment.
+     */
+    void on_descriptors_created() override;
+
+    /**
+     * @brief Reject buffers that are not VolumeGridBuffer.
+     * @param cmd_id Command buffer this cycle's dispatches will be recorded into.
+     * @param buffer The attached buffer, received as VKBuffer.
+     * @return True if the attached buffer is a VolumeGridBuffer.
+     */
+    bool on_before_execute(Portal::Graphics::CommandBufferID cmd_id, const std::shared_ptr<VKBuffer>& buffer) override;
+
+    /**
+     * @brief Write this pass's read/write parity into the push constant block.
+     * @param cmd_id Command buffer being recorded into.
+     * @param buffer Buffer under processing.
+     * @param index Zero-based iteration index.
+     * @return Always true. Every pass dispatches.
+     */
+    bool on_iteration(
+        Portal::Graphics::CommandBufferID cmd_id,
+        const std::shared_ptr<VKBuffer>& buffer,
+        uint32_t index) override;
+
+    /**
+     * @brief Barrier both pressure slots between consecutive passes.
+     * @param cmd_id Command buffer being recorded into.
+     * @param buffer Buffer under processing.
+     * @param index Zero-based index of the pass just recorded.
+     *
+     * The default implementation barriers the attached buffer's own
+     * handle, which these passes never touch.
+     */
+    void on_iteration_barrier(
+        Portal::Graphics::CommandBufferID cmd_id,
+        const std::shared_ptr<VKBuffer>& buffer,
+        uint32_t index) override;
+
+    /**
+     * @brief Write the field descriptors for this cycle's slot assignment,
+     *        run the normal shader processing path, then swap the pressure
+     *        field when the iteration count is odd.
+     *
+     * The swap is here rather than in on_after_execute because a slot
+     * exchange is not idempotent and on_after_execute is invoked more than
+     * once per cycle.
+     */
+    void processing_function(const std::shared_ptr<Buffer>& buffer) override;
+
+private:
+    /**
+     * @brief Issue direct ShaderFoundry descriptor writes for the
+     *        divergence read slot and both pressure slots.
+     */
+    void write_field_descriptors();
+
+    /**
+     * @brief Size the push constant block to at least PressureParams and
+     *        write the attached volume's lattice dimensions and cell size.
+     */
+    void write_params();
+
+    /**
+     * @brief Write the parity word of the staged push constant block.
+     * @param parity Zero to read slot A and write slot B, one for the reverse.
+     */
+    void write_parity(uint32_t parity);
+
+    std::string m_divergence_field;
+    std::string m_pressure_field;
+
+    std::shared_ptr<VolumeGridBuffer> m_volume; ///< The attached volume, cached for descriptor writes and the slot swap.
+};
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/RaymarchBuffer.cpp
+++ b/src/MayaFlux/Buffers/State/RaymarchBuffer.cpp
@@ -3,82 +3,32 @@
 #include "MayaFlux/Buffers/BufferProcessingChain.hpp"
 #include "MayaFlux/Buffers/Shaders/RenderProcessor.hpp"
 #include "MayaFlux/Journal/Archivist.hpp"
-#include "MayaFlux/Kakshya/NDData/VertexFormats.hpp"
+#include "MayaFlux/Kinesis/GeometryPrimitives.hpp"
 
 namespace MayaFlux::Buffers {
-
-namespace {
-    constexpr uint32_t k_box_vertices = 36;
-
-    constexpr std::array<uint32_t, 36> k_box_corners {
-        0, 2, 1, 1, 2, 3,
-        4, 5, 6, 5, 7, 6,
-        0, 1, 4, 1, 5, 4,
-        2, 6, 3, 3, 6, 7,
-        0, 4, 2, 2, 4, 6,
-        1, 3, 5, 3, 7, 5
-    };
-}
 
 RaymarchBuffer::RaymarchBuffer(
     Kinesis::Lattice3D lattice,
     RaymarchProcessor::FieldSource source,
     size_t field_bytes)
-    : VKBuffer(
-          k_box_vertices * sizeof(Kakshya::MeshVertex),
-          Usage::VERTEX,
-          Kakshya::DataModality::VERTICES_3D)
+    : MeshBuffer(Kinesis::generate_box(
+          (lattice.bounds.min + lattice.bounds.max) * 0.5F,
+          (lattice.bounds.max - lattice.bounds.min) * 0.5F))
     , m_lattice(lattice)
     , m_source(std::move(source))
     , m_field_bytes(field_bytes)
 {
-    auto layout = Kakshya::VertexLayout::for_meshes(sizeof(Kakshya::MeshVertex));
-    layout.vertex_count = k_box_vertices;
-    set_vertex_layout(layout);
-}
-
-void RaymarchBuffer::write_box()
-{
-    const glm::vec3 lo = m_lattice.bounds.min;
-    const glm::vec3 hi = m_lattice.bounds.max;
-
-    const std::array<glm::vec3, 8> corners {
-        glm::vec3(lo.x, lo.y, lo.z),
-        glm::vec3(hi.x, lo.y, lo.z),
-        glm::vec3(lo.x, hi.y, lo.z),
-        glm::vec3(hi.x, hi.y, lo.z),
-        glm::vec3(lo.x, lo.y, hi.z),
-        glm::vec3(hi.x, lo.y, hi.z),
-        glm::vec3(lo.x, hi.y, hi.z),
-        glm::vec3(hi.x, hi.y, hi.z),
-    };
-
-    std::vector<Kakshya::MeshVertex> vertices(k_box_vertices);
-    for (uint32_t i = 0; i < k_box_vertices; ++i) {
-        vertices[i].position = corners[k_box_corners[i]];
-    }
-
-    Buffers::upload_to_gpu(
-        std::span<const Kakshya::MeshVertex>(vertices),
-        std::static_pointer_cast<VKBuffer>(shared_from_this()));
 }
 
 void RaymarchBuffer::setup_processors(ProcessingToken token)
 {
-    auto chain = get_processing_chain();
-    if (!chain) {
-        chain = std::make_shared<BufferProcessingChain>();
-        set_processing_chain(chain);
-    }
-    chain->set_preferred_token(token);
+    MeshBuffer::setup_processors(token);
 
     m_march_processor = std::make_shared<RaymarchProcessor>(
         m_source, m_field_bytes, m_lattice);
     m_march_processor->set_processing_token(token);
 
-    set_default_processor(m_march_processor);
-
-    write_box();
+    get_processing_chain()->add_processor(m_march_processor, shared_from_this());
 
     MF_DEBUG(Journal::Component::Buffers, Journal::Context::Init,
         "RaymarchBuffer: proxy box over {}x{}x{} lattice",
@@ -88,23 +38,17 @@ void RaymarchBuffer::setup_processors(ProcessingToken token)
 void RaymarchBuffer::setup_rendering(const RenderConfig& config)
 {
     RenderConfig resolved = config;
-    resolved.topology = Portal::Graphics::PrimitiveTopology::TRIANGLE_LIST;
 
     if (resolved.vertex_shader.empty())
         resolved.vertex_shader = "volume_raymarch.vert.spv";
     if (resolved.fragment_shader.empty())
         resolved.fragment_shader = "volume_raymarch.frag.spv";
 
-    apply_render_config(resolved, ShaderConfig { resolved.vertex_shader });
+    MeshBuffer::setup_rendering(resolved);
 
     m_render_processor->set_cull_mode(Portal::Graphics::CullMode::FRONT);
     m_render_processor->enable_alpha_blending();
-    m_render_processor->enable_depth_test();
-    m_render_processor->set_vertex_range(0, k_box_vertices);
-
-    get_processing_chain()->add_final_processor(m_render_processor, shared_from_this());
-
-    set_needs_depth_attachment(true);
+    m_render_processor->disable_depth_test();
 }
 
 } // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/RaymarchBuffer.cpp
+++ b/src/MayaFlux/Buffers/State/RaymarchBuffer.cpp
@@ -1,0 +1,110 @@
+#include "RaymarchBuffer.hpp"
+
+#include "MayaFlux/Buffers/BufferProcessingChain.hpp"
+#include "MayaFlux/Buffers/Shaders/RenderProcessor.hpp"
+#include "MayaFlux/Journal/Archivist.hpp"
+#include "MayaFlux/Kakshya/NDData/VertexFormats.hpp"
+
+namespace MayaFlux::Buffers {
+
+namespace {
+    constexpr uint32_t k_box_vertices = 36;
+
+    constexpr std::array<uint32_t, 36> k_box_corners {
+        0, 2, 1, 1, 2, 3,
+        4, 5, 6, 5, 7, 6,
+        0, 1, 4, 1, 5, 4,
+        2, 6, 3, 3, 6, 7,
+        0, 4, 2, 2, 4, 6,
+        1, 3, 5, 3, 7, 5
+    };
+}
+
+RaymarchBuffer::RaymarchBuffer(
+    Kinesis::Lattice3D lattice,
+    RaymarchProcessor::FieldSource source,
+    size_t field_bytes)
+    : VKBuffer(
+          k_box_vertices * sizeof(Kakshya::MeshVertex),
+          Usage::VERTEX,
+          Kakshya::DataModality::VERTICES_3D)
+    , m_lattice(lattice)
+    , m_source(std::move(source))
+    , m_field_bytes(field_bytes)
+{
+    auto layout = Kakshya::VertexLayout::for_meshes(sizeof(Kakshya::MeshVertex));
+    layout.vertex_count = k_box_vertices;
+    set_vertex_layout(layout);
+}
+
+void RaymarchBuffer::write_box()
+{
+    const glm::vec3 lo = m_lattice.bounds.min;
+    const glm::vec3 hi = m_lattice.bounds.max;
+
+    const std::array<glm::vec3, 8> corners {
+        glm::vec3(lo.x, lo.y, lo.z),
+        glm::vec3(hi.x, lo.y, lo.z),
+        glm::vec3(lo.x, hi.y, lo.z),
+        glm::vec3(hi.x, hi.y, lo.z),
+        glm::vec3(lo.x, lo.y, hi.z),
+        glm::vec3(hi.x, lo.y, hi.z),
+        glm::vec3(lo.x, hi.y, hi.z),
+        glm::vec3(hi.x, hi.y, hi.z),
+    };
+
+    std::vector<Kakshya::MeshVertex> vertices(k_box_vertices);
+    for (uint32_t i = 0; i < k_box_vertices; ++i) {
+        vertices[i].position = corners[k_box_corners[i]];
+    }
+
+    Buffers::upload_to_gpu(
+        std::span<const Kakshya::MeshVertex>(vertices),
+        std::static_pointer_cast<VKBuffer>(shared_from_this()));
+}
+
+void RaymarchBuffer::setup_processors(ProcessingToken token)
+{
+    auto chain = get_processing_chain();
+    if (!chain) {
+        chain = std::make_shared<BufferProcessingChain>();
+        set_processing_chain(chain);
+    }
+    chain->set_preferred_token(token);
+
+    m_march_processor = std::make_shared<RaymarchProcessor>(
+        m_source, m_field_bytes, m_lattice);
+    m_march_processor->set_processing_token(token);
+
+    set_default_processor(m_march_processor);
+
+    write_box();
+
+    MF_DEBUG(Journal::Component::Buffers, Journal::Context::Init,
+        "RaymarchBuffer: proxy box over {}x{}x{} lattice",
+        m_lattice.resolution.x, m_lattice.resolution.y, m_lattice.resolution.z);
+}
+
+void RaymarchBuffer::setup_rendering(const RenderConfig& config)
+{
+    RenderConfig resolved = config;
+    resolved.topology = Portal::Graphics::PrimitiveTopology::TRIANGLE_LIST;
+
+    if (resolved.vertex_shader.empty())
+        resolved.vertex_shader = "volume_raymarch.vert.spv";
+    if (resolved.fragment_shader.empty())
+        resolved.fragment_shader = "volume_raymarch.frag.spv";
+
+    apply_render_config(resolved, ShaderConfig { resolved.vertex_shader });
+
+    m_render_processor->set_cull_mode(Portal::Graphics::CullMode::FRONT);
+    m_render_processor->enable_alpha_blending();
+    m_render_processor->enable_depth_test();
+    m_render_processor->set_vertex_range(0, k_box_vertices);
+
+    get_processing_chain()->add_final_processor(m_render_processor, shared_from_this());
+
+    set_needs_depth_attachment(true);
+}
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/RaymarchBuffer.hpp
+++ b/src/MayaFlux/Buffers/State/RaymarchBuffer.hpp
@@ -1,40 +1,31 @@
 #pragma once
 
+#include "MayaFlux/Buffers/Geometry/MeshBuffer.hpp"
+
 #include "RaymarchProcessor.hpp"
 
 namespace MayaFlux::Buffers {
 
 /**
  * @class RaymarchBuffer
- * @brief Proxy geometry bounding a scalar field, drawn by a fragment
- *        stage that integrates the field along the view ray.
+ * @brief Proxy box bounding a scalar field, drawn by a fragment stage that
+ *        integrates the field along the view ray.
  *
- * Holds thirty-six vertices, the twelve triangles of the box a
- * Lattice3D's bounds describe, written once at construction. The box is
- * only what rasterises the pixels the march covers: the image is produced
- * entirely in the fragment stage.
+ * A MeshBuffer holding the box Kinesis::generate_box produces over a
+ * Lattice3D's bounds. MeshProcessor uploads it and links the index buffer,
+ * so the geometry path is the ordinary indexed mesh path with nothing
+ * special about it. The image is produced entirely in the fragment stage;
+ * the box only rasterises the pixels the march covers.
  *
- * Owns no field. The field arrives through the RaymarchProcessor's source
+ * Owns no field. The field arrives through RaymarchProcessor's source
  * callable, so a VolumeGridBuffer running its own simulation chain is
- * untouched by this and its field is read where it lies. Any other owner
- * of a float array over the same lattice works identically.
+ * untouched and its field is read where it lies.
  *
  * Back faces are rasterised rather than front, and the fragment stage
- * clips the ray's entry against the box itself, so the volume survives
- * the observer moving inside its bounds.
- *
- * Usage:
- * @code
- * auto smoke = std::make_shared<RaymarchBuffer>(
- *     volume->get_lattice(),
- *     [volume] { return volume->read_handle("density"); },
- *     volume->get_field_bytes("density")) | Graphics;
- *
- * smoke->setup_rendering({ .target_window = window });
- * smoke->march_processor()->set_emission(3.0F);
- * @endcode
+ * clips ray entry against the box, so the volume survives the observer
+ * moving inside its bounds.
  */
-class MAYAFLUX_API RaymarchBuffer : public VKBuffer {
+class MAYAFLUX_API RaymarchBuffer : public MeshBuffer {
 public:
     /**
      * @brief Construct proxy geometry over a lattice.
@@ -50,20 +41,17 @@ public:
     ~RaymarchBuffer() override = default;
 
     /**
-     * @brief Establish the chain with the march staging processor in it.
+     * @brief Attach MeshProcessor for upload and RaymarchProcessor for staging.
      * @param token Processing domain, normally GRAPHICS_BACKEND.
      */
     void setup_processors(ProcessingToken token) override;
 
     /**
      * @brief Attach a RenderProcessor drawing the proxy box.
-     * @param config Render target. Shaders default to the raymarch pair,
-     *        topology is forced to TRIANGLE_LIST, culling to FRONT, and
-     *        alpha blending is enabled.
+     * @param config Render target. Shaders default to the raymarch pair.
      *
-     * Depth writes are disabled while depth testing stays on, so the
-     * volume occludes correctly against opaque geometry without occluding
-     * itself or anything drawn after it.
+     * Culls front faces and disables depth writes: a proxy box that writes
+     * depth occludes every later volume at the same geometry.
      */
     void setup_rendering(const RenderConfig& config);
 
@@ -74,11 +62,6 @@ public:
     [[nodiscard]] const Kinesis::Lattice3D& get_lattice() const { return m_lattice; }
 
 private:
-    /**
-     * @brief Write the twelve triangles of the bounding box.
-     */
-    void write_box();
-
     Kinesis::Lattice3D m_lattice;
     RaymarchProcessor::FieldSource m_source;
     size_t m_field_bytes;

--- a/src/MayaFlux/Buffers/State/RaymarchBuffer.hpp
+++ b/src/MayaFlux/Buffers/State/RaymarchBuffer.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include "RaymarchProcessor.hpp"
+
+namespace MayaFlux::Buffers {
+
+/**
+ * @class RaymarchBuffer
+ * @brief Proxy geometry bounding a scalar field, drawn by a fragment
+ *        stage that integrates the field along the view ray.
+ *
+ * Holds thirty-six vertices, the twelve triangles of the box a
+ * Lattice3D's bounds describe, written once at construction. The box is
+ * only what rasterises the pixels the march covers: the image is produced
+ * entirely in the fragment stage.
+ *
+ * Owns no field. The field arrives through the RaymarchProcessor's source
+ * callable, so a VolumeGridBuffer running its own simulation chain is
+ * untouched by this and its field is read where it lies. Any other owner
+ * of a float array over the same lattice works identically.
+ *
+ * Back faces are rasterised rather than front, and the fragment stage
+ * clips the ray's entry against the box itself, so the volume survives
+ * the observer moving inside its bounds.
+ *
+ * Usage:
+ * @code
+ * auto smoke = std::make_shared<RaymarchBuffer>(
+ *     volume->get_lattice(),
+ *     [volume] { return volume->read_handle("density"); },
+ *     volume->get_field_bytes("density")) | Graphics;
+ *
+ * smoke->setup_rendering({ .target_window = window });
+ * smoke->march_processor()->set_emission(3.0F);
+ * @endcode
+ */
+class MAYAFLUX_API RaymarchBuffer : public VKBuffer {
+public:
+    /**
+     * @brief Construct proxy geometry over a lattice.
+     * @param lattice Extent the box spans and the field is stored over.
+     * @param source Callable resolving the field handle each cycle.
+     * @param field_bytes Byte size of one slot of that field.
+     */
+    RaymarchBuffer(
+        Kinesis::Lattice3D lattice,
+        RaymarchProcessor::FieldSource source,
+        size_t field_bytes);
+
+    ~RaymarchBuffer() override = default;
+
+    /**
+     * @brief Establish the chain with the march staging processor in it.
+     * @param token Processing domain, normally GRAPHICS_BACKEND.
+     */
+    void setup_processors(ProcessingToken token) override;
+
+    /**
+     * @brief Attach a RenderProcessor drawing the proxy box.
+     * @param config Render target. Shaders default to the raymarch pair,
+     *        topology is forced to TRIANGLE_LIST, culling to FRONT, and
+     *        alpha blending is enabled.
+     *
+     * Depth writes are disabled while depth testing stays on, so the
+     * volume occludes correctly against opaque geometry without occluding
+     * itself or anything drawn after it.
+     */
+    void setup_rendering(const RenderConfig& config);
+
+    /** @brief The march staging stage, valid after setup_processors. */
+    [[nodiscard]] std::shared_ptr<RaymarchProcessor> march_processor() const { return m_march_processor; }
+
+    /** @brief The lattice the box spans. */
+    [[nodiscard]] const Kinesis::Lattice3D& get_lattice() const { return m_lattice; }
+
+private:
+    /**
+     * @brief Write the twelve triangles of the bounding box.
+     */
+    void write_box();
+
+    Kinesis::Lattice3D m_lattice;
+    RaymarchProcessor::FieldSource m_source;
+    size_t m_field_bytes;
+
+    std::shared_ptr<RaymarchProcessor> m_march_processor;
+};
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/RaymarchProcessor.cpp
+++ b/src/MayaFlux/Buffers/State/RaymarchProcessor.cpp
@@ -1,0 +1,160 @@
+#include "RaymarchProcessor.hpp"
+
+#include "MayaFlux/Journal/Archivist.hpp"
+
+namespace MayaFlux::Buffers {
+
+namespace {
+    constexpr const char* k_binding_name = "volume_field";
+    constexpr const char* k_fragment_name = "march_params";
+}
+
+RaymarchProcessor::RaymarchProcessor(
+    FieldSource source,
+    size_t field_bytes,
+    Kinesis::Lattice3D lattice,
+    uint32_t set,
+    uint32_t binding)
+    : m_source(std::move(source))
+    , m_field_bytes(field_bytes)
+    , m_lattice(lattice)
+    , m_set(set)
+    , m_binding(binding)
+{
+    if (m_set == 0) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::Init,
+            "RaymarchProcessor: set 0 is the ViewTransform reservation, "
+            "falling back to set 1");
+        m_set = 1;
+    }
+
+    m_params.max_steps = 128;
+    m_params.step_scale = 0.5F;
+    m_params.density_scale = 1.0F;
+    m_params.absorption = 12.0F;
+    m_params.cool_r = 0.35F;
+    m_params.cool_g = 0.10F;
+    m_params.cool_b = 0.05F;
+    m_params.hot_r = 1.0F;
+    m_params.hot_g = 0.82F;
+    m_params.hot_b = 0.45F;
+    m_params.emission = 2.2F;
+    m_params.threshold = 0.02F;
+
+    write_lattice_params();
+}
+
+void RaymarchProcessor::write_lattice_params()
+{
+    const glm::vec3 cell = m_lattice.cell_size();
+
+    m_params.width = m_lattice.resolution.x;
+    m_params.height = m_lattice.resolution.y;
+    m_params.depth = m_lattice.resolution.z;
+    m_params.bounds_min_x = m_lattice.bounds.min.x;
+    m_params.bounds_min_y = m_lattice.bounds.min.y;
+    m_params.bounds_min_z = m_lattice.bounds.min.z;
+    m_params.cell_size_x = cell.x;
+    m_params.cell_size_y = cell.y;
+    m_params.cell_size_z = cell.z;
+}
+
+void RaymarchProcessor::set_max_steps(uint32_t steps) { m_params.max_steps = steps; }
+void RaymarchProcessor::set_step_scale(float scale) { m_params.step_scale = scale; }
+void RaymarchProcessor::set_density_scale(float scale) { m_params.density_scale = scale; }
+void RaymarchProcessor::set_absorption(float absorption) { m_params.absorption = absorption; }
+void RaymarchProcessor::set_emission(float emission) { m_params.emission = emission; }
+void RaymarchProcessor::set_threshold(float threshold) { m_params.threshold = threshold; }
+
+void RaymarchProcessor::set_emission_ramp(const glm::vec3& cool, const glm::vec3& hot)
+{
+    m_params.cool_r = cool.r;
+    m_params.cool_g = cool.g;
+    m_params.cool_b = cool.b;
+    m_params.hot_r = hot.r;
+    m_params.hot_g = hot.g;
+    m_params.hot_b = hot.b;
+}
+
+void RaymarchProcessor::on_attach(const std::shared_ptr<Buffer>& buffer)
+{
+    auto vk_buffer = std::dynamic_pointer_cast<VKBuffer>(buffer);
+    if (!vk_buffer) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "RaymarchProcessor requires a VKBuffer");
+        return;
+    }
+
+    stage_params(vk_buffer);
+
+    if (m_source) {
+        stage_descriptor(vk_buffer, m_source());
+    }
+}
+
+void RaymarchProcessor::processing_function(const std::shared_ptr<Buffer>& buffer)
+{
+    auto vk_buffer = std::dynamic_pointer_cast<VKBuffer>(buffer);
+    if (!vk_buffer || !m_source) {
+        return;
+    }
+
+    const vk::Buffer handle = m_source();
+    if (!handle) {
+        return;
+    }
+
+    stage_descriptor(vk_buffer, handle);
+    stage_params(vk_buffer);
+}
+
+void RaymarchProcessor::stage_descriptor(
+    const std::shared_ptr<VKBuffer>& buffer, vk::Buffer handle)
+{
+    auto& bindings = buffer->get_pipeline_context().descriptor_buffer_bindings;
+
+    auto it = std::ranges::find_if(bindings, [this](const auto& entry) {
+        return entry.set == m_set && entry.binding == m_binding;
+    });
+
+    if (it == bindings.end()) {
+        bindings.push_back(Portal::Graphics::DescriptorBindingInfo {
+            .set = m_set,
+            .binding = m_binding,
+            .type = vk::DescriptorType::eStorageBuffer,
+            .buffer_info = vk::DescriptorBufferInfo(handle, 0, m_field_bytes),
+            .name = k_binding_name,
+            .count = 1,
+        });
+        return;
+    }
+
+    it->buffer_info.buffer = handle;
+    it->buffer_info.offset = 0;
+    it->buffer_info.range = m_field_bytes;
+}
+
+void RaymarchProcessor::stage_params(const std::shared_ptr<VKBuffer>& buffer)
+{
+    auto& fragments = buffer->get_pipeline_context().push_constant_bindings;
+
+    const auto* bytes = reinterpret_cast<const uint8_t*>(&m_params);
+
+    auto it = std::ranges::find_if(fragments, [](const auto& entry) {
+        return entry.name == k_fragment_name;
+    });
+
+    if (it == fragments.end()) {
+        fragments.push_back(Portal::Graphics::PushConstantBindingInfo {
+            .offset = 0,
+            .data = std::vector<uint8_t>(bytes, bytes + sizeof(MarchParams)),
+            .name = k_fragment_name,
+        });
+        return;
+    }
+
+    it->offset = 0;
+    it->data.assign(bytes, bytes + sizeof(MarchParams));
+}
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/RaymarchProcessor.hpp
+++ b/src/MayaFlux/Buffers/State/RaymarchProcessor.hpp
@@ -1,0 +1,179 @@
+#pragma once
+
+#include "MayaFlux/Buffers/VKBuffer.hpp"
+#include "MayaFlux/Kinesis/Spatial/Lattice.hpp"
+
+namespace MayaFlux::Buffers {
+
+/**
+ * @class RaymarchProcessor
+ * @brief Stages a scalar field and its march parameters onto the buffer a
+ *        RenderProcessor draws, so the fragment stage integrates the field
+ *        through a proxy volume.
+ *
+ * Dispatches nothing and records no commands. Each cycle it resolves a
+ * vk::Buffer from its field source, writes a DescriptorBindingInfo for it
+ * into the attached buffer's pipeline context, and writes its parameter
+ * block as a staged push constant fragment. RenderProcessor unifies both
+ * into the pipeline it builds and updates the descriptor before binding
+ * the set, which is the designed path for handing resources to the
+ * renderer without a processor of its own.
+ *
+ * The field source is a callable rather than a handle because a
+ * double-buffered field's read slot moves whenever an upstream stage
+ * swaps. Calling it fresh each cycle picks that up. It is also what keeps
+ * this class free of any dependency on VolumeGridBuffer: any callable
+ * returning a valid handle to a float array of the lattice's cell count
+ * works, whatever owns it.
+ *
+ * Set 1 binding 0 by default. Set 0 is the engine's ViewTransform
+ * reservation and cannot be used.
+ */
+class MAYAFLUX_API RaymarchProcessor : public VKBufferProcessor {
+public:
+    /**
+     * @brief Callable resolving the handle to sample this cycle.
+     *
+     * Returning a null handle skips the cycle's staging, leaving the
+     * previous cycle's descriptor in place.
+     */
+    using FieldSource = std::function<vk::Buffer()>;
+
+    /**
+     * @struct MarchParams
+     * @brief Parameter block staged as a push constant fragment.
+     *
+     * Offsets are fixed by this declaration. The fragment is staged at
+     * offset zero, so these are absolute offsets in the render pipeline's
+     * push constant range.
+     */
+    struct MarchParams {
+        uint32_t width;
+        uint32_t height;
+        uint32_t depth;
+        uint32_t max_steps;
+        float bounds_min_x;
+        float bounds_min_y;
+        float bounds_min_z;
+        float step_scale;
+        float cell_size_x;
+        float cell_size_y;
+        float cell_size_z;
+        float density_scale;
+        float cool_r;
+        float cool_g;
+        float cool_b;
+        float absorption;
+        float hot_r;
+        float hot_g;
+        float hot_b;
+        float emission;
+        float threshold;
+        float pad0;
+        float pad1;
+        float pad2;
+    };
+
+    static_assert(sizeof(MarchParams) == 96);
+    static_assert(sizeof(MarchParams) % 16 == 0);
+
+    /**
+     * @brief Construct a march staging processor.
+     * @param source Callable resolving the field handle each cycle.
+     * @param field_bytes Byte size of one slot of that field.
+     * @param lattice Discretization the field is stored over. Must match
+     *        the lattice the field was allocated against.
+     * @param set Descriptor set index. Must not be zero.
+     * @param binding Binding index within that set.
+     */
+    RaymarchProcessor(
+        FieldSource source,
+        size_t field_bytes,
+        Kinesis::Lattice3D lattice,
+        uint32_t set = 1,
+        uint32_t binding = 0);
+
+    ~RaymarchProcessor() override = default;
+
+    /**
+     * @brief Set the sample count along the longest ray through the volume.
+     * @param steps Step count. Higher resolves thin structure, linearly
+     *        more expensive per covered pixel.
+     */
+    void set_max_steps(uint32_t steps);
+
+    /**
+     * @brief Set the step length as a fraction of one cell.
+     * @param scale Below one oversamples, above one undersamples and bands.
+     */
+    void set_step_scale(float scale);
+
+    /**
+     * @brief Set the multiplier applied to every sample before integration.
+     * @param scale Raises or lowers apparent opacity without touching the field.
+     */
+    void set_density_scale(float scale);
+
+    /**
+     * @brief Set the extinction coefficient.
+     * @param absorption Higher makes the volume opaque in a shorter distance.
+     */
+    void set_absorption(float absorption);
+
+    /**
+     * @brief Set the emission colours interpolated by sample value.
+     * @param cool Colour at the threshold.
+     * @param hot Colour at and above unity.
+     */
+    void set_emission_ramp(const glm::vec3& cool, const glm::vec3& hot);
+
+    /**
+     * @brief Set the emissive strength.
+     * @param emission Zero gives pure absorption, a density shadow.
+     */
+    void set_emission(float emission);
+
+    /**
+     * @brief Set the sample value below which a step contributes nothing.
+     * @param threshold Cutoff. Suppresses the smeared tail advection leaves.
+     */
+    void set_threshold(float threshold);
+
+    /** @brief The lattice the sampled field is stored over. */
+    [[nodiscard]] const Kinesis::Lattice3D& get_lattice() const { return m_lattice; }
+
+    /** @brief The staged parameter block. */
+    [[nodiscard]] const MarchParams& get_params() const { return m_params; }
+
+    void on_attach(const std::shared_ptr<Buffer>& buffer) override;
+    void processing_function(const std::shared_ptr<Buffer>& buffer) override;
+
+private:
+    /**
+     * @brief Write the lattice-derived words of the parameter block.
+     */
+    void write_lattice_params();
+
+    /**
+     * @brief Insert or replace the descriptor entry for the field handle.
+     * @param buffer Buffer whose pipeline context is staged onto.
+     * @param handle Handle resolved this cycle.
+     */
+    void stage_descriptor(const std::shared_ptr<VKBuffer>& buffer, vk::Buffer handle);
+
+    /**
+     * @brief Insert or replace the push constant fragment.
+     * @param buffer Buffer whose pipeline context is staged onto.
+     */
+    void stage_params(const std::shared_ptr<VKBuffer>& buffer);
+
+    FieldSource m_source;
+    size_t m_field_bytes;
+    Kinesis::Lattice3D m_lattice;
+    uint32_t m_set;
+    uint32_t m_binding;
+
+    MarchParams m_params {};
+};
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/SolenoidalProcessor.cpp
+++ b/src/MayaFlux/Buffers/State/SolenoidalProcessor.cpp
@@ -1,0 +1,156 @@
+#include "SolenoidalProcessor.hpp"
+#include "VolumeGridBuffer.hpp"
+
+namespace MayaFlux::Buffers {
+
+namespace {
+    constexpr uint32_t k_workgroup_x = 8;
+    constexpr uint32_t k_workgroup_y = 8;
+    constexpr uint32_t k_workgroup_z = 4;
+}
+
+SolenoidalProcessor::SolenoidalProcessor(
+    std::string pressure_field,
+    std::string velocity_field,
+    const std::string& shader_path)
+    : ComputeProcessor(shader_path, k_workgroup_x)
+    , m_pressure_field(std::move(pressure_field))
+    , m_velocity_field(std::move(velocity_field))
+{
+    m_config.bindings["pressure_in"] = ShaderBinding(0, 0, vk::DescriptorType::eStorageBuffer);
+    m_config.bindings["velocity_in"] = ShaderBinding(0, 1, vk::DescriptorType::eStorageBuffer);
+    m_config.bindings["velocity_out"] = ShaderBinding(0, 2, vk::DescriptorType::eStorageBuffer);
+}
+
+SolenoidalProcessor::SolenoidalProcessor(
+    std::string pressure_field,
+    std::string velocity_field,
+    const Portal::Graphics::ShaderSpec& spec)
+    : ComputeProcessor(spec)
+    , m_pressure_field(std::move(pressure_field))
+    , m_velocity_field(std::move(velocity_field))
+{
+    m_config.bindings["pressure_in"] = ShaderBinding(0, 0, vk::DescriptorType::eStorageBuffer);
+    m_config.bindings["velocity_in"] = ShaderBinding(0, 1, vk::DescriptorType::eStorageBuffer);
+    m_config.bindings["velocity_out"] = ShaderBinding(0, 2, vk::DescriptorType::eStorageBuffer);
+}
+
+void SolenoidalProcessor::on_attach(const std::shared_ptr<Buffer>& buffer)
+{
+    ComputeProcessor::on_attach(buffer);
+
+    m_volume = std::dynamic_pointer_cast<VolumeGridBuffer>(buffer);
+    if (!m_volume) {
+        return;
+    }
+
+    if (!m_volume->has_field(m_pressure_field)) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "SolenoidalProcessor: volume has no field '{}'", m_pressure_field);
+        m_volume.reset();
+        return;
+    }
+
+    if (!m_volume->has_field(m_velocity_field)) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "SolenoidalProcessor: volume has no field '{}'", m_velocity_field);
+        m_volume.reset();
+        return;
+    }
+
+    if (m_volume->read_handle(m_velocity_field) == m_volume->write_handle(m_velocity_field)) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "SolenoidalProcessor: velocity field '{}' is not double-buffered; "
+            "gradient subtraction reads a neighbourhood of the field it writes",
+            m_velocity_field);
+        m_volume.reset();
+        return;
+    }
+
+    set_workgroup_size(k_workgroup_x, k_workgroup_y, k_workgroup_z);
+    set_dispatch_mode(ShaderDispatchConfig::DispatchMode::MANUAL);
+    set_manual_dispatch(
+        (m_volume->get_width() + k_workgroup_x - 1) / k_workgroup_x,
+        (m_volume->get_height() + k_workgroup_y - 1) / k_workgroup_y,
+        (m_volume->get_depth() + k_workgroup_z - 1) / k_workgroup_z);
+
+    write_params();
+}
+
+void SolenoidalProcessor::write_params()
+{
+    if (m_config.push_constant_size < sizeof(SolenoidalParams)) {
+        set_push_constant_size(sizeof(SolenoidalParams));
+    }
+
+    auto& data = get_push_constant_data();
+    if (data.size() < m_config.push_constant_size) {
+        data.resize(m_config.push_constant_size);
+    }
+
+    const glm::vec3 cell = m_volume->get_cell_size();
+
+    const SolenoidalParams params {
+        .width = m_volume->get_width(),
+        .height = m_volume->get_height(),
+        .depth = m_volume->get_depth(),
+        .pad0 = 0,
+        .cell_size_x = cell.x,
+        .cell_size_y = cell.y,
+        .cell_size_z = cell.z,
+        .pad1 = 0.0F,
+    };
+
+    std::memcpy(data.data(), &params, sizeof(SolenoidalParams));
+}
+
+void SolenoidalProcessor::write_field_descriptors()
+{
+    if (!m_volume || m_descriptor_set_ids.empty()) {
+        return;
+    }
+
+    auto& foundry = Portal::Graphics::get_shader_foundry();
+
+    foundry.update_descriptor_buffer(
+        m_descriptor_set_ids[0], 0, vk::DescriptorType::eStorageBuffer,
+        m_volume->read_handle(m_pressure_field), 0,
+        m_volume->get_field_bytes(m_pressure_field));
+
+    foundry.update_descriptor_buffer(
+        m_descriptor_set_ids[0], 1, vk::DescriptorType::eStorageBuffer,
+        m_volume->read_handle(m_velocity_field), 0,
+        m_volume->get_field_bytes(m_velocity_field));
+
+    foundry.update_descriptor_buffer(
+        m_descriptor_set_ids[0], 2, vk::DescriptorType::eStorageBuffer,
+        m_volume->write_handle(m_velocity_field), 0,
+        m_volume->get_field_bytes(m_velocity_field));
+}
+
+void SolenoidalProcessor::on_descriptors_created()
+{
+    write_field_descriptors();
+}
+
+void SolenoidalProcessor::processing_function(const std::shared_ptr<Buffer>& buffer)
+{
+    if (m_volume && are_descriptors_ready()) {
+        write_field_descriptors();
+    }
+
+    ComputeProcessor::processing_function(buffer);
+
+    if (m_volume) {
+        m_volume->swap_field(m_velocity_field);
+    }
+}
+
+bool SolenoidalProcessor::on_before_execute(
+    Portal::Graphics::CommandBufferID /*cmd_id*/,
+    const std::shared_ptr<VKBuffer>& buffer)
+{
+    return m_volume && std::dynamic_pointer_cast<VolumeGridBuffer>(buffer) != nullptr;
+}
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/SolenoidalProcessor.cpp
+++ b/src/MayaFlux/Buffers/State/SolenoidalProcessor.cpp
@@ -1,156 +1,37 @@
 #include "SolenoidalProcessor.hpp"
-#include "VolumeGridBuffer.hpp"
 
 namespace MayaFlux::Buffers {
 
-namespace {
-    constexpr uint32_t k_workgroup_x = 8;
-    constexpr uint32_t k_workgroup_y = 8;
-    constexpr uint32_t k_workgroup_z = 4;
+std::vector<VolumeFieldProcessor::FieldBinding> SolenoidalProcessor::make_bindings(
+    const std::string& pressure_field, const std::string& velocity_field)
+{
+    return {
+        { .name = "pressure_in", .binding = 0, .field = pressure_field, .access = FieldAccess::READ },
+        { .name = "velocity_in", .binding = 1, .field = velocity_field, .access = FieldAccess::READ },
+        { .name = "velocity_out", .binding = 2, .field = velocity_field, .access = FieldAccess::WRITE },
+    };
 }
 
 SolenoidalProcessor::SolenoidalProcessor(
     std::string pressure_field,
     std::string velocity_field,
     const std::string& shader_path)
-    : ComputeProcessor(shader_path, k_workgroup_x)
+    : VolumeFieldProcessor(make_bindings(pressure_field, velocity_field), shader_path)
     , m_pressure_field(std::move(pressure_field))
     , m_velocity_field(std::move(velocity_field))
 {
-    m_config.bindings["pressure_in"] = ShaderBinding(0, 0, vk::DescriptorType::eStorageBuffer);
-    m_config.bindings["velocity_in"] = ShaderBinding(0, 1, vk::DescriptorType::eStorageBuffer);
-    m_config.bindings["velocity_out"] = ShaderBinding(0, 2, vk::DescriptorType::eStorageBuffer);
+    add_swap_field(m_velocity_field);
 }
 
 SolenoidalProcessor::SolenoidalProcessor(
     std::string pressure_field,
     std::string velocity_field,
     const Portal::Graphics::ShaderSpec& spec)
-    : ComputeProcessor(spec)
+    : VolumeFieldProcessor(make_bindings(pressure_field, velocity_field), spec)
     , m_pressure_field(std::move(pressure_field))
     , m_velocity_field(std::move(velocity_field))
 {
-    m_config.bindings["pressure_in"] = ShaderBinding(0, 0, vk::DescriptorType::eStorageBuffer);
-    m_config.bindings["velocity_in"] = ShaderBinding(0, 1, vk::DescriptorType::eStorageBuffer);
-    m_config.bindings["velocity_out"] = ShaderBinding(0, 2, vk::DescriptorType::eStorageBuffer);
-}
-
-void SolenoidalProcessor::on_attach(const std::shared_ptr<Buffer>& buffer)
-{
-    ComputeProcessor::on_attach(buffer);
-
-    m_volume = std::dynamic_pointer_cast<VolumeGridBuffer>(buffer);
-    if (!m_volume) {
-        return;
-    }
-
-    if (!m_volume->has_field(m_pressure_field)) {
-        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
-            "SolenoidalProcessor: volume has no field '{}'", m_pressure_field);
-        m_volume.reset();
-        return;
-    }
-
-    if (!m_volume->has_field(m_velocity_field)) {
-        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
-            "SolenoidalProcessor: volume has no field '{}'", m_velocity_field);
-        m_volume.reset();
-        return;
-    }
-
-    if (m_volume->read_handle(m_velocity_field) == m_volume->write_handle(m_velocity_field)) {
-        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
-            "SolenoidalProcessor: velocity field '{}' is not double-buffered; "
-            "gradient subtraction reads a neighbourhood of the field it writes",
-            m_velocity_field);
-        m_volume.reset();
-        return;
-    }
-
-    set_workgroup_size(k_workgroup_x, k_workgroup_y, k_workgroup_z);
-    set_dispatch_mode(ShaderDispatchConfig::DispatchMode::MANUAL);
-    set_manual_dispatch(
-        (m_volume->get_width() + k_workgroup_x - 1) / k_workgroup_x,
-        (m_volume->get_height() + k_workgroup_y - 1) / k_workgroup_y,
-        (m_volume->get_depth() + k_workgroup_z - 1) / k_workgroup_z);
-
-    write_params();
-}
-
-void SolenoidalProcessor::write_params()
-{
-    if (m_config.push_constant_size < sizeof(SolenoidalParams)) {
-        set_push_constant_size(sizeof(SolenoidalParams));
-    }
-
-    auto& data = get_push_constant_data();
-    if (data.size() < m_config.push_constant_size) {
-        data.resize(m_config.push_constant_size);
-    }
-
-    const glm::vec3 cell = m_volume->get_cell_size();
-
-    const SolenoidalParams params {
-        .width = m_volume->get_width(),
-        .height = m_volume->get_height(),
-        .depth = m_volume->get_depth(),
-        .pad0 = 0,
-        .cell_size_x = cell.x,
-        .cell_size_y = cell.y,
-        .cell_size_z = cell.z,
-        .pad1 = 0.0F,
-    };
-
-    std::memcpy(data.data(), &params, sizeof(SolenoidalParams));
-}
-
-void SolenoidalProcessor::write_field_descriptors()
-{
-    if (!m_volume || m_descriptor_set_ids.empty()) {
-        return;
-    }
-
-    auto& foundry = Portal::Graphics::get_shader_foundry();
-
-    foundry.update_descriptor_buffer(
-        m_descriptor_set_ids[0], 0, vk::DescriptorType::eStorageBuffer,
-        m_volume->read_handle(m_pressure_field), 0,
-        m_volume->get_field_bytes(m_pressure_field));
-
-    foundry.update_descriptor_buffer(
-        m_descriptor_set_ids[0], 1, vk::DescriptorType::eStorageBuffer,
-        m_volume->read_handle(m_velocity_field), 0,
-        m_volume->get_field_bytes(m_velocity_field));
-
-    foundry.update_descriptor_buffer(
-        m_descriptor_set_ids[0], 2, vk::DescriptorType::eStorageBuffer,
-        m_volume->write_handle(m_velocity_field), 0,
-        m_volume->get_field_bytes(m_velocity_field));
-}
-
-void SolenoidalProcessor::on_descriptors_created()
-{
-    write_field_descriptors();
-}
-
-void SolenoidalProcessor::processing_function(const std::shared_ptr<Buffer>& buffer)
-{
-    if (m_volume && are_descriptors_ready()) {
-        write_field_descriptors();
-    }
-
-    ComputeProcessor::processing_function(buffer);
-
-    if (m_volume) {
-        m_volume->swap_field(m_velocity_field);
-    }
-}
-
-bool SolenoidalProcessor::on_before_execute(
-    Portal::Graphics::CommandBufferID /*cmd_id*/,
-    const std::shared_ptr<VKBuffer>& buffer)
-{
-    return m_volume && std::dynamic_pointer_cast<VolumeGridBuffer>(buffer) != nullptr;
+    add_swap_field(m_velocity_field);
 }
 
 } // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/SolenoidalProcessor.hpp
+++ b/src/MayaFlux/Buffers/State/SolenoidalProcessor.hpp
@@ -1,68 +1,39 @@
 #pragma once
 
-#include "MayaFlux/Buffers/Shaders/ComputeProcessor.hpp"
+#include "VolumeFieldProcessor.hpp"
 
 namespace MayaFlux::Buffers {
 
-class VolumeGridBuffer;
-
 /**
  * @class SolenoidalProcessor
- * @brief ComputeProcessor subtracting a pressure gradient from a
- *        VolumeGridBuffer's velocity field, leaving it divergence-free.
+ * @brief VolumeFieldProcessor subtracting a pressure gradient from a
+ *        velocity field, leaving it divergence-free.
  *
  * Central differences on the six axis neighbours of the pressure field,
- * clamped at the lattice boundary, matching the stencil DivergenceProcessor
- * uses in the opposite direction. The pressure solve carries no time step
- * or density factor, so the correction is the plain difference
- * v - grad(p) with no additional scale; introducing one here would apply
- * the factor twice.
+ * clamped at the lattice boundary, mirroring DivergenceProcessor's
+ * stencil in the opposite direction.
+ *
+ * The pressure solve carries no time step or density factor, so pressure
+ * absorbs both and the correction is the plain difference v - grad(p).
+ * Introducing a scale here would apply the factor twice.
  *
  * Closes the incompressible chain: advect, divergence, pressure,
  * solenoidal. Correctness is observable by running divergence again after
- * this stage and reading the result, which should approach zero on the
+ * this stage and reading the result, which approaches zero on the
  * interior as the Jacobi iteration count rises.
  *
- * Boundary cells receive a one-sided gradient by clamping rather than a
- * wall condition. Normal velocity at the lattice edge is not forced to
- * zero, so material leaves the domain rather than reflecting.
- *
- * The velocity field must be double-buffered: the stage reads every cell's
- * neighbourhood while writing, so the write must land in a separate slot.
- * The swap happens in processing_function after the parent call, since a
- * slot exchange is not idempotent and on_after_execute is invoked more
- * than once per cycle.
- *
- * Descriptor bindings are written directly via
- * ShaderFoundry::update_descriptor_buffer, since VolumeGridBuffer's field
- * storage consists of raw handle pairs with no VKBuffer wrapper.
+ * Boundary cells receive a clamped one-sided gradient rather than a wall
+ * condition. Normal velocity at the lattice edge is not forced to zero,
+ * so a seed with wall-normal flow drains the domain.
  */
-class MAYAFLUX_API SolenoidalProcessor : public ComputeProcessor {
+class MAYAFLUX_API SolenoidalProcessor : public VolumeFieldProcessor {
 public:
-    /**
-     * @struct SolenoidalParams
-     * @brief Push constant block the gradient subtraction shader receives.
-     *
-     * Layout is identical to DivergenceProcessor::DivergenceParams, the two
-     * stages differing only in stencil direction.
-     */
-    struct SolenoidalParams {
-        uint32_t width;
-        uint32_t height;
-        uint32_t depth;
-        uint32_t pad0;
-        float cell_size_x;
-        float cell_size_y;
-        float cell_size_z;
-        float pad1;
-    };
-
     /**
      * @brief Construct a gradient subtraction stage.
      * @param pressure_field Name of the scalar field differentiated. Must
      *        have stride sizeof(float).
      * @param velocity_field Name of the field corrected. Must have stride
-     *        sizeof(glm::vec4) and two slots.
+     *        sizeof(glm::vec4) and be double-buffered.
      * @param shader_path Path to the compute shader.
      */
     SolenoidalProcessor(
@@ -87,52 +58,18 @@ public:
     /** @brief Name of the field this stage corrects. */
     [[nodiscard]] const std::string& get_velocity_field() const { return m_velocity_field; }
 
-protected:
-    /**
-     * @brief Size the dispatch to the lattice and write the parameter
-     *        block, once the attached volume's dimensions are known.
-     * @param buffer The attached buffer, expected to be a VolumeGridBuffer.
-     */
-    void on_attach(const std::shared_ptr<Buffer>& buffer) override;
-
-    /**
-     * @brief Write the three field descriptors for the current slot
-     *        assignment.
-     */
-    void on_descriptors_created() override;
-
-    /**
-     * @brief Reject buffers that are not VolumeGridBuffer.
-     * @param cmd_id Command buffer this cycle's dispatch will be recorded into.
-     * @param buffer The attached buffer, received as VKBuffer.
-     * @return True if the attached buffer is a VolumeGridBuffer.
-     */
-    bool on_before_execute(Portal::Graphics::CommandBufferID cmd_id, const std::shared_ptr<VKBuffer>& buffer) override;
-
-    /**
-     * @brief Write the field descriptors for this cycle's slot assignment,
-     *        run the normal shader processing path, then swap the velocity
-     *        field.
-     */
-    void processing_function(const std::shared_ptr<Buffer>& buffer) override;
-
 private:
     /**
-     * @brief Issue direct ShaderFoundry descriptor writes for the pressure
-     *        read slot and both velocity slots.
+     * @brief Build the binding table for the two field names.
+     * @param pressure_field Field differentiated.
+     * @param velocity_field Field corrected, bound in both slots.
+     * @return Table binding pressure read and both velocity slots.
      */
-    void write_field_descriptors();
-
-    /**
-     * @brief Size the push constant block to at least SolenoidalParams and
-     *        write the attached volume's lattice dimensions and cell size.
-     */
-    void write_params();
+    static std::vector<FieldBinding> make_bindings(
+        const std::string& pressure_field, const std::string& velocity_field);
 
     std::string m_pressure_field;
     std::string m_velocity_field;
-
-    std::shared_ptr<VolumeGridBuffer> m_volume; ///< The attached volume, cached for descriptor writes and the slot swap.
 };
 
 } // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/SolenoidalProcessor.hpp
+++ b/src/MayaFlux/Buffers/State/SolenoidalProcessor.hpp
@@ -1,0 +1,138 @@
+#pragma once
+
+#include "MayaFlux/Buffers/Shaders/ComputeProcessor.hpp"
+
+namespace MayaFlux::Buffers {
+
+class VolumeGridBuffer;
+
+/**
+ * @class SolenoidalProcessor
+ * @brief ComputeProcessor subtracting a pressure gradient from a
+ *        VolumeGridBuffer's velocity field, leaving it divergence-free.
+ *
+ * Central differences on the six axis neighbours of the pressure field,
+ * clamped at the lattice boundary, matching the stencil DivergenceProcessor
+ * uses in the opposite direction. The pressure solve carries no time step
+ * or density factor, so the correction is the plain difference
+ * v - grad(p) with no additional scale; introducing one here would apply
+ * the factor twice.
+ *
+ * Closes the incompressible chain: advect, divergence, pressure,
+ * solenoidal. Correctness is observable by running divergence again after
+ * this stage and reading the result, which should approach zero on the
+ * interior as the Jacobi iteration count rises.
+ *
+ * Boundary cells receive a one-sided gradient by clamping rather than a
+ * wall condition. Normal velocity at the lattice edge is not forced to
+ * zero, so material leaves the domain rather than reflecting.
+ *
+ * The velocity field must be double-buffered: the stage reads every cell's
+ * neighbourhood while writing, so the write must land in a separate slot.
+ * The swap happens in processing_function after the parent call, since a
+ * slot exchange is not idempotent and on_after_execute is invoked more
+ * than once per cycle.
+ *
+ * Descriptor bindings are written directly via
+ * ShaderFoundry::update_descriptor_buffer, since VolumeGridBuffer's field
+ * storage consists of raw handle pairs with no VKBuffer wrapper.
+ */
+class MAYAFLUX_API SolenoidalProcessor : public ComputeProcessor {
+public:
+    /**
+     * @struct SolenoidalParams
+     * @brief Push constant block the gradient subtraction shader receives.
+     *
+     * Layout is identical to DivergenceProcessor::DivergenceParams, the two
+     * stages differing only in stencil direction.
+     */
+    struct SolenoidalParams {
+        uint32_t width;
+        uint32_t height;
+        uint32_t depth;
+        uint32_t pad0;
+        float cell_size_x;
+        float cell_size_y;
+        float cell_size_z;
+        float pad1;
+    };
+
+    /**
+     * @brief Construct a gradient subtraction stage.
+     * @param pressure_field Name of the scalar field differentiated. Must
+     *        have stride sizeof(float).
+     * @param velocity_field Name of the field corrected. Must have stride
+     *        sizeof(glm::vec4) and two slots.
+     * @param shader_path Path to the compute shader.
+     */
+    SolenoidalProcessor(
+        std::string pressure_field,
+        std::string velocity_field,
+        const std::string& shader_path);
+
+    /**
+     * @brief Construct a gradient subtraction stage from a generated ShaderSpec.
+     * @param pressure_field Name of the scalar field differentiated.
+     * @param velocity_field Name of the field corrected.
+     * @param spec ShaderSpec implementing the stencil.
+     */
+    SolenoidalProcessor(
+        std::string pressure_field,
+        std::string velocity_field,
+        const Portal::Graphics::ShaderSpec& spec);
+
+    /** @brief Name of the field this stage differentiates. */
+    [[nodiscard]] const std::string& get_pressure_field() const { return m_pressure_field; }
+
+    /** @brief Name of the field this stage corrects. */
+    [[nodiscard]] const std::string& get_velocity_field() const { return m_velocity_field; }
+
+protected:
+    /**
+     * @brief Size the dispatch to the lattice and write the parameter
+     *        block, once the attached volume's dimensions are known.
+     * @param buffer The attached buffer, expected to be a VolumeGridBuffer.
+     */
+    void on_attach(const std::shared_ptr<Buffer>& buffer) override;
+
+    /**
+     * @brief Write the three field descriptors for the current slot
+     *        assignment.
+     */
+    void on_descriptors_created() override;
+
+    /**
+     * @brief Reject buffers that are not VolumeGridBuffer.
+     * @param cmd_id Command buffer this cycle's dispatch will be recorded into.
+     * @param buffer The attached buffer, received as VKBuffer.
+     * @return True if the attached buffer is a VolumeGridBuffer.
+     */
+    bool on_before_execute(Portal::Graphics::CommandBufferID cmd_id, const std::shared_ptr<VKBuffer>& buffer) override;
+
+    /**
+     * @brief Write the field descriptors for this cycle's slot assignment,
+     *        run the normal shader processing path, then swap the velocity
+     *        field.
+     */
+    void processing_function(const std::shared_ptr<Buffer>& buffer) override;
+
+private:
+    /**
+     * @brief Issue direct ShaderFoundry descriptor writes for the pressure
+     *        read slot and both velocity slots.
+     */
+    void write_field_descriptors();
+
+    /**
+     * @brief Size the push constant block to at least SolenoidalParams and
+     *        write the attached volume's lattice dimensions and cell size.
+     */
+    void write_params();
+
+    std::string m_pressure_field;
+    std::string m_velocity_field;
+
+    std::shared_ptr<VolumeGridBuffer> m_volume; ///< The attached volume, cached for descriptor writes and the slot swap.
+};
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/VolumeFieldProcessor.cpp
+++ b/src/MayaFlux/Buffers/State/VolumeFieldProcessor.cpp
@@ -156,6 +156,16 @@ void VolumeFieldProcessor::write_lattice_word3(uint32_t value)
     std::memcpy(data.data() + k_word3_offset, &value, sizeof(uint32_t));
 }
 
+void VolumeFieldProcessor::write_lattice_word7(float value)
+{
+    auto& data = get_push_constant_data();
+    if (data.size() < sizeof(LatticeParams)) {
+        return;
+    }
+
+    std::memcpy(data.data() + k_word7_offset, &value, sizeof(float));
+}
+
 void VolumeFieldProcessor::write_param_tail(size_t offset, const void* data_in, size_t size)
 {
     if (offset < k_word7_offset) {

--- a/src/MayaFlux/Buffers/State/VolumeFieldProcessor.cpp
+++ b/src/MayaFlux/Buffers/State/VolumeFieldProcessor.cpp
@@ -1,0 +1,224 @@
+#include "VolumeFieldProcessor.hpp"
+#include "VolumeGridBuffer.hpp"
+
+namespace MayaFlux::Buffers {
+
+namespace {
+    constexpr uint32_t k_workgroup_x = 8;
+    constexpr uint32_t k_workgroup_y = 8;
+    constexpr uint32_t k_workgroup_z = 4;
+    constexpr size_t k_word3_offset = offsetof(VolumeFieldProcessor::LatticeParams, word3);
+    constexpr size_t k_word7_offset = offsetof(VolumeFieldProcessor::LatticeParams, word7);
+}
+
+VolumeFieldProcessor::VolumeFieldProcessor(
+    std::vector<FieldBinding> bindings, const std::string& shader_path)
+    : ComputeProcessor(shader_path, k_workgroup_x)
+    , m_bindings(std::move(bindings))
+{
+    register_bindings();
+}
+
+VolumeFieldProcessor::VolumeFieldProcessor(
+    std::vector<FieldBinding> bindings, const Portal::Graphics::ShaderSpec& spec)
+    : ComputeProcessor(spec)
+    , m_bindings(std::move(bindings))
+{
+    register_bindings();
+}
+
+void VolumeFieldProcessor::register_bindings()
+{
+    for (const auto& entry : m_bindings) {
+        m_config.bindings[entry.name]
+            = ShaderBinding(0, entry.binding, vk::DescriptorType::eStorageBuffer);
+    }
+}
+
+void VolumeFieldProcessor::add_swap_field(std::string field)
+{
+    m_swap_fields.push_back(std::move(field));
+}
+
+void VolumeFieldProcessor::reserve_param_size(size_t size)
+{
+    if (m_config.push_constant_size < size) {
+        set_push_constant_size(size);
+    }
+}
+
+bool VolumeFieldProcessor::validate_fields()
+{
+    for (const auto& entry : m_bindings) {
+        if (!m_volume->has_field(entry.field)) {
+            MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+                "VolumeFieldProcessor: volume has no field '{}' for binding '{}'",
+                entry.field, entry.name);
+            return false;
+        }
+    }
+
+    for (const auto& entry : m_bindings) {
+        if (entry.access != FieldAccess::WRITE) {
+            continue;
+        }
+
+        const bool also_read = std::ranges::any_of(m_bindings, [&](const FieldBinding& other) {
+            return other.access == FieldAccess::READ && other.field == entry.field;
+        });
+
+        if (!also_read) {
+            continue;
+        }
+
+        if (m_volume->read_handle(entry.field) == m_volume->write_handle(entry.field)) {
+            MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+                "VolumeFieldProcessor: field '{}' is bound for both read and write "
+                "but is not double-buffered",
+                entry.field);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void VolumeFieldProcessor::size_dispatch()
+{
+    set_workgroup_size(k_workgroup_x, k_workgroup_y, k_workgroup_z);
+    set_dispatch_mode(ShaderDispatchConfig::DispatchMode::MANUAL);
+    set_manual_dispatch(
+        (m_volume->get_width() + k_workgroup_x - 1) / k_workgroup_x,
+        (m_volume->get_height() + k_workgroup_y - 1) / k_workgroup_y,
+        (m_volume->get_depth() + k_workgroup_z - 1) / k_workgroup_z);
+}
+
+void VolumeFieldProcessor::on_attach(const std::shared_ptr<Buffer>& buffer)
+{
+    ComputeProcessor::on_attach(buffer);
+
+    m_volume = std::dynamic_pointer_cast<VolumeGridBuffer>(buffer);
+    if (!m_volume) {
+        return;
+    }
+
+    if (!validate_fields()) {
+        m_volume.reset();
+        return;
+    }
+
+    size_dispatch();
+    reserve_param_size(sizeof(LatticeParams));
+    write_lattice_params();
+
+    on_volume_ready();
+}
+
+void VolumeFieldProcessor::write_lattice_params()
+{
+    if (!m_volume) {
+        return;
+    }
+
+    auto& data = get_push_constant_data();
+    if (data.size() < m_config.push_constant_size) {
+        data.resize(m_config.push_constant_size);
+    }
+
+    const glm::vec3 cell = m_volume->get_cell_size();
+
+    uint32_t preserved_3 = 0;
+    float preserved_7 = 0.0F;
+    std::memcpy(&preserved_3, data.data() + k_word3_offset, sizeof(uint32_t));
+    std::memcpy(&preserved_7, data.data() + k_word7_offset, sizeof(float));
+
+    const LatticeParams params {
+        .width = m_volume->get_width(),
+        .height = m_volume->get_height(),
+        .depth = m_volume->get_depth(),
+        .word3 = preserved_3,
+        .cell_size_x = cell.x,
+        .cell_size_y = cell.y,
+        .cell_size_z = cell.z,
+        .word7 = preserved_7,
+    };
+
+    std::memcpy(data.data(), &params, sizeof(LatticeParams));
+}
+
+void VolumeFieldProcessor::write_lattice_word3(uint32_t value)
+{
+    auto& data = get_push_constant_data();
+    if (data.size() < sizeof(LatticeParams)) {
+        return;
+    }
+
+    std::memcpy(data.data() + k_word3_offset, &value, sizeof(uint32_t));
+}
+
+void VolumeFieldProcessor::write_param_tail(size_t offset, const void* data_in, size_t size)
+{
+    if (offset < k_word7_offset) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "VolumeFieldProcessor: parameter offset {} overlaps the shared prefix",
+            offset);
+        return;
+    }
+
+    auto& data = get_push_constant_data();
+    if (data.size() < offset + size) {
+        data.resize(offset + size);
+    }
+
+    std::memcpy(data.data() + offset, data_in, size);
+}
+
+void VolumeFieldProcessor::write_field_descriptors()
+{
+    if (!m_volume || m_descriptor_set_ids.empty()) {
+        return;
+    }
+
+    auto& foundry = Portal::Graphics::get_shader_foundry();
+
+    for (const auto& entry : m_bindings) {
+        const vk::Buffer handle = entry.access == FieldAccess::READ
+            ? m_volume->read_handle(entry.field)
+            : m_volume->write_handle(entry.field);
+
+        foundry.update_descriptor_buffer(
+            m_descriptor_set_ids[0], entry.binding, vk::DescriptorType::eStorageBuffer,
+            handle, 0, m_volume->get_field_bytes(entry.field));
+    }
+}
+
+void VolumeFieldProcessor::on_descriptors_created()
+{
+    write_field_descriptors();
+}
+
+void VolumeFieldProcessor::processing_function(const std::shared_ptr<Buffer>& buffer)
+{
+    if (m_volume && are_descriptors_ready()) {
+        write_field_descriptors();
+    }
+
+    ComputeProcessor::processing_function(buffer);
+
+    if (!m_volume || !wants_swap()) {
+        return;
+    }
+
+    for (const auto& field : m_swap_fields) {
+        m_volume->swap_field(field);
+    }
+}
+
+bool VolumeFieldProcessor::on_before_execute(
+    Portal::Graphics::CommandBufferID /*cmd_id*/,
+    const std::shared_ptr<VKBuffer>& buffer)
+{
+    return m_volume && std::dynamic_pointer_cast<VolumeGridBuffer>(buffer) != nullptr;
+}
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/VolumeFieldProcessor.cpp
+++ b/src/MayaFlux/Buffers/State/VolumeFieldProcessor.cpp
@@ -7,8 +7,25 @@ namespace {
     constexpr uint32_t k_workgroup_x = 8;
     constexpr uint32_t k_workgroup_y = 8;
     constexpr uint32_t k_workgroup_z = 4;
-    constexpr size_t k_word3_offset = offsetof(VolumeFieldProcessor::LatticeParams, word3);
-    constexpr size_t k_word7_offset = offsetof(VolumeFieldProcessor::LatticeParams, word7);
+
+    /**
+     * @struct LatticePrefix
+     * @brief Byte layout of the parameter block's leading eight words.
+     */
+    struct LatticePrefix {
+        uint32_t width;
+        uint32_t height;
+        uint32_t depth;
+        uint32_t word3;
+        float cell_size_x;
+        float cell_size_y;
+        float cell_size_z;
+        float word7;
+    };
+
+    constexpr size_t k_word3_offset = offsetof(LatticePrefix, word3);
+    constexpr size_t k_word7_offset = offsetof(LatticePrefix, word7);
+    constexpr size_t k_prefix_size = sizeof(LatticePrefix);
 }
 
 VolumeFieldProcessor::VolumeFieldProcessor(
@@ -85,12 +102,14 @@ bool VolumeFieldProcessor::validate_fields()
 
 void VolumeFieldProcessor::size_dispatch()
 {
+    const glm::uvec3 res = m_volume->get_lattice().resolution;
+
     set_workgroup_size(k_workgroup_x, k_workgroup_y, k_workgroup_z);
     set_dispatch_mode(ShaderDispatchConfig::DispatchMode::MANUAL);
     set_manual_dispatch(
-        (m_volume->get_width() + k_workgroup_x - 1) / k_workgroup_x,
-        (m_volume->get_height() + k_workgroup_y - 1) / k_workgroup_y,
-        (m_volume->get_depth() + k_workgroup_z - 1) / k_workgroup_z);
+        (res.x + k_workgroup_x - 1) / k_workgroup_x,
+        (res.y + k_workgroup_y - 1) / k_workgroup_y,
+        (res.z + k_workgroup_z - 1) / k_workgroup_z);
 }
 
 void VolumeFieldProcessor::on_attach(const std::shared_ptr<Buffer>& buffer)
@@ -108,7 +127,7 @@ void VolumeFieldProcessor::on_attach(const std::shared_ptr<Buffer>& buffer)
     }
 
     size_dispatch();
-    reserve_param_size(sizeof(LatticeParams));
+    reserve_param_size(k_prefix_size);
     write_lattice_params();
 
     on_volume_ready();
@@ -125,17 +144,18 @@ void VolumeFieldProcessor::write_lattice_params()
         data.resize(m_config.push_constant_size);
     }
 
-    const glm::vec3 cell = m_volume->get_cell_size();
+    const Kinesis::Lattice3D& lattice = m_volume->get_lattice();
+    const glm::vec3 cell = lattice.cell_size();
 
     uint32_t preserved_3 = 0;
     float preserved_7 = 0.0F;
     std::memcpy(&preserved_3, data.data() + k_word3_offset, sizeof(uint32_t));
     std::memcpy(&preserved_7, data.data() + k_word7_offset, sizeof(float));
 
-    const LatticeParams params {
-        .width = m_volume->get_width(),
-        .height = m_volume->get_height(),
-        .depth = m_volume->get_depth(),
+    const LatticePrefix prefix {
+        .width = lattice.resolution.x,
+        .height = lattice.resolution.y,
+        .depth = lattice.resolution.z,
         .word3 = preserved_3,
         .cell_size_x = cell.x,
         .cell_size_y = cell.y,
@@ -143,13 +163,13 @@ void VolumeFieldProcessor::write_lattice_params()
         .word7 = preserved_7,
     };
 
-    std::memcpy(data.data(), &params, sizeof(LatticeParams));
+    std::memcpy(data.data(), &prefix, k_prefix_size);
 }
 
 void VolumeFieldProcessor::write_lattice_word3(uint32_t value)
 {
     auto& data = get_push_constant_data();
-    if (data.size() < sizeof(LatticeParams)) {
+    if (data.size() < k_prefix_size) {
         return;
     }
 
@@ -159,7 +179,7 @@ void VolumeFieldProcessor::write_lattice_word3(uint32_t value)
 void VolumeFieldProcessor::write_lattice_word7(float value)
 {
     auto& data = get_push_constant_data();
-    if (data.size() < sizeof(LatticeParams)) {
+    if (data.size() < k_prefix_size) {
         return;
     }
 
@@ -168,10 +188,9 @@ void VolumeFieldProcessor::write_lattice_word7(float value)
 
 void VolumeFieldProcessor::write_param_tail(size_t offset, const void* data_in, size_t size)
 {
-    if (offset < k_word7_offset) {
+    if (offset < k_prefix_size) {
         MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
-            "VolumeFieldProcessor: parameter offset {} overlaps the shared prefix",
-            offset);
+            "VolumeFieldProcessor: parameter offset {} overlaps the prefix", offset);
         return;
     }
 

--- a/src/MayaFlux/Buffers/State/VolumeFieldProcessor.hpp
+++ b/src/MayaFlux/Buffers/State/VolumeFieldProcessor.hpp
@@ -17,6 +17,12 @@ class VolumeGridBuffer;
  * Subclasses supply only a binding table and whatever parameter words
  * follow the shared prefix.
  *
+ * The parameter block opens with a fixed prefix: three lattice extents, a
+ * subclass word, three cell sizes, a second subclass word. The layout is
+ * private to the base. Subclasses reach it through write_lattice_word3,
+ * write_lattice_word7, and write_param_tail, which rejects any offset
+ * overlapping the prefix.
+ *
  * The binding table drives both descriptor writes and validation. A field
  * appearing with both READ and WRITE access is required to be
  * double-buffered, since the stage would otherwise read a neighbourhood
@@ -55,26 +61,6 @@ public:
         uint32_t binding; ///< Binding index within set 0.
         std::string field; ///< Field name on the attached volume.
         FieldAccess access; ///< Which slot of that field.
-    };
-
-    /**
-     * @struct LatticeParams
-     * @brief Leading words of every volume stage's push constant block.
-     *
-     * Words three and seven are left to the subclass: PressureProcessor
-     * carries parity in word three, AdvectProcessor carries its time step
-     * in word seven, and the others leave both zero. Parameters beyond
-     * word seven are written through write_param_tail.
-     */
-    struct LatticeParams {
-        uint32_t width;
-        uint32_t height;
-        uint32_t depth;
-        uint32_t word3;
-        float cell_size_x;
-        float cell_size_y;
-        float cell_size_z;
-        float word7;
     };
 
     /** @brief The attached volume, or null if attachment failed validation. */
@@ -165,8 +151,8 @@ protected:
     void write_lattice_word3(uint32_t value);
 
     /**
-     * @brief Write word seven of the shared prefix.
-     * @param value Subclass-defined float, typically a rate or coefficient.
+     * @brief Write word seven of the parameter prefix, at byte offset 28.
+     * @param value Subclass-defined float, typically a rate or step.
      */
     void write_lattice_word7(float value);
 

--- a/src/MayaFlux/Buffers/State/VolumeFieldProcessor.hpp
+++ b/src/MayaFlux/Buffers/State/VolumeFieldProcessor.hpp
@@ -165,6 +165,12 @@ protected:
     void write_lattice_word3(uint32_t value);
 
     /**
+     * @brief Write word seven of the shared prefix.
+     * @param value Subclass-defined float, typically a rate or coefficient.
+     */
+    void write_lattice_word7(float value);
+
+    /**
      * @brief Write subclass parameters past the shared prefix.
      * @param offset Byte offset from the start of the push constant block.
      *        Values below sizeof(LatticeParams) are rejected.

--- a/src/MayaFlux/Buffers/State/VolumeFieldProcessor.hpp
+++ b/src/MayaFlux/Buffers/State/VolumeFieldProcessor.hpp
@@ -1,0 +1,214 @@
+#pragma once
+
+#include "MayaFlux/Buffers/Shaders/ComputeProcessor.hpp"
+
+namespace MayaFlux::Buffers {
+
+class VolumeGridBuffer;
+
+/**
+ * @class VolumeFieldProcessor
+ * @brief ComputeProcessor operating on named fields of a VolumeGridBuffer.
+ *
+ * Holds everything the lattice stages share: validating field names
+ * against the attached volume, sizing the dispatch from the lattice,
+ * writing the common leading push constant words, rewriting field
+ * descriptors every cycle, and swapping slots after the dispatch.
+ * Subclasses supply only a binding table and whatever parameter words
+ * follow the shared prefix.
+ *
+ * The binding table drives both descriptor writes and validation. A field
+ * appearing with both READ and WRITE access is required to be
+ * double-buffered, since the stage would otherwise read a neighbourhood
+ * of the storage it is writing. A field appearing only as WRITE carries
+ * no such requirement.
+ *
+ * Descriptors are written directly through
+ * ShaderFoundry::update_descriptor_buffer rather than bind_buffer, since
+ * VolumeGridBuffer's field storage consists of raw handle pairs with no
+ * VKBuffer wrapper. The write happens in processing_function, before
+ * execute_shader binds the set into the command buffer, because a
+ * descriptor set already bound into an open command buffer cannot be
+ * rewritten.
+ *
+ * Slot swaps happen in processing_function after the parent call rather
+ * than in on_after_execute, which fires more than once per cycle. A swap
+ * is not idempotent.
+ */
+class MAYAFLUX_API VolumeFieldProcessor : public ComputeProcessor {
+public:
+    /**
+     * @enum FieldAccess
+     * @brief Which slot of a field a binding resolves to.
+     */
+    enum class FieldAccess {
+        READ, ///< Resolves to VolumeGridBuffer::read_handle.
+        WRITE ///< Resolves to VolumeGridBuffer::write_handle.
+    };
+
+    /**
+     * @struct FieldBinding
+     * @brief One shader binding and the field slot it draws from.
+     */
+    struct FieldBinding {
+        std::string name; ///< Shader binding name, as declared in ShaderConfig.
+        uint32_t binding; ///< Binding index within set 0.
+        std::string field; ///< Field name on the attached volume.
+        FieldAccess access; ///< Which slot of that field.
+    };
+
+    /**
+     * @struct LatticeParams
+     * @brief Leading words of every volume stage's push constant block.
+     *
+     * Words three and seven are left to the subclass: PressureProcessor
+     * carries parity in word three, AdvectProcessor carries its time step
+     * in word seven, and the others leave both zero. Parameters beyond
+     * word seven are written through write_param_tail.
+     */
+    struct LatticeParams {
+        uint32_t width;
+        uint32_t height;
+        uint32_t depth;
+        uint32_t word3;
+        float cell_size_x;
+        float cell_size_y;
+        float cell_size_z;
+        float word7;
+    };
+
+    /** @brief The attached volume, or null if attachment failed validation. */
+    [[nodiscard]] const std::shared_ptr<VolumeGridBuffer>& get_volume() const { return m_volume; }
+
+protected:
+    /**
+     * @brief Construct from a shader path.
+     * @param bindings Binding table. Entries are registered into
+     *        m_config.bindings in order.
+     * @param shader_path Path to the compute shader.
+     */
+    VolumeFieldProcessor(std::vector<FieldBinding> bindings, const std::string& shader_path);
+
+    /**
+     * @brief Construct from a generated ShaderSpec.
+     * @param bindings Binding table.
+     * @param spec ShaderSpec implementing the stage.
+     */
+    VolumeFieldProcessor(std::vector<FieldBinding> bindings, const Portal::Graphics::ShaderSpec& spec);
+
+    /**
+     * @brief Cache and validate the volume, size the dispatch, write the
+     *        shared parameter prefix, then call on_volume_ready.
+     * @param buffer The attached buffer, expected to be a VolumeGridBuffer.
+     *
+     * On any validation failure the cached volume is reset, which makes
+     * on_before_execute reject every subsequent cycle.
+     */
+    void on_attach(const std::shared_ptr<Buffer>& buffer) override;
+
+    /**
+     * @brief Write every binding in the table for the current slot assignment.
+     */
+    void on_descriptors_created() override;
+
+    /**
+     * @brief Reject buffers that are not the validated volume.
+     * @param cmd_id Command buffer this cycle's dispatch will be recorded into.
+     * @param buffer The attached buffer, received as VKBuffer.
+     * @return True if a volume survived validation and matches the argument.
+     */
+    bool on_before_execute(Portal::Graphics::CommandBufferID cmd_id, const std::shared_ptr<VKBuffer>& buffer) override;
+
+    /**
+     * @brief Rewrite field descriptors, run the shader, then swap.
+     * @param buffer Buffer under processing.
+     *
+     * Read slots change whenever an upstream stage swaps, so the bindings
+     * are rewritten every cycle rather than once.
+     */
+    void processing_function(const std::shared_ptr<Buffer>& buffer) override;
+
+    /**
+     * @brief Hook for subclass parameters, called at the end of on_attach.
+     *
+     * The volume is non-null and the shared prefix is already written when
+     * this runs. Subclasses writing parameters past the prefix override
+     * this rather than on_attach.
+     */
+    virtual void on_volume_ready() { }
+
+    /**
+     * @brief Whether this cycle's dispatch should be followed by a swap.
+     * @return True by default.
+     *
+     * PressureProcessor overrides this: after an even number of Jacobi
+     * passes the result is already in the read slot.
+     */
+    [[nodiscard]] virtual bool wants_swap() const { return true; }
+
+    /**
+     * @brief Register a field to swap after each dispatch.
+     * @param field Field name. Order of registration is order of swap.
+     */
+    void add_swap_field(std::string field);
+
+    /**
+     * @brief Write the lattice dimensions and cell size into the staged
+     *        push constant block, preserving word three.
+     */
+    void write_lattice_params();
+
+    /**
+     * @brief Write word three of the shared prefix.
+     * @param value Subclass-defined word, typically a mode or parity flag.
+     */
+    void write_lattice_word3(uint32_t value);
+
+    /**
+     * @brief Write subclass parameters past the shared prefix.
+     * @param offset Byte offset from the start of the push constant block.
+     *        Values below sizeof(LatticeParams) are rejected.
+     * @param data Source bytes.
+     * @param size Byte count.
+     */
+    void write_param_tail(size_t offset, const void* data, size_t size);
+
+    /**
+     * @brief Raise the push constant block to at least this size.
+     * @param size Byte count the subclass's full parameter struct occupies.
+     *
+     * Called from the subclass constructor. The base raises the block to
+     * sizeof(LatticeParams) independently.
+     */
+    void reserve_param_size(size_t size);
+
+private:
+    /**
+     * @brief Register the binding table into m_config.bindings.
+     */
+    void register_bindings();
+
+    /**
+     * @brief Check every named field exists and that read-write fields
+     *        carry two slots.
+     * @return True if the cached volume satisfies the binding table.
+     */
+    bool validate_fields();
+
+    /**
+     * @brief Size the manual dispatch to cover the lattice.
+     */
+    void size_dispatch();
+
+    /**
+     * @brief Issue descriptor writes for every entry in the binding table.
+     */
+    void write_field_descriptors();
+
+    std::vector<FieldBinding> m_bindings;
+    std::vector<std::string> m_swap_fields;
+
+    std::shared_ptr<VolumeGridBuffer> m_volume; ///< The attached volume, null until on_attach validates it.
+};
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/VolumeGridBuffer.cpp
+++ b/src/MayaFlux/Buffers/State/VolumeGridBuffer.cpp
@@ -1,8 +1,12 @@
 #include "VolumeGridBuffer.hpp"
 
 #include "MayaFlux/Buffers/BufferProcessingChain.hpp"
+#include "MayaFlux/Buffers/Shaders/RenderProcessor.hpp"
+#include "MayaFlux/Buffers/Shaders/SDFMeshProcessor.hpp"
 #include "MayaFlux/Buffers/Staging/StagingUtils.hpp"
+#include "MayaFlux/Buffers/State/VolumeSurfaceProcessor.hpp"
 #include "MayaFlux/Journal/Archivist.hpp"
+#include "MayaFlux/Kakshya/NDData/VertexFormats.hpp"
 #include "MayaFlux/Registry/BackendRegistry.hpp"
 #include "MayaFlux/Registry/Service/BufferService.hpp"
 
@@ -13,8 +17,9 @@ VolumeGridBuffer::VolumeGridBuffer(
     uint32_t height,
     uint32_t depth,
     std::initializer_list<FieldDecl> fields,
-    Kinesis::AABB3D bounds)
-    : VolumeGridBuffer(width, height, depth, std::vector<FieldDecl>(fields), bounds)
+    Kinesis::AABB3D bounds,
+    std::optional<SurfaceConfig> surface)
+    : VolumeGridBuffer(width, height, depth, std::vector<FieldDecl>(fields), bounds, std::move(surface))
 {
 }
 
@@ -23,12 +28,14 @@ VolumeGridBuffer::VolumeGridBuffer(
     uint32_t height,
     uint32_t depth,
     std::vector<FieldDecl> fields,
-    Kinesis::AABB3D bounds)
-    : VKBuffer(1, Usage::COMPUTE, Kakshya::DataModality::VOLUMETRIC_3D)
+    Kinesis::AABB3D bounds,
+    std::optional<SurfaceConfig> surface)
+    : VKBuffer(surface_storage_bytes(surface), Usage::VERTEX, Kakshya::DataModality::VERTICES_3D)
     , m_width(width)
     , m_height(height)
     , m_depth(depth)
     , m_bounds(bounds)
+    , m_surface(std::move(surface))
 {
     force_internal_usage(true);
     allocate_fields(fields);
@@ -134,8 +141,73 @@ void VolumeGridBuffer::setup_processors(ProcessingToken token)
     }
     chain->set_preferred_token(token);
 
+    if (!m_surface) {
+        MF_DEBUG(Journal::Component::Buffers, Journal::Context::Init,
+            "VolumeGridBuffer: chain established, no extraction configured");
+        return;
+    }
+
+    auto self = std::dynamic_pointer_cast<VolumeGridBuffer>(shared_from_this());
+
+    m_surface_processor = std::make_shared<VolumeSurfaceProcessor>(
+        self, m_surface->field_name,
+        m_surface->res_x, m_surface->res_y, m_surface->res_z,
+        m_surface->threshold);
+
+    auto svc = Registry::BackendRegistry::instance()
+                   .get_service<Registry::Service::BufferService>();
+
+    m_counter_buf = std::make_shared<VKBuffer>(
+        sizeof(uint32_t), Usage::HOST_STORAGE, Kakshya::DataModality::UNKNOWN);
+    svc->initialize_buffer(m_counter_buf);
+
+    m_mesh_processor = std::make_shared<SDFMeshProcessor>(
+        m_surface_processor->grid_buf(), m_counter_buf,
+        m_bounds.min, m_bounds.max,
+        m_surface->res_x, m_surface->res_y, m_surface->res_z, 0.0F);
+
+    const uint32_t max_vertices = m_surface_processor->worst_case_vertices();
+    auto layout = Kakshya::VertexLayout::for_meshes(sizeof(Kakshya::MeshVertex));
+    layout.vertex_count = max_vertices;
+    set_vertex_layout(layout);
+
+    m_surface_processor->set_processing_token(token);
+    m_mesh_processor->set_processing_token(token);
+
+    set_default_processor(m_surface_processor);
+    chain->add_processor(m_mesh_processor, self);
+
+    MF_INFO(Journal::Component::Buffers, Journal::Context::Init,
+        "VolumeGridBuffer: surfacing '{}' at {}x{}x{}, {} max vertices",
+        m_surface->field_name, m_surface->res_x, m_surface->res_y,
+        m_surface->res_z, max_vertices);
+
     MF_DEBUG(Journal::Component::Buffers, Journal::Context::Init,
         "VolumeGridBuffer: chain established, no stages attached");
+}
+
+void VolumeGridBuffer::setup_rendering(const RenderConfig& config)
+{
+    if (!m_surface) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::Init,
+            "setup_rendering: no SurfaceConfig was supplied at construction");
+        return;
+    }
+
+    RenderConfig resolved = config;
+    resolved.topology = Portal::Graphics::PrimitiveTopology::TRIANGLE_LIST;
+
+    if (resolved.vertex_shader.empty())
+        resolved.vertex_shader = "triangle.vert.spv";
+    if (resolved.fragment_shader.empty())
+        resolved.fragment_shader = "triangle.frag.spv";
+
+    apply_render_config(resolved, ShaderConfig { resolved.vertex_shader });
+
+    get_processing_chain()->add_final_processor(m_render_processor, shared_from_this());
+
+    m_render_processor->set_vertex_range(0, 0);
+    set_needs_depth_attachment(true);
 }
 
 glm::vec3 VolumeGridBuffer::get_cell_size() const
@@ -320,6 +392,19 @@ void VolumeGridBuffer::read_field(const std::string& name, void* data, size_t si
 
     const uint32_t slot = field->read_is_a ? field->slot_a : field->slot_b;
     download_back_buffer(get_buffer_resources().back_buffers[slot], data, size, m_transfer_staging);
+}
+
+size_t VolumeGridBuffer::surface_storage_bytes(const std::optional<SurfaceConfig>& surface)
+{
+    if (!surface) {
+        return 1;
+    }
+
+    const uint64_t voxels = static_cast<uint64_t>(std::max(surface->res_x, 1U))
+        * std::max(surface->res_y, 1U)
+        * std::max(surface->res_z, 1U);
+
+    return static_cast<size_t>(voxels * 15U * sizeof(Kakshya::MeshVertex));
 }
 
 } // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/VolumeGridBuffer.cpp
+++ b/src/MayaFlux/Buffers/State/VolumeGridBuffer.cpp
@@ -3,7 +3,6 @@
 #include "MayaFlux/Buffers/BufferProcessingChain.hpp"
 #include "MayaFlux/Buffers/Shaders/RenderProcessor.hpp"
 #include "MayaFlux/Buffers/Shaders/SDFMeshProcessor.hpp"
-#include "MayaFlux/Buffers/Staging/StagingUtils.hpp"
 #include "MayaFlux/Buffers/State/VolumeSurfaceProcessor.hpp"
 #include "MayaFlux/Journal/Archivist.hpp"
 #include "MayaFlux/Kakshya/NDData/VertexFormats.hpp"
@@ -30,6 +29,11 @@ VolumeGridBuffer::VolumeGridBuffer(
 {
     force_internal_usage(true);
     allocate_fields(fields);
+}
+
+VolumeGridBuffer::~VolumeGridBuffer()
+{
+    resolve_transfer(m_pending_transfer);
 }
 
 void VolumeGridBuffer::allocate_fields(const std::vector<FieldDecl>& decls)
@@ -343,8 +347,11 @@ void VolumeGridBuffer::seed_raw(const std::string& name, const void* data, size_
         return;
     }
 
+    resolve_transfer(m_pending_transfer);
+
     const uint32_t slot = field->read_is_a ? field->slot_a : field->slot_b;
-    upload_back_buffer(get_buffer_resources().back_buffers[slot], data, size, m_transfer_staging);
+    m_pending_transfer = upload_back_buffer_async(
+        get_buffer_resources().back_buffers[slot], data, size, m_transfer_staging);
 }
 
 void VolumeGridBuffer::accumulate(const std::string& name, const Kinesis::SpatialField& field)
@@ -429,6 +436,7 @@ void VolumeGridBuffer::read_field(const std::string& name, void* data, size_t si
     }
 
     const uint32_t slot = field->read_is_a ? field->slot_a : field->slot_b;
+    resolve_transfer(m_pending_transfer);
     download_back_buffer(get_buffer_resources().back_buffers[slot], data, size, m_transfer_staging);
 }
 

--- a/src/MayaFlux/Buffers/State/VolumeGridBuffer.cpp
+++ b/src/MayaFlux/Buffers/State/VolumeGridBuffer.cpp
@@ -3,11 +3,21 @@
 #include "MayaFlux/Buffers/BufferProcessingChain.hpp"
 #include "MayaFlux/Buffers/Shaders/RenderProcessor.hpp"
 #include "MayaFlux/Buffers/Shaders/SDFMeshProcessor.hpp"
-#include "MayaFlux/Buffers/State/VolumeSurfaceProcessor.hpp"
+
 #include "MayaFlux/Journal/Archivist.hpp"
 #include "MayaFlux/Kakshya/NDData/VertexFormats.hpp"
+
 #include "MayaFlux/Registry/BackendRegistry.hpp"
 #include "MayaFlux/Registry/Service/BufferService.hpp"
+
+#include "AdvectProcessor.hpp"
+#include "BuoyancyProcessor.hpp"
+#include "DiffuseProcessor.hpp"
+#include "DivergenceProcessor.hpp"
+#include "PressureProcessor.hpp"
+#include "SolenoidalProcessor.hpp"
+#include "VolumeSurfaceProcessor.hpp"
+#include "WallProcessor.hpp"
 
 namespace MayaFlux::Buffers {
 
@@ -31,13 +41,42 @@ VolumeGridBuffer::VolumeGridBuffer(
     allocate_fields(fields);
 }
 
+VolumeGridBuffer::VolumeGridBuffer(
+    Kinesis::Lattice3D lattice,
+    std::optional<SurfaceConfig> surface)
+    : VKBuffer(surface_storage_bytes(surface), Usage::VERTEX, Kakshya::DataModality::VERTICES_3D)
+    , m_lattice(lattice)
+    , m_surface(std::move(surface))
+{
+    force_internal_usage(true);
+}
+
 VolumeGridBuffer::~VolumeGridBuffer()
 {
     resolve_transfer(m_pending_transfer);
 }
 
-void VolumeGridBuffer::allocate_fields(const std::vector<FieldDecl>& decls)
+bool VolumeGridBuffer::allocate_field(
+    const std::string& name, size_t stride_bytes, bool double_buffered)
 {
+    if (name.empty()) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::Init,
+            "VolumeGridBuffer: field declared with empty name, skipped");
+        return false;
+    }
+
+    if (stride_bytes == 0) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::Init,
+            "VolumeGridBuffer: field '{}' declares zero stride, skipped", name);
+        return false;
+    }
+
+    if (m_fields.contains(name)) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::Init,
+            "VolumeGridBuffer: duplicate field '{}', later declaration discarded", name);
+        return false;
+    }
+
     auto buffer_service = Registry::BackendRegistry::instance()
                               .get_service<Registry::Service::BufferService>();
 
@@ -59,58 +98,49 @@ void VolumeGridBuffer::allocate_fields(const std::vector<FieldDecl>& decls)
         static_cast<VkMemoryPropertyFlags>(vk::MemoryPropertyFlagBits::eDeviceLocal));
 
     auto& resources = get_buffer_resources();
-    const uint32_t cells = get_cell_count();
+    const size_t field_bytes = static_cast<size_t>(get_cell_count()) * stride_bytes;
+    const uint32_t slot_count = double_buffered ? 2 : 1;
 
-    size_t total_bytes = 0;
-    size_t largest_field = 0;
+    Field field {
+        .stride_bytes = stride_bytes,
+        .slot_a = static_cast<uint32_t>(resources.back_buffers.size()),
+        .slot_b = 0,
+        .read_is_a = true,
+    };
 
+    for (uint32_t i = 0; i < slot_count; ++i) {
+        void* out_buffer = nullptr;
+        void* out_memory = nullptr;
+        void* out_mapped = nullptr;
+
+        buffer_service->allocate_raw_buffer(
+            field_bytes, usage_flags, memory_flags, false,
+            out_buffer, out_memory, out_mapped);
+
+        VKBufferResources::GenerationSlot slot;
+        slot.buffer = static_cast<vk::Buffer>(static_cast<VkBuffer>(out_buffer));
+        slot.memory = static_cast<vk::DeviceMemory>(static_cast<VkDeviceMemory>(out_memory));
+        slot.mapped_ptr = out_mapped;
+
+        resources.back_buffers.push_back(slot);
+    }
+
+    field.slot_b = double_buffered ? field.slot_a + 1 : field.slot_a;
+
+    m_fields.emplace(name, field);
+    m_field_order.push_back(name);
+
+    MF_DEBUG(Journal::Component::Buffers, Journal::Context::Init,
+        "VolumeGridBuffer: field '{}', stride {}, {} slot(s), {} bytes",
+        name, stride_bytes, slot_count, field_bytes * slot_count);
+
+    return true;
+}
+
+void VolumeGridBuffer::allocate_fields(const std::vector<FieldDecl>& decls)
+{
     for (const auto& decl : decls) {
-        if (decl.stride_bytes == 0) {
-            MF_ERROR(Journal::Component::Buffers, Journal::Context::Init,
-                "VolumeGridBuffer: field '{}' declares zero stride, skipped", decl.name);
-            continue;
-        }
-
-        if (m_fields.contains(decl.name)) {
-            MF_ERROR(Journal::Component::Buffers, Journal::Context::Init,
-                "VolumeGridBuffer: duplicate field '{}', later declaration discarded", decl.name);
-            continue;
-        }
-
-        const size_t field_bytes = static_cast<size_t>(cells) * decl.stride_bytes;
-        const uint32_t slot_count = decl.double_buffered ? 2 : 1;
-
-        Field field {
-            .stride_bytes = decl.stride_bytes,
-            .slot_a = static_cast<uint32_t>(resources.back_buffers.size()),
-            .slot_b = 0,
-            .read_is_a = true,
-        };
-
-        for (uint32_t i = 0; i < slot_count; ++i) {
-            void* out_buffer = nullptr;
-            void* out_memory = nullptr;
-            void* out_mapped = nullptr;
-
-            buffer_service->allocate_raw_buffer(
-                field_bytes, usage_flags, memory_flags, false,
-                out_buffer, out_memory, out_mapped);
-
-            VKBufferResources::GenerationSlot slot;
-            slot.buffer = static_cast<vk::Buffer>(static_cast<VkBuffer>(out_buffer));
-            slot.memory = static_cast<vk::DeviceMemory>(static_cast<VkDeviceMemory>(out_memory));
-            slot.mapped_ptr = out_mapped;
-
-            resources.back_buffers.push_back(slot);
-        }
-
-        field.slot_b = decl.double_buffered ? field.slot_a + 1 : field.slot_a;
-
-        m_fields.emplace(decl.name, field);
-        m_field_order.push_back(decl.name);
-
-        total_bytes += field_bytes * slot_count;
-        largest_field = std::max(largest_field, field_bytes);
+        allocate_field(decl.name, decl.stride_bytes, decl.double_buffered);
     }
 
     if (m_fields.empty()) {
@@ -122,9 +152,45 @@ void VolumeGridBuffer::allocate_fields(const std::vector<FieldDecl>& decls)
     }
 
     MF_INFO(Journal::Component::Buffers, Journal::Context::Init,
-        "VolumeGridBuffer: {}x{}x{} lattice, {} fields, {} slots, {} bytes total",
+        "VolumeGridBuffer: {}x{}x{} lattice, {} fields, {} slots",
         m_lattice.resolution.x, m_lattice.resolution.y, m_lattice.resolution.z,
-        m_fields.size(), resources.back_buffers.size(), total_bytes);
+        m_fields.size(), get_buffer_resources().back_buffers.size());
+}
+
+ScalarRef VolumeGridBuffer::declare_scalar(std::string name)
+{
+    if (!allocate_field(name, sizeof(float), true)) {
+        return {};
+    }
+
+    return ScalarRef {
+        .name = std::move(name),
+        .owner = std::dynamic_pointer_cast<VolumeGridBuffer>(shared_from_this()),
+    };
+}
+
+ScalarRef VolumeGridBuffer::declare_scratch(std::string name)
+{
+    if (!allocate_field(name, sizeof(float), false)) {
+        return {};
+    }
+
+    return ScalarRef {
+        .name = std::move(name),
+        .owner = std::dynamic_pointer_cast<VolumeGridBuffer>(shared_from_this()),
+    };
+}
+
+VectorRef VolumeGridBuffer::declare_vector(std::string name)
+{
+    if (!allocate_field(name, sizeof(glm::vec4), true)) {
+        return {};
+    }
+
+    return VectorRef {
+        .name = std::move(name),
+        .owner = std::dynamic_pointer_cast<VolumeGridBuffer>(shared_from_this()),
+    };
 }
 
 void VolumeGridBuffer::setup_processors(ProcessingToken token)
@@ -203,6 +269,122 @@ void VolumeGridBuffer::setup_rendering(const RenderConfig& config)
 
     m_render_processor->set_vertex_range(0, 0);
     set_needs_depth_attachment(true);
+}
+
+VolumeGridBuffer::FlowStages VolumeGridBuffer::setup_flow(const FlowConfig& config)
+{
+    FlowStages stages;
+
+    auto self = std::dynamic_pointer_cast<VolumeGridBuffer>(shared_from_this());
+    auto chain = get_processing_chain();
+
+    if (!chain) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::Init,
+            "setup_flow: no processing chain, call after registration");
+        return stages;
+    }
+
+    const auto require = [this](const std::string& name, const char* role) {
+        if (name.empty()) {
+            MF_ERROR(Journal::Component::Buffers, Journal::Context::Init,
+                "setup_flow: no field supplied for '{}'", role);
+            return false;
+        }
+        if (!has_field(name)) {
+            MF_ERROR(Journal::Component::Buffers, Journal::Context::Init,
+                "setup_flow: '{}' names no field on this volume, supplied as '{}'",
+                name, role);
+            return false;
+        }
+        return true;
+    };
+
+    if (!require(config.velocity, "velocity")
+        || !require(config.divergence, "divergence")
+        || !require(config.pressure, "pressure")) {
+        return stages;
+    }
+
+    if (config.viscosity > 0.0F && !require(config.scratch, "scratch")) {
+        return stages;
+    }
+
+    stages.self_advect = std::make_shared<AdvectProcessor>(
+        config.velocity, config.velocity, "volume_advect_vector.comp");
+    stages.self_advect->set_time_step(config.time_step);
+    chain->add_processor(stages.self_advect, self);
+
+    if (config.buoyancy) {
+        const auto& b = *config.buoyancy;
+
+        if (!require(b.temperature, "buoyancy.temperature")
+            || !require(b.density, "buoyancy.density")) {
+            return stages;
+        }
+
+        stages.buoyancy = std::make_shared<BuoyancyProcessor>(
+            b.temperature, b.density, config.velocity,
+            b.direction, "volume_buoyancy.comp");
+        stages.buoyancy->set_time_step(config.time_step);
+        stages.buoyancy->set_temperature_gain(b.temperature_gain);
+        stages.buoyancy->set_density_gain(b.density_gain);
+        stages.buoyancy->set_ambient(b.ambient);
+        chain->add_processor(stages.buoyancy, self);
+    }
+
+    if (config.viscosity > 0.0F) {
+        stages.diffuse = std::make_shared<DiffuseProcessor>(
+            config.velocity, config.scratch, "volume_diffuse_vector.comp");
+        stages.diffuse->set_rate(config.viscosity);
+        stages.diffuse->set_time_step(config.time_step);
+        chain->add_processor(stages.diffuse, self);
+    }
+
+    if (config.walls) {
+        stages.wall_advected = std::make_shared<WallProcessor>(
+            config.velocity, "volume_wall.comp");
+        chain->add_processor(stages.wall_advected, self);
+    }
+
+    stages.divergence = std::make_shared<DivergenceProcessor>(
+        config.velocity, config.divergence, "volume_divergence.comp");
+    chain->add_processor(stages.divergence, self);
+
+    stages.pressure = std::make_shared<PressureProcessor>(
+        config.divergence, config.pressure, "volume_pressure_jacobi.comp");
+    stages.pressure->set_iteration_count(config.jacobi_iterations);
+    chain->add_processor(stages.pressure, self);
+
+    stages.solenoidal = std::make_shared<SolenoidalProcessor>(
+        config.pressure, config.velocity, "volume_solenoidal.comp");
+    chain->add_processor(stages.solenoidal, self);
+
+    if (config.walls) {
+        stages.wall_projected = std::make_shared<WallProcessor>(
+            config.velocity, "volume_wall.comp");
+        chain->add_processor(stages.wall_projected, self);
+    }
+
+    for (const auto& carried : config.carried) {
+        if (!require(carried.field, "carried")) {
+            continue;
+        }
+
+        auto advect = std::make_shared<AdvectProcessor>(
+            config.velocity, carried.field, "volume_advect_scalar.comp");
+        advect->set_time_step(config.time_step);
+        advect->set_dissipation(carried.dissipation);
+        chain->add_processor(advect, self);
+
+        stages.carriers.push_back(std::move(advect));
+    }
+
+    MF_INFO(Journal::Component::Buffers, Journal::Context::Init,
+        "VolumeGridBuffer::setup_flow: {} carried, buoyancy {}, viscosity {}, walls {}",
+        stages.carriers.size(), config.buoyancy ? "on" : "off",
+        config.viscosity, config.walls ? "on" : "off");
+
+    return stages;
 }
 
 const VolumeGridBuffer::Field* VolumeGridBuffer::find_field(

--- a/src/MayaFlux/Buffers/State/VolumeGridBuffer.cpp
+++ b/src/MayaFlux/Buffers/State/VolumeGridBuffer.cpp
@@ -1,0 +1,325 @@
+#include "VolumeGridBuffer.hpp"
+
+#include "MayaFlux/Buffers/BufferProcessingChain.hpp"
+#include "MayaFlux/Buffers/Staging/StagingUtils.hpp"
+#include "MayaFlux/Journal/Archivist.hpp"
+#include "MayaFlux/Registry/BackendRegistry.hpp"
+#include "MayaFlux/Registry/Service/BufferService.hpp"
+
+namespace MayaFlux::Buffers {
+
+VolumeGridBuffer::VolumeGridBuffer(
+    uint32_t width,
+    uint32_t height,
+    uint32_t depth,
+    std::initializer_list<FieldDecl> fields,
+    Kinesis::AABB3D bounds)
+    : VolumeGridBuffer(width, height, depth, std::vector<FieldDecl>(fields), bounds)
+{
+}
+
+VolumeGridBuffer::VolumeGridBuffer(
+    uint32_t width,
+    uint32_t height,
+    uint32_t depth,
+    std::vector<FieldDecl> fields,
+    Kinesis::AABB3D bounds)
+    : VKBuffer(1, Usage::COMPUTE, Kakshya::DataModality::VOLUMETRIC_3D)
+    , m_width(width)
+    , m_height(height)
+    , m_depth(depth)
+    , m_bounds(bounds)
+{
+    force_internal_usage(true);
+    allocate_fields(fields);
+}
+
+void VolumeGridBuffer::allocate_fields(const std::vector<FieldDecl>& decls)
+{
+    auto buffer_service = Registry::BackendRegistry::instance()
+                              .get_service<Registry::Service::BufferService>();
+
+    if (!buffer_service || !buffer_service->allocate_raw_buffer) {
+        error<std::runtime_error>(
+            Journal::Component::Buffers,
+            Journal::Context::Init,
+            std::source_location::current(),
+            "VolumeGridBuffer requires a valid buffer service");
+    }
+
+    const auto usage_flags = static_cast<uint32_t>(
+        static_cast<VkBufferUsageFlags>(
+            vk::BufferUsageFlagBits::eStorageBuffer
+            | vk::BufferUsageFlagBits::eTransferSrc
+            | vk::BufferUsageFlagBits::eTransferDst));
+
+    const auto memory_flags = static_cast<uint32_t>(
+        static_cast<VkMemoryPropertyFlags>(vk::MemoryPropertyFlagBits::eDeviceLocal));
+
+    auto& resources = get_buffer_resources();
+    const uint32_t cells = get_cell_count();
+
+    size_t total_bytes = 0;
+    size_t largest_field = 0;
+
+    for (const auto& decl : decls) {
+        if (decl.stride_bytes == 0) {
+            MF_ERROR(Journal::Component::Buffers, Journal::Context::Init,
+                "VolumeGridBuffer: field '{}' declares zero stride, skipped", decl.name);
+            continue;
+        }
+
+        if (m_fields.contains(decl.name)) {
+            MF_ERROR(Journal::Component::Buffers, Journal::Context::Init,
+                "VolumeGridBuffer: duplicate field '{}', later declaration discarded", decl.name);
+            continue;
+        }
+
+        const size_t field_bytes = static_cast<size_t>(cells) * decl.stride_bytes;
+        const uint32_t slot_count = decl.double_buffered ? 2 : 1;
+
+        Field field {
+            .stride_bytes = decl.stride_bytes,
+            .slot_a = static_cast<uint32_t>(resources.back_buffers.size()),
+            .slot_b = 0,
+            .read_is_a = true,
+        };
+
+        for (uint32_t i = 0; i < slot_count; ++i) {
+            void* out_buffer = nullptr;
+            void* out_memory = nullptr;
+            void* out_mapped = nullptr;
+
+            buffer_service->allocate_raw_buffer(
+                field_bytes, usage_flags, memory_flags, false,
+                out_buffer, out_memory, out_mapped);
+
+            VKBufferResources::GenerationSlot slot;
+            slot.buffer = static_cast<vk::Buffer>(static_cast<VkBuffer>(out_buffer));
+            slot.memory = static_cast<vk::DeviceMemory>(static_cast<VkDeviceMemory>(out_memory));
+            slot.mapped_ptr = out_mapped;
+
+            resources.back_buffers.push_back(slot);
+        }
+
+        field.slot_b = decl.double_buffered ? field.slot_a + 1 : field.slot_a;
+
+        m_fields.emplace(decl.name, field);
+        m_field_order.push_back(decl.name);
+
+        total_bytes += field_bytes * slot_count;
+        largest_field = std::max(largest_field, field_bytes);
+    }
+
+    if (m_fields.empty()) {
+        error<std::runtime_error>(
+            Journal::Component::Buffers,
+            Journal::Context::Init,
+            std::source_location::current(),
+            "VolumeGridBuffer constructed with no valid fields");
+    }
+
+    MF_INFO(Journal::Component::Buffers, Journal::Context::Init,
+        "VolumeGridBuffer: {}x{}x{} lattice, {} fields, {} slots, {} bytes total",
+        m_width, m_height, m_depth, m_fields.size(),
+        resources.back_buffers.size(), total_bytes);
+}
+
+void VolumeGridBuffer::setup_processors(ProcessingToken token)
+{
+    auto chain = get_processing_chain();
+    if (!chain) {
+        chain = std::make_shared<BufferProcessingChain>();
+        set_processing_chain(chain);
+    }
+    chain->set_preferred_token(token);
+
+    MF_DEBUG(Journal::Component::Buffers, Journal::Context::Init,
+        "VolumeGridBuffer: chain established, no stages attached");
+}
+
+glm::vec3 VolumeGridBuffer::get_cell_size() const
+{
+    const glm::vec3 extent = m_bounds.extent();
+    return glm::vec3 {
+        extent.x / static_cast<float>(m_width),
+        extent.y / static_cast<float>(m_height),
+        extent.z / static_cast<float>(m_depth),
+    };
+}
+
+glm::vec3 VolumeGridBuffer::cell_centre(uint32_t x, uint32_t y, uint32_t z) const
+{
+    const glm::vec3 cell = get_cell_size();
+    return m_bounds.min
+        + glm::vec3 {
+              (static_cast<float>(x) + 0.5F) * cell.x,
+              (static_cast<float>(y) + 0.5F) * cell.y,
+              (static_cast<float>(z) + 0.5F) * cell.z,
+          };
+}
+
+const VolumeGridBuffer::Field* VolumeGridBuffer::find_field(
+    const std::string& name, const char* context) const
+{
+    auto it = m_fields.find(name);
+    if (it == m_fields.end()) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferManagement,
+            "VolumeGridBuffer::{}: no field named '{}'", context, name);
+        return nullptr;
+    }
+    return &it->second;
+}
+
+bool VolumeGridBuffer::has_field(const std::string& name) const
+{
+    return m_fields.contains(name);
+}
+
+size_t VolumeGridBuffer::get_field_bytes(const std::string& name) const
+{
+    auto it = m_fields.find(name);
+    if (it == m_fields.end()) {
+        return 0;
+    }
+    return static_cast<size_t>(get_cell_count()) * it->second.stride_bytes;
+}
+
+std::vector<std::string> VolumeGridBuffer::get_field_names() const
+{
+    return m_field_order;
+}
+
+vk::Buffer VolumeGridBuffer::read_handle(const std::string& name) const
+{
+    const auto* field = find_field(name, "read_handle");
+    if (!field) {
+        return nullptr;
+    }
+
+    const uint32_t slot = field->read_is_a ? field->slot_a : field->slot_b;
+    return get_buffer_resources().back_buffers[slot].buffer;
+}
+
+vk::Buffer VolumeGridBuffer::write_handle(const std::string& name) const
+{
+    const auto* field = find_field(name, "write_handle");
+    if (!field) {
+        return nullptr;
+    }
+
+    const uint32_t slot = field->read_is_a ? field->slot_b : field->slot_a;
+    return get_buffer_resources().back_buffers[slot].buffer;
+}
+
+void VolumeGridBuffer::swap_field(const std::string& name)
+{
+    auto it = m_fields.find(name);
+    if (it == m_fields.end()) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferManagement,
+            "VolumeGridBuffer::swap_field: no field named '{}'", name);
+        return;
+    }
+
+    if (it->second.slot_a == it->second.slot_b) {
+        return;
+    }
+
+    it->second.read_is_a = !it->second.read_is_a;
+}
+
+void VolumeGridBuffer::seed(const std::string& name, const Kinesis::SpatialField& field)
+{
+    const auto* decl = find_field(name, "seed");
+    if (!decl) {
+        return;
+    }
+
+    if (decl->stride_bytes != sizeof(float)) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferManagement,
+            "VolumeGridBuffer::seed: field '{}' has stride {}, SpatialField requires {}",
+            name, decl->stride_bytes, sizeof(float));
+        return;
+    }
+
+    std::vector<float> values(get_cell_count());
+
+    size_t i = 0;
+    for (uint32_t z = 0; z < m_depth; ++z) {
+        for (uint32_t y = 0; y < m_height; ++y) {
+            for (uint32_t x = 0; x < m_width; ++x) {
+                values[i++] = field(cell_centre(x, y, z));
+            }
+        }
+    }
+
+    seed_raw(name, values.data(), values.size() * sizeof(float));
+}
+
+void VolumeGridBuffer::seed(const std::string& name, const Kinesis::VectorField& field)
+{
+    const auto* decl = find_field(name, "seed");
+    if (!decl) {
+        return;
+    }
+
+    if (decl->stride_bytes != sizeof(glm::vec4)) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferManagement,
+            "VolumeGridBuffer::seed: field '{}' has stride {}, VectorField requires {}",
+            name, decl->stride_bytes, sizeof(glm::vec4));
+        return;
+    }
+
+    std::vector<glm::vec4> values(get_cell_count());
+
+    size_t i = 0;
+    for (uint32_t z = 0; z < m_depth; ++z) {
+        for (uint32_t y = 0; y < m_height; ++y) {
+            for (uint32_t x = 0; x < m_width; ++x) {
+                values[i++] = glm::vec4(field(cell_centre(x, y, z)), 0.0F);
+            }
+        }
+    }
+
+    seed_raw(name, values.data(), values.size() * sizeof(glm::vec4));
+}
+
+void VolumeGridBuffer::seed_raw(const std::string& name, const void* data, size_t size)
+{
+    const auto* field = find_field(name, "seed_raw");
+    if (!field) {
+        return;
+    }
+
+    const size_t expected = static_cast<size_t>(get_cell_count()) * field->stride_bytes;
+    if (size != expected) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferManagement,
+            "VolumeGridBuffer::seed_raw: size {} does not match expected {} for '{}'",
+            size, expected, name);
+        return;
+    }
+
+    const uint32_t slot = field->read_is_a ? field->slot_a : field->slot_b;
+    upload_back_buffer(get_buffer_resources().back_buffers[slot], data, size, m_transfer_staging);
+}
+
+void VolumeGridBuffer::read_field(const std::string& name, void* data, size_t size)
+{
+    const auto* field = find_field(name, "read_field");
+    if (!field) {
+        return;
+    }
+
+    const size_t expected = static_cast<size_t>(get_cell_count()) * field->stride_bytes;
+    if (size != expected) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferManagement,
+            "VolumeGridBuffer::read_field: size {} does not match expected {} for '{}'",
+            size, expected, name);
+        return;
+    }
+
+    const uint32_t slot = field->read_is_a ? field->slot_a : field->slot_b;
+    download_back_buffer(get_buffer_resources().back_buffers[slot], data, size, m_transfer_staging);
+}
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/VolumeGridBuffer.cpp
+++ b/src/MayaFlux/Buffers/State/VolumeGridBuffer.cpp
@@ -13,28 +13,19 @@
 namespace MayaFlux::Buffers {
 
 VolumeGridBuffer::VolumeGridBuffer(
-    uint32_t width,
-    uint32_t height,
-    uint32_t depth,
+    Kinesis::Lattice3D lattice,
     std::initializer_list<FieldDecl> fields,
-    Kinesis::AABB3D bounds,
     std::optional<SurfaceConfig> surface)
-    : VolumeGridBuffer(width, height, depth, std::vector<FieldDecl>(fields), bounds, std::move(surface))
+    : VolumeGridBuffer(lattice, std::vector<FieldDecl>(fields), std::move(surface))
 {
 }
 
 VolumeGridBuffer::VolumeGridBuffer(
-    uint32_t width,
-    uint32_t height,
-    uint32_t depth,
+    Kinesis::Lattice3D lattice,
     std::vector<FieldDecl> fields,
-    Kinesis::AABB3D bounds,
     std::optional<SurfaceConfig> surface)
     : VKBuffer(surface_storage_bytes(surface), Usage::VERTEX, Kakshya::DataModality::VERTICES_3D)
-    , m_width(width)
-    , m_height(height)
-    , m_depth(depth)
-    , m_bounds(bounds)
+    , m_lattice(lattice)
     , m_surface(std::move(surface))
 {
     force_internal_usage(true);
@@ -128,8 +119,8 @@ void VolumeGridBuffer::allocate_fields(const std::vector<FieldDecl>& decls)
 
     MF_INFO(Journal::Component::Buffers, Journal::Context::Init,
         "VolumeGridBuffer: {}x{}x{} lattice, {} fields, {} slots, {} bytes total",
-        m_width, m_height, m_depth, m_fields.size(),
-        resources.back_buffers.size(), total_bytes);
+        m_lattice.resolution.x, m_lattice.resolution.y, m_lattice.resolution.z,
+        m_fields.size(), resources.back_buffers.size(), total_bytes);
 }
 
 void VolumeGridBuffer::setup_processors(ProcessingToken token)
@@ -151,7 +142,7 @@ void VolumeGridBuffer::setup_processors(ProcessingToken token)
 
     m_surface_processor = std::make_shared<VolumeSurfaceProcessor>(
         self, m_surface->field_name,
-        m_surface->res_x, m_surface->res_y, m_surface->res_z,
+        m_lattice.resampled(m_surface->resolution),
         m_surface->threshold);
 
     auto svc = Registry::BackendRegistry::instance()
@@ -163,8 +154,8 @@ void VolumeGridBuffer::setup_processors(ProcessingToken token)
 
     m_mesh_processor = std::make_shared<SDFMeshProcessor>(
         m_surface_processor->grid_buf(), m_counter_buf,
-        m_bounds.min, m_bounds.max,
-        m_surface->res_x, m_surface->res_y, m_surface->res_z, 0.0F);
+        m_lattice.bounds.min, m_lattice.bounds.max,
+        m_surface->resolution.x, m_surface->resolution.y, m_surface->resolution.z, 0.0F);
 
     const uint32_t max_vertices = m_surface_processor->worst_case_vertices();
     auto layout = Kakshya::VertexLayout::for_meshes(sizeof(Kakshya::MeshVertex));
@@ -179,8 +170,8 @@ void VolumeGridBuffer::setup_processors(ProcessingToken token)
 
     MF_INFO(Journal::Component::Buffers, Journal::Context::Init,
         "VolumeGridBuffer: surfacing '{}' at {}x{}x{}, {} max vertices",
-        m_surface->field_name, m_surface->res_x, m_surface->res_y,
-        m_surface->res_z, max_vertices);
+        m_surface->field_name, m_surface->resolution.x, m_surface->resolution.y,
+        m_surface->resolution.z, max_vertices);
 
     MF_DEBUG(Journal::Component::Buffers, Journal::Context::Init,
         "VolumeGridBuffer: chain established, no stages attached");
@@ -208,27 +199,6 @@ void VolumeGridBuffer::setup_rendering(const RenderConfig& config)
 
     m_render_processor->set_vertex_range(0, 0);
     set_needs_depth_attachment(true);
-}
-
-glm::vec3 VolumeGridBuffer::get_cell_size() const
-{
-    const glm::vec3 extent = m_bounds.extent();
-    return glm::vec3 {
-        extent.x / static_cast<float>(m_width),
-        extent.y / static_cast<float>(m_height),
-        extent.z / static_cast<float>(m_depth),
-    };
-}
-
-glm::vec3 VolumeGridBuffer::cell_centre(uint32_t x, uint32_t y, uint32_t z) const
-{
-    const glm::vec3 cell = get_cell_size();
-    return m_bounds.min
-        + glm::vec3 {
-              (static_cast<float>(x) + 0.5F) * cell.x,
-              (static_cast<float>(y) + 0.5F) * cell.y,
-              (static_cast<float>(z) + 0.5F) * cell.z,
-          };
 }
 
 const VolumeGridBuffer::Field* VolumeGridBuffer::find_field(
@@ -314,13 +284,14 @@ void VolumeGridBuffer::seed(const std::string& name, const Kinesis::SpatialField
         return;
     }
 
-    std::vector<float> values(get_cell_count());
+    const glm::uvec3 res = m_lattice.resolution;
+    std::vector<float> values(m_lattice.cell_count());
 
     size_t i = 0;
-    for (uint32_t z = 0; z < m_depth; ++z) {
-        for (uint32_t y = 0; y < m_height; ++y) {
-            for (uint32_t x = 0; x < m_width; ++x) {
-                values[i++] = field(cell_centre(x, y, z));
+    for (uint32_t z = 0; z < res.z; ++z) {
+        for (uint32_t y = 0; y < res.y; ++y) {
+            for (uint32_t x = 0; x < res.x; ++x) {
+                values[i++] = field(m_lattice.cell_center({ x, y, z }));
             }
         }
     }
@@ -342,13 +313,14 @@ void VolumeGridBuffer::seed(const std::string& name, const Kinesis::VectorField&
         return;
     }
 
-    std::vector<glm::vec4> values(get_cell_count());
+    const glm::uvec3 res = m_lattice.resolution;
+    std::vector<glm::vec4> values(m_lattice.cell_count());
 
     size_t i = 0;
-    for (uint32_t z = 0; z < m_depth; ++z) {
-        for (uint32_t y = 0; y < m_height; ++y) {
-            for (uint32_t x = 0; x < m_width; ++x) {
-                values[i++] = glm::vec4(field(cell_centre(x, y, z)), 0.0F);
+    for (uint32_t z = 0; z < res.z; ++z) {
+        for (uint32_t y = 0; y < res.y; ++y) {
+            for (uint32_t x = 0; x < res.x; ++x) {
+                values[i++] = glm::vec4(field(m_lattice.cell_center({ x, y, z })), 0.0F);
             }
         }
     }
@@ -400,10 +372,8 @@ size_t VolumeGridBuffer::surface_storage_bytes(const std::optional<SurfaceConfig
         return 1;
     }
 
-    const uint64_t voxels = static_cast<uint64_t>(std::max(surface->res_x, 1U))
-        * std::max(surface->res_y, 1U)
-        * std::max(surface->res_z, 1U);
-
+    const glm::uvec3 res = glm::max(surface->resolution, glm::uvec3(1U));
+    const uint64_t voxels = static_cast<uint64_t>(res.x) * res.y * res.z;
     return static_cast<size_t>(voxels * 15U * sizeof(Kakshya::MeshVertex));
 }
 

--- a/src/MayaFlux/Buffers/State/VolumeGridBuffer.cpp
+++ b/src/MayaFlux/Buffers/State/VolumeGridBuffer.cpp
@@ -347,6 +347,72 @@ void VolumeGridBuffer::seed_raw(const std::string& name, const void* data, size_
     upload_back_buffer(get_buffer_resources().back_buffers[slot], data, size, m_transfer_staging);
 }
 
+void VolumeGridBuffer::accumulate(const std::string& name, const Kinesis::SpatialField& field)
+{
+    const auto* decl = find_field(name, "accumulate");
+    if (!decl) {
+        return;
+    }
+
+    if (decl->stride_bytes != sizeof(float)) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferManagement,
+            "VolumeGridBuffer::accumulate: field '{}' has stride {}, SpatialField requires {}",
+            name, decl->stride_bytes, sizeof(float));
+        return;
+    }
+
+    const glm::uvec3 res = m_lattice.resolution;
+    std::vector<float> values(m_lattice.cell_count());
+
+    read_field(name, values.data(), values.size() * sizeof(float));
+
+    size_t i = 0;
+    for (uint32_t z = 0; z < res.z; ++z) {
+        for (uint32_t y = 0; y < res.y; ++y) {
+            for (uint32_t x = 0; x < res.x; ++x) {
+                values[i++] += field(m_lattice.cell_center({ x, y, z }));
+            }
+        }
+    }
+
+    seed_raw(name, values.data(), values.size() * sizeof(float));
+}
+
+void VolumeGridBuffer::accumulate(const std::string& name, const Kinesis::VectorField& field)
+{
+    const auto* decl = find_field(name, "accumulate");
+    if (!decl) {
+        return;
+    }
+
+    if (decl->stride_bytes != sizeof(glm::vec4)) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferManagement,
+            "VolumeGridBuffer::accumulate: field '{}' has stride {}, VectorField requires {}",
+            name, decl->stride_bytes, sizeof(glm::vec4));
+        return;
+    }
+
+    const glm::uvec3 res = m_lattice.resolution;
+    std::vector<glm::vec4> values(m_lattice.cell_count());
+
+    read_field(name, values.data(), values.size() * sizeof(glm::vec4));
+
+    size_t i = 0;
+    for (uint32_t z = 0; z < res.z; ++z) {
+        for (uint32_t y = 0; y < res.y; ++y) {
+            for (uint32_t x = 0; x < res.x; ++x) {
+                const glm::vec3 v = field(m_lattice.cell_center({ x, y, z }));
+                values[i].x += v.x;
+                values[i].y += v.y;
+                values[i].z += v.z;
+                ++i;
+            }
+        }
+    }
+
+    seed_raw(name, values.data(), values.size() * sizeof(glm::vec4));
+}
+
 void VolumeGridBuffer::read_field(const std::string& name, void* data, size_t size)
 {
     const auto* field = find_field(name, "read_field");

--- a/src/MayaFlux/Buffers/State/VolumeGridBuffer.hpp
+++ b/src/MayaFlux/Buffers/State/VolumeGridBuffer.hpp
@@ -3,6 +3,8 @@
 #include "MayaFlux/Buffers/VKBuffer.hpp"
 #include "MayaFlux/Kinesis/Spatial/Lattice.hpp"
 
+#include "MayaFlux/Buffers/Staging/StagingUtils.hpp"
+
 namespace MayaFlux::Buffers {
 
 class VolumeSurfaceProcessor;
@@ -124,7 +126,7 @@ public:
      * during buffer service teardown, as with RelaxationGridBuffer. This
      * class performs no manual Vulkan destruction.
      */
-    ~VolumeGridBuffer() override = default;
+    ~VolumeGridBuffer() override;
 
     /**
      * @brief Establish the processing chain without attaching any stage.
@@ -307,6 +309,8 @@ private:
     std::shared_ptr<VolumeSurfaceProcessor> m_surface_processor;
     std::shared_ptr<SDFMeshProcessor> m_mesh_processor;
     std::shared_ptr<VKBuffer> m_counter_buf; ///< Atomic vertex counter for the extraction stage.
+
+    TransferHandle m_pending_transfer; ///< In-flight seed upload, resolved before the next transfer.
 
     /**
      * @brief Bytes of vertex storage the extraction resolution requires.

--- a/src/MayaFlux/Buffers/State/VolumeGridBuffer.hpp
+++ b/src/MayaFlux/Buffers/State/VolumeGridBuffer.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "MayaFlux/Buffers/VKBuffer.hpp"
-#include "MayaFlux/Kinesis/Spatial/Bounds.hpp"
-#include "MayaFlux/Kinesis/Tendency/Tendency.hpp"
+#include "MayaFlux/Kinesis/Spatial/Lattice.hpp"
 
 namespace MayaFlux::Buffers {
 
@@ -87,49 +86,35 @@ public:
      * determines this buffer's own vertex storage size: mc_emit allocates
      * slots by atomicAdd without a capacity check, so storage is sized to
      * the worst case of fifteen vertices per voxel. At 48 cubed that is
-     * roughly 95 MB, at 64 cubed roughly 225 MB, so extraction resolution
-     * is worth keeping at or below the simulation resolution.
+     * roughly 95 MB, at 64 cubed roughly 225 MB.
      */
     struct SurfaceConfig {
         std::string field_name; ///< Scalar field surfaced. Stride must be sizeof(float).
-        uint32_t res_x; ///< Extraction cell count along X.
-        uint32_t res_y; ///< Extraction cell count along Y.
-        uint32_t res_z; ///< Extraction cell count along Z.
+        glm::uvec3 resolution; ///< Extraction cell count per axis, over the volume's own bounds.
         float threshold; ///< Field value the surface is placed at.
     };
 
     /**
      * @brief Construct an unregistered multi-field volume.
-     * @param width Cell count along X.
-     * @param height Cell count along Y.
-     * @param depth Cell count along Z.
+     * @param lattice Discretized extent every field is stored over.
      * @param fields Field declarations. Duplicated names are rejected with
      *        an error and the later declaration discarded.
-     * @param bounds World-space extent the lattice covers, used to derive
-     *        cell size for seeding and for gradient terms in shaders.
+     * @param surface Optional isosurface extraction parameters.
      */
     VolumeGridBuffer(
-        uint32_t width,
-        uint32_t height,
-        uint32_t depth,
+        Kinesis::Lattice3D lattice,
         std::initializer_list<FieldDecl> fields,
-        Kinesis::AABB3D bounds,
         std::optional<SurfaceConfig> surface = std::nullopt);
 
     /**
      * @brief Construct from a runtime-built field list.
-     * @param width Cell count along X.
-     * @param height Cell count along Y.
-     * @param depth Cell count along Z.
+     * @param lattice Discretized extent every field is stored over.
      * @param fields Field declarations.
-     * @param bounds World-space extent the lattice covers.
+     * @param surface Optional isosurface extraction parameters.
      */
     VolumeGridBuffer(
-        uint32_t width,
-        uint32_t height,
-        uint32_t depth,
+        Kinesis::Lattice3D lattice,
         std::vector<FieldDecl> fields,
-        Kinesis::AABB3D bounds,
         std::optional<SurfaceConfig> surface = std::nullopt);
 
     /**
@@ -173,23 +158,26 @@ public:
     /** @brief The marching cubes stage, valid after setup_rendering. */
     [[nodiscard]] std::shared_ptr<SDFMeshProcessor> mesh_processor() const { return m_mesh_processor; }
 
+    /** @brief The lattice every field is discretized over. */
+    [[nodiscard]] const Kinesis::Lattice3D& get_lattice() const { return m_lattice; }
+
     /** @brief Cell count along X. */
-    [[nodiscard]] uint32_t get_width() const { return m_width; }
+    [[nodiscard]] uint32_t get_width() const { return m_lattice.resolution.x; }
 
     /** @brief Cell count along Y. */
-    [[nodiscard]] uint32_t get_height() const { return m_height; }
+    [[nodiscard]] uint32_t get_height() const { return m_lattice.resolution.y; }
 
     /** @brief Cell count along Z. */
-    [[nodiscard]] uint32_t get_depth() const { return m_depth; }
+    [[nodiscard]] uint32_t get_depth() const { return m_lattice.resolution.z; }
 
-    /** @brief Total cell count, width * height * depth. */
-    [[nodiscard]] uint32_t get_cell_count() const { return m_width * m_height * m_depth; }
+    /** @brief Total cell count. */
+    [[nodiscard]] uint32_t get_cell_count() const { return static_cast<uint32_t>(m_lattice.cell_count()); }
 
     /** @brief World-space extent the lattice covers. */
-    [[nodiscard]] const Kinesis::AABB3D& get_bounds() const { return m_bounds; }
+    [[nodiscard]] const Kinesis::AABB3D& get_bounds() const { return m_lattice.bounds; }
 
     /** @brief World-space size of one cell along each axis. */
-    [[nodiscard]] glm::vec3 get_cell_size() const;
+    [[nodiscard]] glm::vec3 get_cell_size() const { return m_lattice.cell_size(); }
 
     /** @brief Whether a field of this name was declared. */
     [[nodiscard]] bool has_field(const std::string& name) const;
@@ -288,13 +276,7 @@ private:
      */
     [[nodiscard]] const Field* find_field(const std::string& name, const char* context) const;
 
-    /** @brief World-space centre of the cell at the given lattice index. */
-    [[nodiscard]] glm::vec3 cell_centre(uint32_t x, uint32_t y, uint32_t z) const;
-
-    uint32_t m_width;
-    uint32_t m_height;
-    uint32_t m_depth;
-    Kinesis::AABB3D m_bounds;
+    Kinesis::Lattice3D m_lattice;
 
     std::vector<std::string> m_field_order;
     std::unordered_map<std::string, Field> m_fields;

--- a/src/MayaFlux/Buffers/State/VolumeGridBuffer.hpp
+++ b/src/MayaFlux/Buffers/State/VolumeGridBuffer.hpp
@@ -6,6 +6,10 @@
 
 namespace MayaFlux::Buffers {
 
+class VolumeSurfaceProcessor;
+class SDFMeshProcessor;
+class RenderProcessor;
+
 /**
  * @class VolumeGridBuffer
  * @brief GPU-resident state for multi-field simulations evaluated over a
@@ -32,6 +36,17 @@ namespace MayaFlux::Buffers {
  * for these handles directly against ShaderFoundry, as
  * RelaxationStepProcessor does, resolving them through read_handle() and
  * write_handle().
+ *
+ * Chain layout:
+ *   default   - VolumeSurfaceProcessor, resampling the surfaced field
+ *   flat[0]   - SDFMeshProcessor, extracting the isosurface
+ *   flat[1..] - simulation stages, added by the caller at any point
+ *   final     - RenderProcessor
+ *
+ * Extraction occupies the default and first flat slots so that
+ * simulation stages appended by the caller always follow it. The surface
+ * therefore reflects the previous cycle's field rather than the current
+ * one, which at frame rate is not observable.
  *
  * The VKBuffer base owns no vertex output. Extraction is a separate
  * concern: attach SDFMeshProcessor against a scalar field for an
@@ -65,6 +80,25 @@ public:
     };
 
     /**
+     * @struct SurfaceConfig
+     * @brief Isosurface extraction parameters for a scalar field.
+     *
+     * Supplied at construction because the extraction resolution
+     * determines this buffer's own vertex storage size: mc_emit allocates
+     * slots by atomicAdd without a capacity check, so storage is sized to
+     * the worst case of fifteen vertices per voxel. At 48 cubed that is
+     * roughly 95 MB, at 64 cubed roughly 225 MB, so extraction resolution
+     * is worth keeping at or below the simulation resolution.
+     */
+    struct SurfaceConfig {
+        std::string field_name; ///< Scalar field surfaced. Stride must be sizeof(float).
+        uint32_t res_x; ///< Extraction cell count along X.
+        uint32_t res_y; ///< Extraction cell count along Y.
+        uint32_t res_z; ///< Extraction cell count along Z.
+        float threshold; ///< Field value the surface is placed at.
+    };
+
+    /**
      * @brief Construct an unregistered multi-field volume.
      * @param width Cell count along X.
      * @param height Cell count along Y.
@@ -79,7 +113,8 @@ public:
         uint32_t height,
         uint32_t depth,
         std::initializer_list<FieldDecl> fields,
-        Kinesis::AABB3D bounds);
+        Kinesis::AABB3D bounds,
+        std::optional<SurfaceConfig> surface = std::nullopt);
 
     /**
      * @brief Construct from a runtime-built field list.
@@ -94,7 +129,8 @@ public:
         uint32_t height,
         uint32_t depth,
         std::vector<FieldDecl> fields,
-        Kinesis::AABB3D bounds);
+        Kinesis::AABB3D bounds,
+        std::optional<SurfaceConfig> surface = std::nullopt);
 
     /**
      * @brief Destructor.
@@ -112,8 +148,30 @@ public:
      * The volume declares no default processor and no stages of its own.
      * Simulation identity is the sequence of processors the caller adds,
      * not a property of this class.
+     *
+     * When a SurfaceConfig was supplied at construction, two stages are
+     * appended: the field-to-corner-grid resample and the marching cubes
+     * extraction writing into this buffer's own vertex storage. Simulation
+     * stages added before this call keep their position ahead of them.
      */
     void setup_processors(ProcessingToken token) override;
+
+    /**
+     * @brief Attach a RenderProcessor drawing the extracted surface.
+     * @param config Render target. Vertex and fragment shaders default to
+     *        the untextured triangle pair; topology is forced to
+     *        TRIANGLE_LIST.
+     *
+     * Requires a SurfaceConfig at construction. Without one this buffer
+     * has no vertex storage and nothing to draw.
+     */
+    void setup_rendering(const RenderConfig& config);
+
+    /** @brief The surface extraction stage, valid after setup_rendering. */
+    [[nodiscard]] std::shared_ptr<VolumeSurfaceProcessor> surface_processor() const { return m_surface_processor; }
+
+    /** @brief The marching cubes stage, valid after setup_rendering. */
+    [[nodiscard]] std::shared_ptr<SDFMeshProcessor> mesh_processor() const { return m_mesh_processor; }
 
     /** @brief Cell count along X. */
     [[nodiscard]] uint32_t get_width() const { return m_width; }
@@ -240,8 +298,19 @@ private:
 
     std::vector<std::string> m_field_order;
     std::unordered_map<std::string, Field> m_fields;
+    std::optional<SurfaceConfig> m_surface;
 
     std::shared_ptr<VKBuffer> m_transfer_staging; ///< Reused across seed and read calls.
+    std::shared_ptr<VolumeSurfaceProcessor> m_surface_processor;
+    std::shared_ptr<SDFMeshProcessor> m_mesh_processor;
+    std::shared_ptr<VKBuffer> m_counter_buf; ///< Atomic vertex counter for the extraction stage.
+
+    /**
+     * @brief Bytes of vertex storage the extraction resolution requires.
+     * @param surface Extraction parameters, or nullopt for no extraction.
+     * @return Worst-case vertex bytes, or 1 when no surface is configured.
+     */
+    static size_t surface_storage_bytes(const std::optional<SurfaceConfig>& surface);
 };
 
 } // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/VolumeGridBuffer.hpp
+++ b/src/MayaFlux/Buffers/State/VolumeGridBuffer.hpp
@@ -1,0 +1,247 @@
+#pragma once
+
+#include "MayaFlux/Buffers/VKBuffer.hpp"
+#include "MayaFlux/Kinesis/Spatial/Bounds.hpp"
+#include "MayaFlux/Kinesis/Tendency/Tendency.hpp"
+
+namespace MayaFlux::Buffers {
+
+/**
+ * @class VolumeGridBuffer
+ * @brief GPU-resident state for multi-field simulations evaluated over a
+ *        fixed 3D topology: incompressible fluid, gas and smoke, reaction
+ *        systems, and any process where several quantities co-evolve over
+ *        the same cell lattice.
+ *
+ * Where RelaxationGridBuffer carries one field over a 2D topology and
+ * advances it with one rule dispatch per cycle, this carries N named
+ * fields over a 3D topology and advances them with a chain of processors,
+ * each responsible for one stage. A velocity field, a pressure field, a
+ * divergence scratch field and one or more carried scalars are the
+ * ordinary case; nothing in the class knows what any of them mean.
+ *
+ * All field storage lives as raw Vulkan handle pairs inside
+ * VKBufferResources::back_buffers, allocated once at construction as
+ * device-local with transfer source and destination usage. Fields are
+ * addressed by name; each declares its own component stride and whether
+ * it needs a second slot for ping-pong. Single-slot fields resolve read
+ * and write to the same handle, which suits scratch quantities
+ * recomputed from nothing each stage.
+ *
+ * No VKBuffer object represents any field. Processors write descriptors
+ * for these handles directly against ShaderFoundry, as
+ * RelaxationStepProcessor does, resolving them through read_handle() and
+ * write_handle().
+ *
+ * The VKBuffer base owns no vertex output. Extraction is a separate
+ * concern: attach SDFMeshProcessor against a scalar field for an
+ * isosurface, or a bespoke processor for raymarching or debug points.
+ * The buffer emits nothing on its own.
+ *
+ * Usage:
+ * @code
+ * auto vol = std::make_shared<VolumeGridBuffer>(
+ *     64, 64, 64,
+ *     { { "velocity", sizeof(glm::vec4) },
+ *       { "pressure", sizeof(float) },
+ *       { "divergence", sizeof(float), false },
+ *       { "density", sizeof(float) } },
+ *     Kinesis::AABB3D { { -1, -1, -1 }, { 1, 1, 1 } });
+ *
+ * vol->seed("density", Kinesis::SpatialField { ... });
+ * vol->setup_processors(ProcessingToken::GRAPHICS_BACKEND);
+ * @endcode
+ */
+class MAYAFLUX_API VolumeGridBuffer : public VKBuffer {
+public:
+    /**
+     * @struct FieldDecl
+     * @brief One field's declaration within a volume.
+     */
+    struct FieldDecl {
+        std::string name; ///< Lookup key, unique within the volume.
+        size_t stride_bytes; ///< Bytes per cell.
+        bool double_buffered = true; ///< False resolves read and write to one slot.
+    };
+
+    /**
+     * @brief Construct an unregistered multi-field volume.
+     * @param width Cell count along X.
+     * @param height Cell count along Y.
+     * @param depth Cell count along Z.
+     * @param fields Field declarations. Duplicated names are rejected with
+     *        an error and the later declaration discarded.
+     * @param bounds World-space extent the lattice covers, used to derive
+     *        cell size for seeding and for gradient terms in shaders.
+     */
+    VolumeGridBuffer(
+        uint32_t width,
+        uint32_t height,
+        uint32_t depth,
+        std::initializer_list<FieldDecl> fields,
+        Kinesis::AABB3D bounds);
+
+    /**
+     * @brief Construct from a runtime-built field list.
+     * @param width Cell count along X.
+     * @param height Cell count along Y.
+     * @param depth Cell count along Z.
+     * @param fields Field declarations.
+     * @param bounds World-space extent the lattice covers.
+     */
+    VolumeGridBuffer(
+        uint32_t width,
+        uint32_t height,
+        uint32_t depth,
+        std::vector<FieldDecl> fields,
+        Kinesis::AABB3D bounds);
+
+    /**
+     * @brief Destructor.
+     *
+     * Raw handles in m_resources.back_buffers are released by the backend
+     * during buffer service teardown, as with RelaxationGridBuffer. This
+     * class performs no manual Vulkan destruction.
+     */
+    ~VolumeGridBuffer() override = default;
+
+    /**
+     * @brief Establish the processing chain without attaching any stage.
+     * @param token Processing domain, typically GRAPHICS_BACKEND.
+     *
+     * The volume declares no default processor and no stages of its own.
+     * Simulation identity is the sequence of processors the caller adds,
+     * not a property of this class.
+     */
+    void setup_processors(ProcessingToken token) override;
+
+    /** @brief Cell count along X. */
+    [[nodiscard]] uint32_t get_width() const { return m_width; }
+
+    /** @brief Cell count along Y. */
+    [[nodiscard]] uint32_t get_height() const { return m_height; }
+
+    /** @brief Cell count along Z. */
+    [[nodiscard]] uint32_t get_depth() const { return m_depth; }
+
+    /** @brief Total cell count, width * height * depth. */
+    [[nodiscard]] uint32_t get_cell_count() const { return m_width * m_height * m_depth; }
+
+    /** @brief World-space extent the lattice covers. */
+    [[nodiscard]] const Kinesis::AABB3D& get_bounds() const { return m_bounds; }
+
+    /** @brief World-space size of one cell along each axis. */
+    [[nodiscard]] glm::vec3 get_cell_size() const;
+
+    /** @brief Whether a field of this name was declared. */
+    [[nodiscard]] bool has_field(const std::string& name) const;
+
+    /** @brief Byte size of one slot of the named field, or 0 if undeclared. */
+    [[nodiscard]] size_t get_field_bytes(const std::string& name) const;
+
+    /** @brief Names of every declared field, in declaration order. */
+    [[nodiscard]] std::vector<std::string> get_field_names() const;
+
+    /**
+     * @brief Handle a stage should read the named field from.
+     * @param name Field name.
+     * @return Vulkan buffer handle, or nullptr if undeclared.
+     */
+    [[nodiscard]] vk::Buffer read_handle(const std::string& name) const;
+
+    /**
+     * @brief Handle a stage should write the named field to.
+     * @param name Field name.
+     * @return Vulkan buffer handle, or nullptr if undeclared.
+     *
+     * Equals read_handle() for single-slot fields.
+     */
+    [[nodiscard]] vk::Buffer write_handle(const std::string& name) const;
+
+    /**
+     * @brief Exchange read and write slots for the named field.
+     * @param name Field name. No effect on single-slot fields.
+     *
+     * Called by whichever stage last wrote the field, after its dispatch,
+     * so the next stage reading it observes the new values. A stage that
+     * writes a field it also reads must swap; a stage writing a scratch
+     * field consumed immediately after need not.
+     */
+    void swap_field(const std::string& name);
+
+    /**
+     * @brief Write initial values into a scalar field from a Kinesis field.
+     * @param name Field name. Must have stride sizeof(float).
+     * @param field Sampled at each cell centre in world space.
+     */
+    void seed(const std::string& name, const Kinesis::SpatialField& field);
+
+    /**
+     * @brief Write initial values into a vector field from a Kinesis field.
+     * @param name Field name. Must have stride sizeof(glm::vec4).
+     * @param field Sampled at each cell centre in world space. The fourth
+     *        component of every cell is zeroed.
+     */
+    void seed(const std::string& name, const Kinesis::VectorField& field);
+
+    /**
+     * @brief Write initial values into a field from raw host memory.
+     * @param name Field name.
+     * @param data Pointer to at least @p size bytes.
+     * @param size Byte count; must equal get_field_bytes(name).
+     *
+     * Writes into the current read slot. For double-buffered fields the
+     * write slot is left untouched, which is correct when the first stage
+     * to touch the field reads before it writes.
+     */
+    void seed_raw(const std::string& name, const void* data, size_t size);
+
+    /**
+     * @brief Copy the current read slot of a field to host memory.
+     * @param name Field name.
+     * @param data Destination pointer, at least get_field_bytes(name) bytes.
+     * @param size Byte count; must equal get_field_bytes(name).
+     *
+     * Blocking. Records a fenced device-to-host copy and waits on it from
+     * the calling thread. Not for per-frame use on the graphics thread.
+     */
+    void read_field(const std::string& name, void* data, size_t size);
+
+private:
+    struct Field {
+        size_t stride_bytes;
+        uint32_t slot_a;
+        uint32_t slot_b;
+        bool read_is_a;
+    };
+
+    /**
+     * @brief Populate m_fields from declarations and allocate one
+     *        device-local raw slot per field slot.
+     * @param decls Field declarations in declaration order.
+     */
+    void allocate_fields(const std::vector<FieldDecl>& decls);
+
+    /**
+     * @brief Resolve a field by name.
+     * @param name Field name.
+     * @param context Caller identifier used in the error path.
+     * @return Pointer to the field, or nullptr with an error logged.
+     */
+    [[nodiscard]] const Field* find_field(const std::string& name, const char* context) const;
+
+    /** @brief World-space centre of the cell at the given lattice index. */
+    [[nodiscard]] glm::vec3 cell_centre(uint32_t x, uint32_t y, uint32_t z) const;
+
+    uint32_t m_width;
+    uint32_t m_height;
+    uint32_t m_depth;
+    Kinesis::AABB3D m_bounds;
+
+    std::vector<std::string> m_field_order;
+    std::unordered_map<std::string, Field> m_fields;
+
+    std::shared_ptr<VKBuffer> m_transfer_staging; ///< Reused across seed and read calls.
+};
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/VolumeGridBuffer.hpp
+++ b/src/MayaFlux/Buffers/State/VolumeGridBuffer.hpp
@@ -243,6 +243,27 @@ public:
     void seed_raw(const std::string& name, const void* data, size_t size);
 
     /**
+     * @brief Add sampled values into a scalar field.
+     * @param name Field name. Must have stride sizeof(float).
+     * @param field Sampled at each cell centre in world space and added
+     *        to whatever the field already holds.
+     *
+     * Blocking. Reads the current read slot to host memory, adds, and
+     * writes back, so it costs a full round trip at the lattice's byte
+     * size. Intended for authored injection on a coarse clock, not as a
+     * chain stage.
+     */
+    void accumulate(const std::string& name, const Kinesis::SpatialField& field);
+
+    /**
+     * @brief Add sampled values into a vector field.
+     * @param name Field name. Must have stride sizeof(glm::vec4).
+     * @param field Sampled at each cell centre in world space and added
+     *        to the first three components. The fourth is left as found.
+     */
+    void accumulate(const std::string& name, const Kinesis::VectorField& field);
+
+    /**
      * @brief Copy the current read slot of a field to host memory.
      * @param name Field name.
      * @param data Destination pointer, at least get_field_bytes(name) bytes.

--- a/src/MayaFlux/Buffers/State/VolumeGridBuffer.hpp
+++ b/src/MayaFlux/Buffers/State/VolumeGridBuffer.hpp
@@ -10,6 +10,77 @@ namespace MayaFlux::Buffers {
 class VolumeSurfaceProcessor;
 class SDFMeshProcessor;
 class RenderProcessor;
+class VolumeGridBuffer;
+class AdvectProcessor;
+class BuoyancyProcessor;
+class WallProcessor;
+class DivergenceProcessor;
+class DiffuseProcessor;
+class PressureProcessor;
+class SolenoidalProcessor;
+
+/**
+ * @struct ScalarRef
+ * @brief A scalar field's name, issued by the volume that owns it.
+ *
+ * Exists so a field is spelled once, at declaration, rather than at every
+ * site that addresses it. A name typed twice is two independent literals
+ * that must agree; a mismatch surfaces as a stage that runs and does
+ * nothing, which is the hardest failure in this subsystem to diagnose.
+ *
+ * Converts implicitly to the field name, so a ref passes anywhere a
+ * processor expects a string. The type distinction bites where a
+ * signature demands one kind: a parameter taking ScalarRef cannot be
+ * handed a vector field.
+ *
+ * Carries a weak reference to its issuer so a ref from one volume used
+ * against another can be rejected rather than silently resolving to a
+ * same-named field.
+ */
+struct ScalarRef {
+    std::string name;
+    std::weak_ptr<VolumeGridBuffer> owner;
+
+    static constexpr size_t stride = sizeof(float);
+
+    operator const std::string&() const { return name; }
+
+    /**
+     * @brief Whether this ref was issued by the given volume.
+     * @param volume Volume to test against.
+     */
+    [[nodiscard]] bool issued_by(const VolumeGridBuffer* volume) const
+    {
+        auto o = owner.lock();
+        return o && o.get() == volume;
+    }
+};
+
+/**
+ * @struct VectorRef
+ * @brief A vector field's name, issued by the volume that owns it.
+ *
+ * As ScalarRef, for fields of glm::vec4 stride. The fourth component is
+ * carried through by every current stage and read by none.
+ */
+struct VectorRef {
+    std::string name;
+    std::weak_ptr<VolumeGridBuffer> owner;
+
+    static constexpr size_t stride = sizeof(glm::vec4);
+
+    operator const std::string&() const { return name; }
+
+    /**
+     * @brief Whether this ref was issued by the given volume.
+     * @param volume Volume to test against.
+     */
+    [[nodiscard]] bool issued_by(const VolumeGridBuffer* volume) const
+    {
+        auto o = owner.lock();
+        return o && o.get() == volume;
+    }
+};
 
 /**
  * @class VolumeGridBuffer
@@ -97,6 +168,75 @@ public:
     };
 
     /**
+     * @struct FlowConfig
+     * @brief Parameters for the incompressible flow stage arrangement.
+     *
+     * Carries what varies between simulations. What does not vary, the
+     * stage ordering, is fixed by setup_flow: buoyancy must precede the
+     * projection or the solve removes the divergence it injects, the wall
+     * condition must follow every stage that writes velocity, and carried
+     * scalars must be advected by the projected velocity rather than the
+     * raw one. Those are correctness constraints, not preferences, and
+     * they are the part callers get wrong.
+     */
+    struct FlowConfig {
+        /**
+         * @struct Carried
+         * @brief A scalar transported by the velocity field.
+         */
+        struct Carried {
+            ScalarRef field; ///< Field advected.
+            float dissipation { 1.0F }; ///< Per-cycle multiplier. One conserves.
+        };
+
+        /**
+         * @struct Buoyancy
+         * @brief Body force accumulated into velocity from two scalars.
+         */
+        struct Buoyancy {
+            ScalarRef temperature; ///< Drives motion along direction.
+            ScalarRef density; ///< Drives motion against it.
+            glm::vec3 direction { 0.0F, 1.0F, 0.0F }; ///< Axis and magnitude.
+            float temperature_gain { 1.0F };
+            float density_gain { 0.0F };
+            float ambient { 0.0F }; ///< Temperature at which the rise term vanishes.
+        };
+
+        VectorRef velocity; ///< Required.
+        ScalarRef divergence; ///< Required. Single-slot is correct.
+        ScalarRef pressure; ///< Required.
+        VectorRef scratch; ///< Required only when viscosity is above zero.
+
+        float time_step { 1.0F / 60.0F }; ///< Applied to every stage that integrates.
+        float viscosity { 0.0F }; ///< Zero omits the diffusion stage entirely.
+        uint32_t jacobi_iterations { 32 };
+        bool walls { true }; ///< Free-slip on the six faces, twice per cycle.
+
+        std::vector<Carried> carried;
+        std::optional<Buoyancy> buoyancy;
+    };
+
+    /**
+     * @struct FlowStages
+     * @brief Every stage setup_flow built, in no particular order.
+     *
+     * Returned rather than stored so each remains reachable for retuning,
+     * feeding, or inspection. Members are null where the config omitted
+     * the corresponding stage.
+     */
+    struct FlowStages {
+        std::shared_ptr<AdvectProcessor> self_advect;
+        std::shared_ptr<BuoyancyProcessor> buoyancy;
+        std::shared_ptr<DiffuseProcessor> diffuse;
+        std::shared_ptr<WallProcessor> wall_advected;
+        std::shared_ptr<DivergenceProcessor> divergence;
+        std::shared_ptr<PressureProcessor> pressure;
+        std::shared_ptr<SolenoidalProcessor> solenoidal;
+        std::shared_ptr<WallProcessor> wall_projected;
+        std::vector<std::shared_ptr<AdvectProcessor>> carriers; ///< Parallel to config.carried.
+    };
+
+    /**
      * @brief Construct an unregistered multi-field volume.
      * @param lattice Discretized extent every field is stored over.
      * @param fields Field declarations. Duplicated names are rejected with
@@ -117,6 +257,20 @@ public:
     VolumeGridBuffer(
         Kinesis::Lattice3D lattice,
         std::vector<FieldDecl> fields,
+        std::optional<SurfaceConfig> surface = std::nullopt);
+
+    /**
+     * @brief Construct a volume with no fields, to be declared after.
+     * @param lattice Discretized extent every field is stored over.
+     * @param surface Optional isosurface extraction parameters. Its field
+     *        name resolves at setup_processors, so it may name a field
+     *        declared after construction.
+     *
+     * Extraction storage is sized here because it depends only on the
+     * extraction resolution, so the SurfaceConfig cannot move later.
+     */
+    explicit VolumeGridBuffer(
+        Kinesis::Lattice3D lattice,
         std::optional<SurfaceConfig> surface = std::nullopt);
 
     /**
@@ -153,6 +307,22 @@ public:
      * has no vertex storage and nothing to draw.
      */
     void setup_rendering(const RenderConfig& config);
+
+    /**
+     * @brief Build and append the incompressible flow stages.
+     * @param config Fields and parameters. Every ref must have been issued
+     *        by this volume.
+     * @return The stages built, all already in the chain.
+     *
+     * Appends in the order: self-advection, buoyancy, diffusion, wall,
+     * divergence, pressure, solenoidal, wall, then one advection per
+     * carried scalar. Carriers run last so they are transported by the
+     * projected velocity.
+     *
+     * Stages added to the chain before this call keep their position
+     * ahead of it, which is where an influx stage belongs.
+     */
+    FlowStages setup_flow(const FlowConfig& config);
 
     /** @brief The surface extraction stage, valid after setup_rendering. */
     [[nodiscard]] std::shared_ptr<VolumeSurfaceProcessor> surface_processor() const { return m_surface_processor; }
@@ -216,6 +386,40 @@ public:
      * field consumed immediately after need not.
      */
     void swap_field(const std::string& name);
+
+    /**
+     * @brief Declare a double-buffered scalar field.
+     * @param name Lookup key, unique within this volume.
+     * @return Ref naming the field, or a ref with an empty name if the
+     *         declaration was rejected.
+     */
+    ScalarRef declare_scalar(std::string name);
+
+    /**
+     * @brief Declare a single-slot scalar field.
+     * @param name Lookup key, unique within this volume.
+     * @return Ref naming the field, or a ref with an empty name if the
+     *         declaration was rejected.
+     *
+     * Read and write resolve to one handle, which suits a quantity
+     * recomputed from other fields every cycle and never carried across
+     * cycles: divergence is the ordinary case. A stage that reads a
+     * neighbourhood of a field it also writes cannot use one of these,
+     * and VolumeFieldProcessor rejects that arrangement at attach.
+     */
+    ScalarRef declare_scratch(std::string name);
+
+    /**
+     * @brief Declare a double-buffered vector field.
+     * @param name Lookup key, unique within this volume.
+     * @return Ref naming the field, or a ref with an empty name if the
+     *         declaration was rejected.
+     *
+     * Vector fields are always double-buffered. The single-slot case
+     * saves one slot, a megabyte at 64 cubed, and every vector field in
+     * use is either advected or diffused, both of which require two.
+     */
+    VectorRef declare_vector(std::string name);
 
     /**
      * @brief Write initial values into a scalar field from a Kinesis field.
@@ -285,11 +489,19 @@ private:
     };
 
     /**
-     * @brief Populate m_fields from declarations and allocate one
-     *        device-local raw slot per field slot.
+     * @brief Populate m_fields from declarations.
      * @param decls Field declarations in declaration order.
      */
     void allocate_fields(const std::vector<FieldDecl>& decls);
+
+    /**
+     * @brief Allocate one field's slots and register it.
+     * @param name Lookup key.
+     * @param stride_bytes Bytes per cell.
+     * @param double_buffered Whether to allocate a second slot.
+     * @return True if the field was registered.
+     */
+    bool allocate_field(const std::string& name, size_t stride_bytes, bool double_buffered);
 
     /**
      * @brief Resolve a field by name.

--- a/src/MayaFlux/Buffers/State/VolumeSurfaceProcessor.cpp
+++ b/src/MayaFlux/Buffers/State/VolumeSurfaceProcessor.cpp
@@ -13,17 +13,13 @@ namespace {
 VolumeSurfaceProcessor::VolumeSurfaceProcessor(
     std::shared_ptr<VolumeGridBuffer> volume,
     std::string field_name,
-    uint32_t res_x,
-    uint32_t res_y,
-    uint32_t res_z,
+    Kinesis::Lattice3D lattice,
     float threshold,
     const std::string& shader_path)
     : ComputeProcessor(shader_path, k_workgroup_x)
     , m_volume(std::move(volume))
     , m_field_name(std::move(field_name))
-    , m_res_x(std::max(res_x, 1U))
-    , m_res_y(std::max(res_y, 1U))
-    , m_res_z(std::max(res_z, 1U))
+    , m_lattice(std::move(lattice))
     , m_threshold(threshold)
 {
     m_config.bindings["field_in"] = ShaderBinding(0, 0, vk::DescriptorType::eStorageBuffer);
@@ -79,9 +75,9 @@ void VolumeSurfaceProcessor::write_params()
         .height = m_volume->get_height(),
         .depth = m_volume->get_depth(),
         .pad0 = 0,
-        .res_x = m_res_x,
-        .res_y = m_res_y,
-        .res_z = m_res_z,
+        .res_x = m_lattice.resolution.x,
+        .res_y = m_lattice.resolution.y,
+        .res_z = m_lattice.resolution.z,
         .threshold = m_threshold,
     };
 

--- a/src/MayaFlux/Buffers/State/VolumeSurfaceProcessor.cpp
+++ b/src/MayaFlux/Buffers/State/VolumeSurfaceProcessor.cpp
@@ -1,0 +1,147 @@
+#include "VolumeSurfaceProcessor.hpp"
+#include "VolumeGridBuffer.hpp"
+
+#include "MayaFlux/Registry/BackendRegistry.hpp"
+#include "MayaFlux/Registry/Service/BufferService.hpp"
+
+namespace MayaFlux::Buffers {
+
+namespace {
+    constexpr uint32_t k_workgroup_x = 64;
+}
+
+VolumeSurfaceProcessor::VolumeSurfaceProcessor(
+    std::shared_ptr<VolumeGridBuffer> volume,
+    std::string field_name,
+    uint32_t res_x,
+    uint32_t res_y,
+    uint32_t res_z,
+    float threshold,
+    const std::string& shader_path)
+    : ComputeProcessor(shader_path, k_workgroup_x)
+    , m_volume(std::move(volume))
+    , m_field_name(std::move(field_name))
+    , m_res_x(std::max(res_x, 1U))
+    , m_res_y(std::max(res_y, 1U))
+    , m_res_z(std::max(res_z, 1U))
+    , m_threshold(threshold)
+{
+    m_config.bindings["field_in"] = ShaderBinding(0, 0, vk::DescriptorType::eStorageBuffer);
+    m_config.bindings["grid_out"] = ShaderBinding(0, 1, vk::DescriptorType::eStorageBuffer);
+
+    m_config.push_constant_size = sizeof(SurfaceParams);
+
+    set_dispatch_mode(ShaderDispatchConfig::DispatchMode::MANUAL);
+    set_manual_dispatch((corner_count() + k_workgroup_x - 1) / k_workgroup_x, 1, 1);
+
+    rebuild_grid_buffer();
+}
+
+void VolumeSurfaceProcessor::rebuild_grid_buffer()
+{
+    auto svc = Registry::BackendRegistry::instance()
+                   .get_service<Registry::Service::BufferService>();
+
+    m_grid_buf = std::make_shared<VKBuffer>(
+        corner_count() * sizeof(float),
+        VKBuffer::Usage::HOST_STORAGE,
+        Kakshya::DataModality::UNKNOWN);
+
+    svc->initialize_buffer(m_grid_buf);
+}
+
+void VolumeSurfaceProcessor::set_threshold(float threshold)
+{
+    m_threshold = threshold;
+    if (m_volume) {
+        write_params();
+    }
+}
+
+void VolumeSurfaceProcessor::on_attach(const std::shared_ptr<Buffer>& buffer)
+{
+    ComputeProcessor::on_attach(buffer);
+
+    /* m_volume = std::dynamic_pointer_cast<VolumeGridBuffer>(buffer);
+    if (!m_volume) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "VolumeSurfaceProcessor requires a VolumeGridBuffer");
+        return;
+    }
+
+    if (!m_volume->has_field(m_field_name)) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "VolumeSurfaceProcessor: volume has no field '{}'", m_field_name);
+        m_volume.reset();
+        return;
+    }
+
+    const size_t expected = static_cast<size_t>(m_volume->get_cell_count()) * sizeof(float);
+    if (m_volume->get_field_bytes(m_field_name) != expected) {
+        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
+            "VolumeSurfaceProcessor: field '{}' is not scalar", m_field_name);
+        m_volume.reset();
+        return;
+    } */
+
+    bind_buffer("grid_out", m_grid_buf);
+
+    write_params();
+}
+
+void VolumeSurfaceProcessor::write_params()
+{
+    auto& data = get_push_constant_data();
+    if (data.size() < sizeof(SurfaceParams)) {
+        data.resize(sizeof(SurfaceParams));
+    }
+
+    const SurfaceParams params {
+        .width = m_volume->get_width(),
+        .height = m_volume->get_height(),
+        .depth = m_volume->get_depth(),
+        .pad0 = 0,
+        .res_x = m_res_x,
+        .res_y = m_res_y,
+        .res_z = m_res_z,
+        .threshold = m_threshold,
+    };
+
+    std::memcpy(data.data(), &params, sizeof(SurfaceParams));
+}
+
+void VolumeSurfaceProcessor::write_field_descriptor()
+{
+    if (!m_volume || m_descriptor_set_ids.empty()) {
+        return;
+    }
+
+    Portal::Graphics::get_shader_foundry().update_descriptor_buffer(
+        m_descriptor_set_ids[0], 0, vk::DescriptorType::eStorageBuffer,
+        m_volume->read_handle(m_field_name), 0,
+        m_volume->get_field_bytes(m_field_name));
+}
+
+void VolumeSurfaceProcessor::on_descriptors_created()
+{
+    write_field_descriptor();
+}
+
+void VolumeSurfaceProcessor::processing_function(const std::shared_ptr<Buffer>& buffer)
+{
+    if (m_volume && are_descriptors_ready()) {
+        write_field_descriptor();
+    }
+
+    ComputeProcessor::processing_function(buffer);
+}
+
+bool VolumeSurfaceProcessor::on_before_execute(
+    Portal::Graphics::CommandBufferID /*cmd_id*/,
+    const std::shared_ptr<VKBuffer>& /*buffer*/)
+{
+    // return m_volume && std::dynamic_pointer_cast<VolumeGridBuffer>(buffer) != nullptr;
+    return m_volume != nullptr;
+}
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/VolumeSurfaceProcessor.cpp
+++ b/src/MayaFlux/Buffers/State/VolumeSurfaceProcessor.cpp
@@ -62,28 +62,6 @@ void VolumeSurfaceProcessor::on_attach(const std::shared_ptr<Buffer>& buffer)
 {
     ComputeProcessor::on_attach(buffer);
 
-    /* m_volume = std::dynamic_pointer_cast<VolumeGridBuffer>(buffer);
-    if (!m_volume) {
-        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
-            "VolumeSurfaceProcessor requires a VolumeGridBuffer");
-        return;
-    }
-
-    if (!m_volume->has_field(m_field_name)) {
-        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
-            "VolumeSurfaceProcessor: volume has no field '{}'", m_field_name);
-        m_volume.reset();
-        return;
-    }
-
-    const size_t expected = static_cast<size_t>(m_volume->get_cell_count()) * sizeof(float);
-    if (m_volume->get_field_bytes(m_field_name) != expected) {
-        MF_ERROR(Journal::Component::Buffers, Journal::Context::BufferProcessing,
-            "VolumeSurfaceProcessor: field '{}' is not scalar", m_field_name);
-        m_volume.reset();
-        return;
-    } */
-
     bind_buffer("grid_out", m_grid_buf);
 
     write_params();

--- a/src/MayaFlux/Buffers/State/VolumeSurfaceProcessor.hpp
+++ b/src/MayaFlux/Buffers/State/VolumeSurfaceProcessor.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "MayaFlux/Buffers/Shaders/ComputeProcessor.hpp"
+#include "MayaFlux/Kinesis/Spatial/Lattice.hpp"
 
 namespace MayaFlux::Buffers {
 
@@ -62,20 +63,18 @@ public:
 
     /**
      * @brief Construct a surface extraction bridge.
+     * @param volume Volume whose field is resampled.
      * @param field_name Name of the scalar field resampled. Must have
      *        stride sizeof(float).
-     * @param res_x Extraction cell count along X. Minimum 1.
-     * @param res_y Extraction cell count along Y. Minimum 1.
-     * @param res_z Extraction cell count along Z. Minimum 1.
+     * @param lattice Extraction lattice, normally the volume's own lattice
+     *        resampled to a different resolution over the same bounds.
      * @param threshold Field value the surface is placed at.
      * @param shader_path Path to the compute shader.
      */
     VolumeSurfaceProcessor(
         std::shared_ptr<VolumeGridBuffer> volume,
         std::string field_name,
-        uint32_t res_x,
-        uint32_t res_y,
-        uint32_t res_z,
+        Kinesis::Lattice3D lattice,
         float threshold,
         const std::string& shader_path = "volume_to_sdf_grid.comp");
 
@@ -99,22 +98,24 @@ public:
     [[nodiscard]] float get_threshold() const { return m_threshold; }
 
     /** @brief Extraction cell count along X. */
-    [[nodiscard]] uint32_t get_res_x() const { return m_res_x; }
+    [[nodiscard]] uint32_t get_res_x() const { return m_lattice.resolution.x; }
 
     /** @brief Extraction cell count along Y. */
-    [[nodiscard]] uint32_t get_res_y() const { return m_res_y; }
+    [[nodiscard]] uint32_t get_res_y() const { return m_lattice.resolution.y; }
 
     /** @brief Extraction cell count along Z. */
-    [[nodiscard]] uint32_t get_res_z() const { return m_res_z; }
+    [[nodiscard]] uint32_t get_res_z() const { return m_lattice.resolution.z; }
+
+    /** @brief The extraction lattice. */
+    [[nodiscard]] const Kinesis::Lattice3D& get_lattice() const { return m_lattice; }
 
     /**
-     * @brief Corner count of the grid, (res_x+1)*(res_y+1)*(res_z+1).
-     *
-     * The grid buffer holds this many floats.
+     * @brief Corner count of the grid, one greater per axis than the
+     *        extraction resolution. The grid buffer holds this many floats.
      */
     [[nodiscard]] uint32_t corner_count() const noexcept
     {
-        return (m_res_x + 1) * (m_res_y + 1) * (m_res_z + 1);
+        return static_cast<uint32_t>(m_lattice.corner_count());
     }
 
     /**
@@ -126,7 +127,7 @@ public:
      */
     [[nodiscard]] uint32_t worst_case_vertices() const noexcept
     {
-        return m_res_x * m_res_y * m_res_z * 15U;
+        return static_cast<uint32_t>(m_lattice.cell_count()) * 15U;
     }
 
 protected:
@@ -179,9 +180,7 @@ private:
     void rebuild_grid_buffer();
 
     std::string m_field_name;
-    uint32_t m_res_x;
-    uint32_t m_res_y;
-    uint32_t m_res_z;
+    Kinesis::Lattice3D m_lattice;
     float m_threshold;
 
     std::shared_ptr<VKBuffer> m_grid_buf;

--- a/src/MayaFlux/Buffers/State/VolumeSurfaceProcessor.hpp
+++ b/src/MayaFlux/Buffers/State/VolumeSurfaceProcessor.hpp
@@ -1,0 +1,191 @@
+#pragma once
+
+#include "MayaFlux/Buffers/Shaders/ComputeProcessor.hpp"
+
+namespace MayaFlux::Buffers {
+
+class VolumeGridBuffer;
+
+/**
+ * @class VolumeSurfaceProcessor
+ * @brief ComputeProcessor resampling one scalar field of a VolumeGridBuffer
+ *        into the corner grid layout the marching cubes stage consumes.
+ *
+ * VolumeGridBuffer stores one value per cell centre; mc_emit.comp reads one
+ * value per lattice corner, of which there are (res+1) on each axis. This
+ * stage bridges the two by trilinear resampling, which also decouples the
+ * extraction resolution from the simulation resolution: surfacing a 128
+ * cube simulation at 64 costs a quarter of the triangles.
+ *
+ * Marching cubes crosses at iso_level with the interior conventionally
+ * negative, while a density field is high inside. The shader therefore
+ * writes threshold minus density, placing the surface where density equals
+ * threshold with negative interior, so the consuming SDFMeshProcessor runs
+ * at iso_level zero.
+ *
+ * Owns the corner grid buffer. SDFPrepProcessor is not needed on this path:
+ * every corner is written each cycle, and SDFMeshProcessor zeroes the
+ * atomic counter itself.
+ *
+ * Chain order:
+ *   flat[n]   - the volume simulation stages
+ *   flat[n+1] - VolumeSurfaceProcessor (field -> corner grid)
+ *   flat[n+2] - SDFMeshProcessor       (corner grid -> vertices)
+ *   final     - RenderProcessor
+ *
+ * The attached buffer must be the VolumeGridBuffer for the field read to
+ * resolve, but the vertex output belongs to whichever buffer
+ * SDFMeshProcessor is attached to.
+ */
+class MAYAFLUX_API VolumeSurfaceProcessor : public ComputeProcessor {
+public:
+    /**
+     * @struct SurfaceParams
+     * @brief Push constant block the resample shader receives.
+     *
+     * Lattice dimensions occupy the leading fields, matching the convention
+     * AdvectProcessor::AdvectParams establishes for volume stages,
+     * followed by the extraction resolution and the surface threshold.
+     */
+    struct SurfaceParams {
+        uint32_t width;
+        uint32_t height;
+        uint32_t depth;
+        uint32_t pad0;
+        uint32_t res_x;
+        uint32_t res_y;
+        uint32_t res_z;
+        float threshold;
+    };
+
+    static_assert(sizeof(SurfaceParams) % 16 == 0);
+
+    /**
+     * @brief Construct a surface extraction bridge.
+     * @param field_name Name of the scalar field resampled. Must have
+     *        stride sizeof(float).
+     * @param res_x Extraction cell count along X. Minimum 1.
+     * @param res_y Extraction cell count along Y. Minimum 1.
+     * @param res_z Extraction cell count along Z. Minimum 1.
+     * @param threshold Field value the surface is placed at.
+     * @param shader_path Path to the compute shader.
+     */
+    VolumeSurfaceProcessor(
+        std::shared_ptr<VolumeGridBuffer> volume,
+        std::string field_name,
+        uint32_t res_x,
+        uint32_t res_y,
+        uint32_t res_z,
+        float threshold,
+        const std::string& shader_path = "volume_to_sdf_grid.comp");
+
+    ~VolumeSurfaceProcessor() override = default;
+
+    /**
+     * @brief The corner grid this stage writes.
+     *
+     * Pass to SDFMeshProcessor's externally-owned-buffers constructor.
+     * Valid immediately after construction.
+     */
+    [[nodiscard]] std::shared_ptr<VKBuffer> grid_buf() const { return m_grid_buf; }
+
+    /**
+     * @brief Set the field value the surface is placed at.
+     * @param threshold Surface level. Takes effect next cycle.
+     */
+    void set_threshold(float threshold);
+
+    /** @brief Field value the surface is placed at. */
+    [[nodiscard]] float get_threshold() const { return m_threshold; }
+
+    /** @brief Extraction cell count along X. */
+    [[nodiscard]] uint32_t get_res_x() const { return m_res_x; }
+
+    /** @brief Extraction cell count along Y. */
+    [[nodiscard]] uint32_t get_res_y() const { return m_res_y; }
+
+    /** @brief Extraction cell count along Z. */
+    [[nodiscard]] uint32_t get_res_z() const { return m_res_z; }
+
+    /**
+     * @brief Corner count of the grid, (res_x+1)*(res_y+1)*(res_z+1).
+     *
+     * The grid buffer holds this many floats.
+     */
+    [[nodiscard]] uint32_t corner_count() const noexcept
+    {
+        return (m_res_x + 1) * (m_res_y + 1) * (m_res_z + 1);
+    }
+
+    /**
+     * @brief Upper bound on vertices mc_emit can produce at this resolution.
+     *
+     * Fifteen per voxel, the maximum five triangles the triangle table
+     * encodes. Size the vertex buffer to at least this many vertices:
+     * mc_emit allocates slots via atomicAdd without a capacity check.
+     */
+    [[nodiscard]] uint32_t worst_case_vertices() const noexcept
+    {
+        return m_res_x * m_res_y * m_res_z * 15U;
+    }
+
+protected:
+    /**
+     * @brief Validate the named field, bind the grid, and size the dispatch.
+     * @param buffer The attached buffer, expected to be a VolumeGridBuffer.
+     */
+    void on_attach(const std::shared_ptr<Buffer>& buffer) override;
+
+    /**
+     * @brief Write the field descriptor for the current slot assignment.
+     */
+    void on_descriptors_created() override;
+
+    /**
+     * @brief Reject buffers that are not VolumeGridBuffer.
+     * @param cmd_id Command buffer this cycle's dispatch will be recorded into.
+     * @param buffer The attached buffer, received as VKBuffer.
+     * @return True if the attached buffer is a VolumeGridBuffer.
+     */
+    bool on_before_execute(Portal::Graphics::CommandBufferID cmd_id, const std::shared_ptr<VKBuffer>& buffer) override;
+
+    /**
+     * @brief Write the field descriptor for this cycle's slot assignment,
+     *        then run the normal shader processing path.
+     *
+     * The field's read slot changes whenever an upstream stage swaps it, so
+     * the binding is rewritten every cycle rather than once.
+     */
+    void processing_function(const std::shared_ptr<Buffer>& buffer) override;
+
+private:
+    /**
+     * @brief Issue the direct ShaderFoundry descriptor write for the field
+     *        read slot. The grid buffer is a real VKBuffer and binds through
+     *        the normal bind_buffer path.
+     */
+    void write_field_descriptor();
+
+    /**
+     * @brief Size the push constant block to at least SurfaceParams and
+     *        write the lattice dimensions, extraction resolution, and
+     *        threshold.
+     */
+    void write_params();
+
+    /**
+     * @brief Allocate the corner grid buffer for the current resolution.
+     */
+    void rebuild_grid_buffer();
+
+    std::string m_field_name;
+    uint32_t m_res_x;
+    uint32_t m_res_y;
+    uint32_t m_res_z;
+    float m_threshold;
+
+    std::shared_ptr<VKBuffer> m_grid_buf;
+    std::shared_ptr<VolumeGridBuffer> m_volume; ///< The attached volume, cached for the descriptor write.
+};
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/WallProcessor.cpp
+++ b/src/MayaFlux/Buffers/State/WallProcessor.cpp
@@ -1,0 +1,28 @@
+#include "WallProcessor.hpp"
+
+namespace MayaFlux::Buffers {
+
+std::vector<VolumeFieldProcessor::FieldBinding> WallProcessor::make_bindings(
+    const std::string& velocity_field)
+{
+    return {
+        { .name = "velocity_in", .binding = 0, .field = velocity_field, .access = FieldAccess::READ },
+        { .name = "velocity_out", .binding = 1, .field = velocity_field, .access = FieldAccess::WRITE },
+    };
+}
+
+WallProcessor::WallProcessor(std::string velocity_field, const std::string& shader_path)
+    : VolumeFieldProcessor(make_bindings(velocity_field), shader_path)
+    , m_velocity_field(std::move(velocity_field))
+{
+    add_swap_field(m_velocity_field);
+}
+
+WallProcessor::WallProcessor(std::string velocity_field, const Portal::Graphics::ShaderSpec& spec)
+    : VolumeFieldProcessor(make_bindings(velocity_field), spec)
+    , m_velocity_field(std::move(velocity_field))
+{
+    add_swap_field(m_velocity_field);
+}
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Buffers/State/WallProcessor.hpp
+++ b/src/MayaFlux/Buffers/State/WallProcessor.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "VolumeFieldProcessor.hpp"
+
+namespace MayaFlux::Buffers {
+
+/**
+ * @class WallProcessor
+ * @brief VolumeFieldProcessor zeroing the wall-normal component of a
+ *        vector field on the six lattice faces.
+ *
+ * Free-slip: the component normal to each face is set to zero on that
+ * face's cells, tangential components pass through unchanged. Edge and
+ * corner cells belong to two or three faces and lose that many
+ * components. Interior cells are copied verbatim.
+ *
+ * Without this the lattice leaks. Semi-Lagrangian advection writes each
+ * cell from a backtraced source, so material whose forward trajectory
+ * exits the lattice is written nowhere and its mass is gone. With no net
+ * flow through a wall the error averages out; with a sustained normal
+ * velocity there, as buoyancy produces, the loss is one-directional and
+ * compounds. The pressure solve cannot correct it: zero-gradient pressure
+ * at the wall means the solenoidal correction's normal component vanishes
+ * there by construction, so the solve is structurally unable to touch the
+ * velocity that is doing the leaking.
+ *
+ * Runs after every stage that writes velocity. In a stable-fluids chain
+ * that is twice: once after self-advection, once after the projection.
+ * Use two instances; the stage carries no per-cycle state but a processor
+ * appears once in a chain.
+ *
+ * The condition is geometric, not physical. It says material cannot cross
+ * the lattice boundary. It does not model a surface, and nothing about it
+ * assumes which axis is up.
+ */
+class MAYAFLUX_API WallProcessor : public VolumeFieldProcessor {
+public:
+    /**
+     * @brief Construct a free-slip wall stage.
+     * @param velocity_field Name of the field constrained. Must have
+     *        stride sizeof(glm::vec4) and be double-buffered.
+     * @param shader_path Path to the compute shader.
+     */
+    WallProcessor(std::string velocity_field, const std::string& shader_path);
+
+    /**
+     * @brief Construct a free-slip wall stage from a generated ShaderSpec.
+     * @param velocity_field Name of the field constrained.
+     * @param spec ShaderSpec implementing the condition.
+     */
+    WallProcessor(std::string velocity_field, const Portal::Graphics::ShaderSpec& spec);
+
+    /** @brief Name of the constrained field. */
+    [[nodiscard]] const std::string& get_velocity_field() const { return m_velocity_field; }
+
+private:
+    /**
+     * @brief Build the binding table for the field name.
+     * @param velocity_field Field bound in both slots.
+     * @return Table binding the read slot and the write slot.
+     */
+    static std::vector<FieldBinding> make_bindings(const std::string& velocity_field);
+
+    std::string m_velocity_field;
+};
+
+} // namespace MayaFlux::Buffers

--- a/src/MayaFlux/Kinesis/GeometryPrimitives.cpp
+++ b/src/MayaFlux/Kinesis/GeometryPrimitives.cpp
@@ -810,6 +810,7 @@ Kakshya::MeshData generate_box(
         std::span<const uint32_t>(indices),
         Kakshya::VertexLayout::for_meshes(sizeof(Kakshya::MeshVertex)));
     data.layout = Kakshya::VertexLayout::for_meshes(sizeof(Kakshya::MeshVertex));
+    data.layout.vertex_count = static_cast<uint32_t>(verts.size());
     return data;
 }
 

--- a/src/MayaFlux/Kinesis/GeometryPrimitives.hpp
+++ b/src/MayaFlux/Kinesis/GeometryPrimitives.hpp
@@ -3,7 +3,7 @@
 #include "MayaFlux/Kakshya/NDData/MeshData.hpp"
 #include "MayaFlux/Kakshya/NDData/VertexFormats.hpp"
 
-#include "MayaFlux/Kinesis/Spatial/Bounds.hpp"
+#include "MayaFlux/Kinesis/Spatial/Lattice.hpp"
 
 namespace MayaFlux::Kinesis {
 
@@ -455,6 +455,18 @@ struct QuadGeometry {
     uint32_t res_x,
     uint32_t res_y,
     uint32_t res_z,
+    float iso_level = 0.0F);
+
+/**
+ * @brief Extract an isosurface mesh from a scalar field over a lattice.
+ * @param field Sampled at grid corners in world space.
+ * @param lattice Cell counts and world bounds of the evaluation volume.
+ * @param iso_level Field value the surface is placed at.
+ * @return Mesh data, empty if the field has no crossings at @p iso_level.
+ */
+MAYAFLUX_API Kakshya::MeshData generate_sdf_mesh(
+    const Kinesis::SpatialField& field,
+    const Lattice3D& lattice,
     float iso_level = 0.0F);
 
 } // namespace MayaFlux::Kinesis

--- a/src/MayaFlux/Kinesis/MarchingCube.cpp
+++ b/src/MayaFlux/Kinesis/MarchingCube.cpp
@@ -232,4 +232,16 @@ Kakshya::MeshData generate_sdf_mesh(
     return data;
 }
 
+Kakshya::MeshData generate_sdf_mesh(
+    const Kinesis::SpatialField& field,
+    const Lattice3D& lattice,
+    float iso_level)
+{
+    return generate_sdf_mesh(
+        field,
+        lattice.bounds.min, lattice.bounds.max,
+        lattice.resolution.x, lattice.resolution.y, lattice.resolution.z,
+        iso_level);
+}
+
 } // namespace MayaFlux::Kinesis

--- a/src/MayaFlux/Kinesis/Spatial/Lattice.hpp
+++ b/src/MayaFlux/Kinesis/Spatial/Lattice.hpp
@@ -1,0 +1,109 @@
+#pragma once
+
+#include "MayaFlux/Kinesis/Spatial/Bounds.hpp"
+
+namespace MayaFlux::Kinesis {
+
+/**
+ * @struct Lattice3D
+ * @brief A regular subdivision of an AABB3D into a cell count per axis.
+ *
+ * Pairs the continuous extent AABB3D describes with the discrete
+ * resolution a sampled field, a simulation grid, or an extraction pass
+ * imposes on it. Everything else is derived: cell size, cell centre,
+ * corner position, linear index.
+ *
+ * Indexing is x-major, y next, z outermost, matching the layout
+ * volume_common.glsl assumes and the order VolumeGridBuffer allocates in.
+ * A different traversal order is a different type, not a flag on this one.
+ *
+ * Cell-centred and corner-sampled are both expressed here rather than
+ * chosen at construction: marching cubes reads corners of the same
+ * lattice whose centres a simulation writes, and forcing that choice into
+ * the type would require two lattices where one describes the geometry.
+ */
+struct Lattice3D {
+    glm::uvec3 resolution { 1U }; ///< Cell count per axis. Zero on any axis is invalid.
+    AABB3D bounds { .min = glm::vec3(-1.0F), .max = glm::vec3(1.0F) }; ///< Continuous extent subdivided.
+
+    /** @brief Edge length of one cell along each axis. */
+    [[nodiscard]] glm::vec3 cell_size() const noexcept
+    {
+        return bounds.extent() / glm::vec3(resolution);
+    }
+
+    /** @brief Total cell count. */
+    [[nodiscard]] size_t cell_count() const noexcept
+    {
+        return static_cast<size_t>(resolution.x) * resolution.y * resolution.z;
+    }
+
+    /** @brief Corner count, one greater than the cell count on each axis. */
+    [[nodiscard]] size_t corner_count() const noexcept
+    {
+        return static_cast<size_t>(resolution.x + 1U)
+            * (resolution.y + 1U) * (resolution.z + 1U);
+    }
+
+    /**
+     * @brief Linear index of a cell, x-major.
+     * @param c Cell coordinate. Not bounds-checked.
+     */
+    [[nodiscard]] size_t index(const glm::uvec3& c) const noexcept
+    {
+        return (static_cast<size_t>(c.z) * resolution.y + c.y) * resolution.x + c.x;
+    }
+
+    /**
+     * @brief Whether a cell coordinate lies inside the lattice.
+     * @param c Cell coordinate.
+     */
+    [[nodiscard]] bool in_bounds(const glm::uvec3& c) const noexcept
+    {
+        return c.x < resolution.x && c.y < resolution.y && c.z < resolution.z;
+    }
+
+    /**
+     * @brief World position of a cell's centre.
+     * @param c Cell coordinate.
+     */
+    [[nodiscard]] glm::vec3 cell_center(const glm::uvec3& c) const noexcept
+    {
+        return bounds.min + (glm::vec3(c) + 0.5F) * cell_size();
+    }
+
+    /**
+     * @brief World position of a lattice corner.
+     * @param c Corner coordinate, valid up to resolution inclusive.
+     */
+    [[nodiscard]] glm::vec3 corner_position(const glm::uvec3& c) const noexcept
+    {
+        return bounds.min + glm::vec3(c) * cell_size();
+    }
+
+    /**
+     * @brief Cell containing a world position, clamped to the lattice.
+     * @param p World position. Points outside bounds clamp to the edge cell.
+     */
+    [[nodiscard]] glm::uvec3 cell_at(const glm::vec3& p) const noexcept
+    {
+        const glm::vec3 local = (p - bounds.min) / cell_size();
+        const glm::vec3 clamped = glm::clamp(
+            glm::floor(local), glm::vec3(0.0F), glm::vec3(resolution) - 1.0F);
+        return glm::uvec3(clamped);
+    }
+
+    /**
+     * @brief A lattice over the same bounds at a different resolution.
+     * @param res New cell count per axis.
+     *
+     * Extraction resolution independent of simulation resolution is this
+     * call.
+     */
+    [[nodiscard]] Lattice3D resampled(const glm::uvec3& res) const noexcept
+    {
+        return { .resolution = res, .bounds = bounds };
+    }
+};
+
+} // namespace MayaFlux::Kinesis


### PR DESCRIPTION
### Scope

Twenty-four commits since `VolumeGridBuffer` landed. What exists now: a buffer carrying arbitrary named fields over a 3D lattice, a set of compute stages that advance them, two independent ways to render the result, and a typed authoring surface over both.

The buffer itself knows nothing about fluids. It holds N named fields, each with its own stride and slot count, addressed by name and resolved to raw Vulkan handles. What a chain of stages does with them is the caller's arrangement. `setup_flow` is one such arrangement, offered because the ordering constraints in incompressible flow are correctness rather than preference, and getting them wrong produces a plausible-looking simulation rather than an error.

### What is here

**State.** `VolumeGridBuffer` with typed field declaration, `seed` from a `Kinesis::SpatialField` or `VectorField`, `accumulate` for host-computed injection, `read_field` for readback, and deferred transfers so seeding no longer stalls the frame it runs on.

**Stages.** Advection, diffusion, divergence, pressure, solenoidal projection, free-slip walls, Boussinesq buoyancy, and shaped influx. All derive from `VolumeFieldProcessor`, which handles field validation, dispatch sizing, per-cycle descriptor rewrites, and slot swaps, so a new stage is a binding table and a shader.

**Rendering.** Marching cubes extraction for surfaces, and raymarched integration for volumes. Both attach to the same fields; neither is privileged.

**Kinesis.** `Lattice3D` pairing cell counts with an `AABB3D`, now the single spatial description used by the buffer, the extraction processor, and the marching cubes free function.

### Authoring

Declaration returns typed refs, so a field name appears once:

```cpp
auto volume = std::make_shared<VolumeGridBuffer>(lattice);

auto velocity    = volume->declare_vector("velocity");
auto scratch     = volume->declare_vector("velocity_prev");
auto temperature = volume->declare_scalar("temperature");
auto density     = volume->declare_scalar("density");
auto divergence  = volume->declare_scratch("divergence");
auto pressure    = volume->declare_scalar("pressure");

volume = volume | Graphics;
```

A full incompressible chain with buoyancy, twelve stages, is one call:

```cpp
auto flow = volume->setup_flow({
    .velocity = velocity,
    .divergence = divergence,
    .pressure = pressure,
    .scratch = scratch,
    .time_step = DT,
    .viscosity = 0.00012F,
    .carried = { { temperature, 0.992F }, { density, 0.9985F } },
    .buoyancy = { .temperature = temperature, .density = density,
                  .temperature_gain = 3.4F, .density_gain = 1.1F },
});
```

Every stage comes back reachable. `flow.pressure->set_iteration_count(48)` and `flow.carriers[1]->set_dissipation(0.999F)` work, and stages can be inserted before or after by hand. The recipe fixes the ordering and nothing else.

Rendering attaches to a field rather than to the volume:

```cpp
auto smoke = std::make_shared<RaymarchBuffer>(
    lattice,
    [volume, density] { return volume->read_handle(density); },
    volume->get_field_bytes(density)) | Graphics;
```

The callable is resolved fresh each cycle, so a stage swapping the field's read slot is picked up with no coordination. Nothing in `RaymarchBuffer` refers to `VolumeGridBuffer`: any owner of a float array over the same lattice works.

### What this opens up

The obvious reading is fluid simulation, and that is the least interesting part of it.

A lattice field is a numerical array with a spatial interpretation. Nothing restricts what writes it or what reads it. An audio spectrum can seed a density field through `accumulate`, an influx stage's rate is a push constant and therefore feedable from an oscillator or an envelope, and `read_field` brings a lattice back to the host where it can drive anything. The direction here is not a fluid solver with an audio skin, it is a shared numerical substrate where a flow field is one thing you might do with a lattice among many.

The two rendering models are deliberately independent of the simulation and of each other. Marching cubes gives a mesh, which composites with ordinary geometry, takes an arbitrary fragment shader, and can be deformed downstream. Raymarching integrates through the field, so the interior gradient survives rather than one level set of it. Neither is "the volume renderer"; both are processors over the same storage, and a third, points or splats or slices, is a binding table and a shader away.

The stage set is a library, not a pipeline. `InfluxProcessor` puts its shape in the shader and takes the shader path as an argument, so a new source geometry is one GLSL file defining `float shape(vec3, float)`. `BuoyancyProcessor` takes a direction vector rather than assuming gravity, so it is a general body force. `WallProcessor` is a geometric constraint with no physical claim. What any of them means is decided by what a caller chains together.

`Lattice3D` is deliberately in Kinesis rather than in Buffers. A discretized region of space with derivable cell size and containment is math, and the same object should eventually serve geometry sampling, spatial audio, and collision alongside field storage.

### Known limits

**Mass is not conserved.** Total density falls measurably with dissipation at exactly one and free-slip walls in place. Semi-Lagrangian backtracing is not conservative, which accounts for some of it, but the loss rate has not been fully explained and the wall condition did not change it. Continuous influx makes it unobservable in practice, which is why the demos use it, but it is not a fix.

**First-order advection smears.** Peaks fall much faster than dissipation reduces them. MacCormack correction is the next item and is why the demos carry threshold and density-scale compensation.

**Extraction storage is worst-case.** Fifteen vertices per voxel, roughly 225 MB at 64 cubed, because `mc_emit` has no capacity check. Mathematically sufficient and never overflows; the cost is allocation, not safety.

**`accumulate` has no in-tree caller** now that influx replaced its only one. Kept because it reaches host-computed injection that no shader path can, but it is speculative until something uses it.

### Incidental fixes

One pre-existing bugs surfaced by being the first caller to hit them.  `Kinesis::generate_box` left `layout.vertex_count` at zero, so any mesh built from it was silently skipped at draw time.