### PR TITLE
Forma: Form, Atelier, and the layout vocabulary

### DIFF
--- a/docs/Portal-Forma-UI-Patterns.md
+++ b/docs/Portal-Forma-UI-Patterns.md
@@ -7,20 +7,35 @@ own layout, Forma owns rendering and hit testing.
 
 This guide maps common ImGui patterns to their Forma equivalents.
 
+Forma has one further difference from ImGui that this guide leans on
+throughout. A `Geometry::` factory returns a `Form<T>`: a geometry function
+together with the topology, buffer capacity, and interaction its realization
+requires. `Portal::Forma::create` realizes one. So the ImGui equivalents below
+are usually a single call, not because Forma grew a widget layer, but because
+the geometry function already knew its own topology and its own inverse
+mapping and now carries them.
+
+Every field of a `Form` is public. Clearing `wire` hands interaction back to
+you, which several patterns below do.
+
 ---
 
 ## Mental model shift
 
 ImGui:
+
 - Call `Begin` / `End` each frame.
 - Declare widgets inline. ImGui handles state, layout, and drawing.
 - Nothing persists. Everything is re-emitted every frame.
 
 Forma:
+
 - Construct elements once at startup. Register them on a `Layer`.
 - Write to `MappedState<T>` to change values. `sync()` redraws geometry.
 - Hit testing and event dispatch run continuously via `Context`.
-- Layout is your NDC arithmetic, done once at construction time.
+- Layout is explicit and done once at construction: `LayoutCursor` to advance
+  rows, `Kinesis::place` to position one region against another, `Surface`
+  named regions for screen anchors.
 
 The frame loop runs invisibly. You do not call `Begin`, you do not loop over
 widgets. You write a value and the geometry function reacts.
@@ -36,25 +51,41 @@ baseline. NDC Y runs +1 (top) to -1 (bottom). `advance(height)` subtracts
 height and returns the AABB just occupied.
 
 ```cpp
-LayoutCursor cursor;             // starts at y = 1.0 (top)
+LayoutCursor cursor;             // starts at y = 1.0 (top), full NDC width
 cursor.skip(0.02F);              // padding
 
-const auto row0 = cursor.advance(0.06F);  // AABB { -1, 0.92, 1, 1.0 } (approximately)
+const auto row0 = cursor.advance(0.06F);
 const auto row1 = cursor.advance(0.06F);
-const auto row2 = cursor.advance(0.06F);
 ```
 
-For columnar layouts, compute x ranges manually:
+For columnar layouts, construct one cursor per column with its own x extent.
+Each advances independently, and `sync_to` brings both back to a common
+baseline after a row that spans them:
 
 ```cpp
-constexpr float x_left  = -0.95F;
-constexpr float x_mid   =  0.0F;
-constexpr float x_right =  0.95F;
+LayoutCursor left  { 1.F, -0.95F, -0.05F };
+LayoutCursor right { 1.F,  0.05F,  0.95F };
 
-// Two columns side by side at the same row y
-auto row = cursor.advance(0.06F);
-Kinesis::AABB2D left_cell  { { x_left, row.min.y }, { x_mid,   row.max.y } };
-Kinesis::AABB2D right_cell { { x_mid,  row.min.y }, { x_right, row.max.y } };
+const auto fader_bounds = left.advance(0.08F);
+const auto meter_bounds = right.advance(0.08F);
+
+left.sync_to(right);
+```
+
+To place one region against another rather than advancing a baseline, use
+`Kinesis::place`:
+
+```cpp
+const auto label = Kinesis::place(fader_bounds, Kinesis::Side::Below,
+    0.F, 0.05F, 0.01F, Kinesis::Align::Span);
+```
+
+`Surface` supplies named screen regions so a panel needs no NDC arithmetic at
+all:
+
+```cpp
+const auto panel = surface.top_left(0.35F, 0.8F);
+LayoutCursor cursor { panel.max.y, panel.min.x, panel.max.x };
 ```
 
 ---
@@ -62,6 +93,7 @@ Kinesis::AABB2D right_cell { { x_mid,  row.min.y }, { x_right, row.max.y } };
 ## ImGui::Text / label
 
 ImGui:
+
 ```cpp
 ImGui::Text("Cutoff: %.2f Hz", freq);
 ```
@@ -96,8 +128,7 @@ For live-updating readouts driven by a reader function, `make_value_row`
 (from `Inspect/QueryUtils.hpp`) does the repress loop for you:
 
 ```cpp
-const glm::uvec2 dims = row_pixel_dims(window, x_min, x_max, row_h);
-auto row_buf = Inspector::make_row_buffer(window, "Cutoff", dims);
+auto row_buf = Inspector::make_row_buffer(window, "Cutoff", row_pixel_dims(window, cursor, row_h));
 
 auto row = make_value_row(
     ValueSpec {
@@ -105,7 +136,7 @@ auto row = make_value_row(
         .reader = [&freq] { return std::format("{:.2f} Hz", freq.load()); },
     },
     std::move(row_buf),
-    surface, cursor, x_min, x_max, row_h);
+    surface, cursor, row_h);
 
 // Each graphics tick:
 row.link.tap();
@@ -116,6 +147,7 @@ row.link.tap();
 ## ImGui::Button
 
 ImGui:
+
 ```cpp
 if (ImGui::Button("Trigger")) { fire(); }
 ```
@@ -153,31 +185,47 @@ surface.ctx().on_leave  (id, [buf, box](uint32_t) {
 });
 ```
 
+This is the pattern that has not shrunk. A button is one element for the
+background plus one for the label plus four handlers, and the text buffer
+still needs its `additional_textures` slot declared by hand.
+
 ---
 
 ## ImGui::Checkbox / toggle
 
 ImGui:
+
 ```cpp
 ImGui::Checkbox("Enable", &enabled);
 ```
 
-Forma: `toggle` geometry function + `on_press` to flip state.
+Forma: the `toggle` Form carries the press that flips the value.
 
 ```cpp
-auto el = Portal::Forma::create_element<bool>(
+auto el = Portal::Forma::create(
     surface,
     Portal::Forma::Geometry::toggle(box, { 0.2F, 0.2F, 0.2F }, { 0.2F, 0.7F, 0.4F }),
-    false,
-    Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP);
+    false);
+
+// Read current value anywhere:
+const bool enabled = el.state->value;
+```
+
+To act on the change rather than poll, take the wire back. Registering a
+second `on_press` on the same button replaces the Form's, so combine both in
+one handler:
+
+```cpp
+auto form = Portal::Forma::Geometry::toggle(box, { 0.2F, 0.2F, 0.2F }, { 0.2F, 0.7F, 0.4F });
+form.wire = {};
+
+auto el = Portal::Forma::create(surface, std::move(form), false);
 
 surface.ctx().on_press(el.element.id, IO::MouseButtons::Left,
     [state = el.state](uint32_t, glm::vec2) {
         state->write(!state->value);
+        on_toggled(state->value);
     });
-
-// Read current value anywhere:
-const bool enabled = el.state->value;
 ```
 
 ---
@@ -185,47 +233,39 @@ const bool enabled = el.state->value;
 ## ImGui::SliderFloat / horizontal fader
 
 ImGui:
+
 ```cpp
 ImGui::SliderFloat("Gain", &gain, 0.0f, 1.0f);
 ```
 
-Forma: `horizontal_fader` geometry function + `on_drag`. No press flag needed.
+Forma: the `horizontal_fader` Form carries the drag.
 
 ```cpp
 constexpr Kinesis::AABB2D track { { -0.8F, -0.05F }, { 0.8F, 0.05F } };
 
-auto el = Portal::Forma::create_element<float>(
-    surface,
-    Portal::Forma::Geometry::horizontal_fader(track, 0.04F),
-    0.5F,
-    Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP);
-
-surface.ctx().on_drag(el.element.id, IO::MouseButtons::Left,
-    [state = el.state, track](uint32_t, glm::vec2 ndc) {
-        state->write(std::clamp(
-            (ndc.x - track.min.x) / track.width(), 0.F, 1.F));
-    });
+auto el = Portal::Forma::create(
+    surface, Portal::Forma::Geometry::horizontal_fader(track, 0.04F), 0.5F);
 
 // Wire to a node:
 auto constant = vega.Constant(0.5) | Audio[0];
 Portal::Forma::bridge().at(el.state).write(constant);
 ```
 
-Arrow-key fine adjustment wires directly to the same state once the element
-has keyboard focus (transferred automatically on click):
+The drag maps the cursor onto the handle's travel, which is shorter than the
+track by one handle width. Writing that mapping by hand is where a
+hand-rolled fader usually goes half a handle out of alignment at the extremes.
+
+Arrow-key fine adjustment is separate, since the Form carries pointer
+interaction only. Focus transfers on click:
 
 ```cpp
-surface.ctx().on_held(el.element.id, IO::Keys::ArrowRight,
-    [state = el.state](uint32_t) {
-        state->write(std::clamp(state->value + 0.005F, 0.F, 1.F));
-    });
-surface.ctx().on_held(el.element.id, IO::Keys::ArrowLeft,
-    [state = el.state](uint32_t) {
-        state->write(std::clamp(state->value - 0.005F, 0.F, 1.F));
-    });
+surface.ctx().key_step(el.element.id, el.state,
+    IO::Keys::ArrowLeft, IO::Keys::ArrowRight, 0.005F);
 ```
 
-For a knob (arc-based), use `stroke_slider` with an `arc_path`:
+For a knob, `stroke_slider` along an `arc_path`. The Form carries the
+arc-length projection that the previous version of this guide left as a
+comment:
 
 ```cpp
 auto path = Kinesis::arc_path({ 0.F, 0.F }, 0.3F, 0.3F,
@@ -234,17 +274,22 @@ auto path = Kinesis::arc_path({ 0.F, 0.F }, 0.3F, 0.3F,
 auto handle_buf = Portal::Forma::create_buffer(
     window, Portal::Graphics::PrimitiveTopology::POINT_LIST);
 
-auto el = Portal::Forma::create_element<float>(
+auto el = Portal::Forma::create(
     surface,
     Portal::Forma::Geometry::stroke_slider(path, handle_buf,
         0.02F, { 0.2F, 0.2F, 0.25F }, { 0.3F, 0.6F, 1.0F }),
-    0.5F,
-    Portal::Graphics::PrimitiveTopology::LINE_LIST);
+    0.5F);
+```
 
-surface.ctx().on_drag(el.element.id, IO::MouseButtons::Left,
-    [state = el.state, path](uint32_t, glm::vec2 ndc) {
-        // project ndc onto path arc-length, write [0,1]
-    });
+For a scaled range rather than [0,1], compose the projection and replace the
+wire:
+
+```cpp
+auto form = Portal::Forma::Geometry::horizontal_fader(track, 0.04F);
+form.wire = Portal::Forma::Geometry::drag_with<float>(
+    Kinesis::scaled(Kinesis::axis_fraction(track, 0.04F), 20.F, 20000.F));
+
+auto el = Portal::Forma::create(surface, std::move(form), 440.F);
 ```
 
 ---
@@ -252,6 +297,7 @@ surface.ctx().on_drag(el.element.id, IO::MouseButtons::Left,
 ## ImGui::CollapsingHeader / tree node
 
 ImGui:
+
 ```cpp
 if (ImGui::CollapsingHeader("Oscillator")) {
     ImGui::SliderFloat("Freq", ...);
@@ -261,9 +307,9 @@ if (ImGui::CollapsingHeader("Oscillator")) {
 Forma: `Collapsible` + `attach` for each body element.
 
 ```cpp
-constexpr float x_min = -0.95F, x_max = 0.95F, row_h = 0.055F;
+constexpr float row_h = 0.055F;
+LayoutCursor cursor { 1.F, -0.95F, 0.95F };
 
-// Header buffer: plain color if no label image, textured if one is set
 auto hbuf = Portal::Forma::create_buffer(window,
     Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP);
 
@@ -271,15 +317,12 @@ auto col = Collapsible {}
     .initially_open(true)
     .closed_color({ 0.2F, 0.2F, 0.22F })
     .open_color({ 0.28F, 0.28F, 0.32F })
-    .place(std::move(hbuf), surface, cursor, x_min, x_max, row_h);
+    .place(std::move(hbuf), surface, cursor, row_h);
 
-// Body elements - each must be created after place() so cursor is advanced
-auto fader_el = Portal::Forma::create_element<float>(
+auto fader_el = Portal::Forma::create(
     surface,
-    Portal::Forma::Geometry::horizontal_fader(
-        cursor.advance(row_h), 0.04F),
-    0.5F,
-    Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP);
+    Portal::Forma::Geometry::horizontal_fader(cursor.advance(row_h), 0.04F),
+    0.5F);
 
 col.attach(surface.layer(), fader_el.element.id);
 ```
@@ -295,10 +338,10 @@ A scrollable inspector-style panel with live-updating labeled rows grouped
 under collapsible headers. This is the pattern the internal Inspector uses.
 
 ```cpp
-constexpr float x_min = -0.95F, x_max = 0.95F, row_h = 0.05F;
-LayoutCursor cursor;
+constexpr float row_h = 0.05F;
+LayoutCursor cursor { 1.F, -0.95F, 0.95F };
 
-const glm::uvec2 dims = row_pixel_dims(window, x_min, x_max, row_h);
+const glm::uvec2 dims = row_pixel_dims(window, cursor, row_h);
 
 // Pre-create one RowBuffer per data field
 auto freq_buf  = Inspector::make_row_buffer(window, "Freq",  dims);
@@ -318,7 +361,7 @@ std::array<ValueSpec, 3> specs { {
 
 auto group = make_value_group(
     specs, std::move(hdr_buf), row_bufs,
-    surface, cursor, x_min, x_max, row_h, true);
+    surface, cursor, row_h, true);
 
 // Each graphics tick - tap all links to repress live values
 schedule_metro(1.0 / 30.0, [g = std::move(group)]() mutable {
@@ -339,22 +382,23 @@ ImGui has no direct equivalent. The closest approximation - a sequence of
 interpolation, and no direct routing to an audio buffer.
 
 Forma's `drawable_canvas` renders a `vector<float>` of N samples as a
-continuous polyline. `wire_canvas_drag` handles all interaction: NDC to
-sample index, amplitude mapping, gap interpolation under fast drag, and
-version increment to trigger `sync()`. The state vector routes directly to
-any bulk float consumer.
+continuous polyline. Its Form carries the painting interaction: NDC to sample
+index, amplitude mapping, gap interpolation under fast drag, and the version
+increment that triggers `sync()`. The state vector routes directly to any bulk
+float consumer.
+
+`Geometry::wire_canvas_drag(ctx, id, state, bounds)` registers that same
+interaction directly, for a canvas assembled by hand or after clearing the
+Form's `wire`.
 
 ```cpp
 constexpr Kinesis::AABB2D bounds { glm::vec2(-0.8F, -0.6F), glm::vec2(0.8F, 0.6F) };
 constexpr uint32_t k_n = 256;
 
-auto el = Portal::Forma::create_element<std::vector<float>>(
+auto el = Portal::Forma::create(
     surface,
     Portal::Forma::Geometry::drawable_canvas(bounds),
-    std::vector<float>(k_n, 0.5F),
-    Portal::Graphics::PrimitiveTopology::LINE_LIST);
-
-Portal::Forma::Geometry::wire_canvas_drag(surface.ctx(), el.element.id, el.state, bounds);
+    std::vector<float>(k_n, 0.5F));
 ```
 
 Routing to consumers:
@@ -383,16 +427,11 @@ Two canvases on one surface give independent control over separate arrays -
 for example IIR a-coefs and b-coefs simultaneously:
 
 ```cpp
-auto b_el = Portal::Forma::create_element<std::vector<float>>(surface,
-    Portal::Forma::Geometry::drawable_canvas(b_bounds, { 0.3F, 0.8F, 0.4F }),
-    b_init, Portal::Graphics::PrimitiveTopology::LINE_LIST);
+auto b_el = Portal::Forma::create(surface,
+    Portal::Forma::Geometry::drawable_canvas(b_bounds, { 0.3F, 0.8F, 0.4F }), b_init);
 
-auto a_el = Portal::Forma::create_element<std::vector<float>>(surface,
-    Portal::Forma::Geometry::drawable_canvas(a_bounds, { 0.8F, 0.4F, 0.3F }),
-    a_init, Portal::Graphics::PrimitiveTopology::LINE_LIST);
-
-Portal::Forma::Geometry::wire_canvas_drag(surface.ctx(), b_el.element.id, b_el.state, b_bounds);
-Portal::Forma::Geometry::wire_canvas_drag(surface.ctx(), a_el.element.id, a_el.state, a_bounds);
+auto a_el = Portal::Forma::create(surface,
+    Portal::Forma::Geometry::drawable_canvas(a_bounds, { 0.8F, 0.4F, 0.3F }), a_init);
 
 Portal::Forma::bridge().at(b_el.state).write([iir](std::span<const float> s) {
     iir->setBCoefficients({ s.begin(), s.end() });
@@ -419,7 +458,7 @@ surface.layer().set_visible(parent_id, false);  // hides all attached children
 
 // Z-order
 surface.layer().send_to_back(id);
-surface.layer().send_to_front(id);
+surface.layer().bring_to_front(id);
 ```
 
 ---
@@ -434,39 +473,40 @@ hit region:
 auto scroll_offset = make_persistent(0.F);
 constexpr float scroll_speed = 0.04F;
 
-// Background hit region covers the panel area
+// Interactive backdrop: scroll routes through hover, so the region must hit-test
 const uint32_t panel_id = surface.layer().add(
-    Portal::Forma::Element {}
-        .with_bounds(panel_bounds)
-        .non_interactive());    // non_interactive = no pointer grab, but scroll fires
+    Portal::Forma::Element {}.with_bounds(panel_bounds)).to_back().id();
 
 surface.ctx().on_scroll(panel_id,
-    [&scroll_offset](uint32_t, glm::vec2 delta) {
+    [&scroll_offset](uint32_t, glm::vec2, double, double dy) {
         scroll_offset = std::clamp(
-            scroll_offset + delta.y * scroll_speed, -8.F, 0.F);
-        // re-run layout with new offset, or drive LayoutCursor state
+            scroll_offset + static_cast<float>(dy) * scroll_speed, -8.F, 0.F);
     });
 ```
 
 Full scrollable panels require re-placing elements at new bounds when the
-offset changes, or using a LayoutCursor whose `state()` is closed over by
-all body geometry functions so they reflow on `state()->write(new_y)`.
+offset changes. `LayoutCursor` holds its baseline in a shared
+`MappedState<float>`, so a geometry function closing over `cursor.state()`
+would reflow on `state()->write(new_y)`. No shipped geometry function does
+this: every factory captures its bounds by value at construction. Reflow is
+available to geometry you write yourself.
 
 ---
 
 ## Key differences from ImGui
 
-| ImGui | Forma |
-|---|---|
-| Immediate: re-emit every frame | Retained: construct once, update on change |
-| Implicit layout engine | Explicit NDC arithmetic + LayoutCursor |
-| Internal widget state | Your state, written via `MappedState<T>::write` |
-| `if (Button(...))` inline action | `on_press` callback registered once |
-| `SliderFloat` with press+drag implicit | `on_drag` callback - no press flag |
-| No keyboard routing to widgets | Per-element key focus: `on_press(key)`, `on_held(key)`, `on_release(key)` |
-| Style stack | Per-element color/geometry at construction |
-| Docking, tables, scroll built-in | Build from primitives; no built-in containers |
-| Thread: main/render thread only | Callbacks on graphics thread; writes from any thread |
-| Immediate feedback | Geometry updates on next `sync()` after `write()` |
-| No curve/array editor primitive | `drawable_canvas` + `wire_canvas_drag`: drawn curve routes directly to audio or any N-element consumer |
-| No audio graph wiring | `Bridge::write` routes element value to nodes, shaders, audio processors, or arbitrary span sinks |
+| ImGui                                             | Forma                                                                                                  |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Immediate: re-emit every frame                    | Retained: construct once, update on change                                                             |
+| Implicit layout engine                            | Explicit NDC arithmetic + LayoutCursor                                                                 |
+| Internal widget state                             | Your state, written via `MappedState<T>::write`                                                        |
+| `if (Button(...))` inline action                  | `on_press` callback registered once                                                                    |
+| `SliderFloat` with press+drag implicit            | `on_drag` callback - no press flag                                                                     |
+| No keyboard routing to widgets                    | Per-element key focus: `on_press(key)`, `on_held(key)`, `on_release(key)`                              |
+| Style stack                                       | Per-element color/geometry at construction                                                             |
+| Docking, tables, scroll built-in                  | Build from primitives; no built-in containers                                                          |
+| Thread: main/render thread only                   | Callbacks on graphics thread; writes from any thread                                                   |
+| Immediate feedback                                | Geometry updates on next `sync()` after `write()`                                                      |
+| No curve/array editor primitive                   | `drawable_canvas` + `wire_canvas_drag`: drawn curve routes directly to audio or any N-element consumer |
+| No audio graph wiring                             | `Bridge::write` routes element value to nodes, shaders, audio processors, or arbitrary span sinks      |
+| No way to build a widget the library did not ship | Any function returning a Form<T> is treated identically to the shipped ones                            |

--- a/docs/Portal-Forma.md
+++ b/docs/Portal-Forma.md
@@ -88,15 +88,15 @@ function. All coordinates are NDC (z = 0).
 
 ### Filled shapes - `Kakshya::Vertex`, TRIANGLE_LIST
 
-| Function | Description |
-|---|---|
-| `filled_rect(region, color)` | 4-vertex TRIANGLE_STRIP rect. Also in `GeometryPrimitives.hpp`. |
-| `filled_rect_gradient(region, bl, br, tl, tr)` | Same shape, per-corner colors. |
-| `filled_rounded_rect(region, corner_r, segments, color)` | Rounded rect decomposed into body rects + corner fans. |
-| `filled_circle(center, radius, segments, color)` | Triangle fan. |
-| `filled_ring(center, inner_r, outer_r, segments, color)` | Annulus as quad strip. |
-| `filled_polygon(center, radius, sides, rotation, color)` | Regular n-gon fan. |
-| `filled_arc(center, radius, start, end, segments, color)` | Pie-slice sector fan. |
+| Function                                                  | Description                                                     |
+| --------------------------------------------------------- | --------------------------------------------------------------- |
+| `filled_rect(region, color)`                              | 4-vertex TRIANGLE_STRIP rect. Also in `GeometryPrimitives.hpp`. |
+| `filled_rect_gradient(region, bl, br, tl, tr)`            | Same shape, per-corner colors.                                  |
+| `filled_rounded_rect(region, corner_r, segments, color)`  | Rounded rect decomposed into body rects + corner fans.          |
+| `filled_circle(center, radius, segments, color)`          | Triangle fan.                                                   |
+| `filled_ring(center, inner_r, outer_r, segments, color)`  | Annulus as quad strip.                                          |
+| `filled_polygon(center, radius, sides, rotation, color)`  | Regular n-gon fan.                                              |
+| `filled_arc(center, radius, start, end, segments, color)` | Pie-slice sector fan.                                           |
 
 ```cpp
 // Rounded panel background
@@ -114,14 +114,14 @@ auto buf = Portal::Forma::create_buffer(
 
 ### Outlines - `Kakshya::LineVertex`, LINE_LIST
 
-| Function | Description |
-|---|---|
-| `rect_outline(region, color, thickness)` | 4 edges, 8 vertices. |
-| `circle_outline(center, radius, segments, color, thickness)` | Closed loop. |
-| `arc_outline(center, radius, start, end, segments, color, thickness)` | Open arc. |
-| `polygon_outline(center, radius, sides, rotation, color, thickness)` | Closed n-gon. |
-| `polyline(pts, color, thickness)` | Open path from a span of `glm::vec2`. |
-| `polyline_colored(pts, colors, thickness)` | Same, per-vertex colors. |
+| Function                                                              | Description                           |
+| --------------------------------------------------------------------- | ------------------------------------- |
+| `rect_outline(region, color, thickness)`                              | 4 edges, 8 vertices.                  |
+| `circle_outline(center, radius, segments, color, thickness)`          | Closed loop.                          |
+| `arc_outline(center, radius, start, end, segments, color, thickness)` | Open arc.                             |
+| `polygon_outline(center, radius, sides, rotation, color, thickness)`  | Closed n-gon.                         |
+| `polyline(pts, color, thickness)`                                     | Open path from a span of `glm::vec2`. |
+| `polyline_colored(pts, colors, thickness)`                            | Same, per-vertex colors.              |
 
 ```cpp
 // Border around a panel
@@ -151,81 +151,118 @@ auto path = Kinesis::arc_path({ 0.F, 0.F }, 0.4F, 0.4F,
 auto handle_buf = Portal::Forma::create_buffer(
     window, Portal::Graphics::PrimitiveTopology::POINT_LIST);
 
-auto el = Portal::Forma::create_element<float>(
-    surface,
-    Portal::Forma::Geometry::stroke_slider(path, handle_buf),
-    0.5F,
-    Portal::Graphics::PrimitiveTopology::LINE_LIST);
+auto el = Portal::Forma::create(
+    surface, Portal::Forma::Geometry::stroke_slider(path, handle_buf), 0.5F);
 ```
 
 ---
 
-## Geometry functions for Mapped\<T\>
+## Form : geometry with everything its realization needs
 
-`Portal::Forma::Geometry` provides ready-made geometry functions for `create_element<T>`. Each produces a closure over its configuration parameters; pass the result directly as the `geom` argument.
+A geometry function alone is not enough to construct an element. Its topology
+is fixed by the vertex kind it writes, its capacity by the vertex count, and
+its interaction by the forward placement it performs. All three are knowledge
+the geometry factory already has, and the call site would otherwise restate
+them.
+
+`Form<T>` carries all four together:
+
+```cpp
+template <typename T>
+struct Form {
+    GeometryFn<T> geometry;
+    Portal::Graphics::PrimitiveTopology topology;
+    size_t capacity;
+    std::function<void(Context&, uint32_t, std::shared_ptr<MappedState<T>>)> wire;
+};
+```
+
+`Portal::Forma::create` realizes one: builds the buffer at the Form's capacity
+and topology, registers the element, syncs so `bounds_hint` and `contains`
+from the geometry function reach the Layer before the first frame, then runs
+the wiring.
+
+```cpp
+constexpr Kinesis::AABB2D track { glm::vec2(-0.8F, -0.08F), glm::vec2(0.8F, 0.08F) };
+
+auto el = Portal::Forma::create(
+    surface, Portal::Forma::Geometry::horizontal_fader(track, 0.04F), 0.5F);
+
+auto constant = vega.Constant(0.0) | Audio[0];
+Portal::Forma::bridge().at(el.state).write(constant);
+```
+
+That is the whole fader: geometry, correct topology, correct buffer size, and
+a drag whose inverse matches the handle placement.
+
+Nothing enumerates the set of Forms. Any function returning one participates
+identically, including one you write. A bare `GeometryFn<T>` converts to a
+`Form<T>` with default topology, default capacity, and no interaction, so
+custom geometry passes to `create` unchanged.
+
+Every field is public and overridable before `create`. To keep the geometry
+but supply your own interaction:
+
+```cpp
+auto form = Portal::Forma::Geometry::horizontal_fader(track, 0.04F);
+form.wire = {};
+
+auto el = Portal::Forma::create(surface, std::move(form), 0.5F);
+
+surface.ctx().on_drag(el.element.id, IO::MouseButtons::Left,
+    [state = el.state](uint32_t, glm::vec2 ndc) { /* your mapping */ });
+```
+
+`capacity` is a hint. `FormaProcessor` grows the buffer when a sync exceeds
+it, at the cost of one reallocation.
+
+---
+
+## Geometry functions
+
+`Portal::Forma::Geometry` provides ready-made Forms. Each closes over its
+configuration parameters and carries the interaction inverse to the placement
+it performs.
 
 ### Controls
 
-| Function | T | Topology | Notes |
-|---|---|---|---|
-| `horizontal_fader(bounds, handle_w)` | `float [0,1]` | TRIANGLE_STRIP | Track + handle quads. Hit region follows handle. |
-| `vertical_fader(bounds, handle_h)` | `float [0,1]` | TRIANGLE_STRIP | Same, vertical orientation. |
-| `stroke_slider(path, handle_buf, ...)` | `float [0,1]` | LINE_LIST | Arc-length scrubber along any polyline. Requires a separate POINT_LIST handle buffer. |
-| `toggle(region, color_off, color_on)` | `bool` | TRIANGLE_STRIP | Color switches on write. Wire `on_press` to flip state. |
-| `drawable_canvas(bounds, color, thickness)` | `vector<float>` | LINE_LIST | N samples rendered as a polyline. Use `wire_canvas_drag` to wire interaction. |
+| Function                                    | T               | Carries                                                                                                                                  |
+| ------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `horizontal_fader(bounds, handle_w)`        | `float [0,1]`   | Drag mapping cursor x to handle position, offset by half a handle so the handle centre tracks the cursor. Hit region follows the handle. |
+| `vertical_fader(bounds, handle_h)`          | `float [0,1]`   | Same, y axis.                                                                                                                            |
+| `stroke_slider(path, handle_buf, ...)`      | `float [0,1]`   | Drag mapping cursor to nearest arc-length position on the path. Requires a separate POINT_LIST handle buffer.                            |
+| `toggle(region, color_off, color_on)`       | `bool`          | Press flipping the value.                                                                                                                |
+| `drawable_canvas(bounds, color, thickness)` | `vector<float>` | Drag painting sample values, interpolating across indices under fast drag.                                                               |
 
 ### Readouts
 
-| Function | T | Topology | Notes |
-|---|---|---|---|
-| `level_meter(bounds, horizontal, fill, track)` | `float [0,1]` | TRIANGLE_STRIP | Fills proportional bar. No hit region. |
-| `radial(center, radius, start, end, color)` | `float [0,1]` | LINE_LIST | Sweeping indicator line. |
+| Function                                       | T             | Carries                                                                                                         |
+| ---------------------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------- |
+| `level_meter(bounds, horizontal, fill, track)` | `float [0,1]` | Nothing. Driven from a node or a Bridge write.                                                                  |
+| `radial(region, start, end, color)`            | `float [0,1]` | Drag mapping cursor angle about the region's centre onto the sweep. Radius is the region's smaller half-extent. |
 
 ### Positional
 
-| Function | T | Topology | Notes |
-|---|---|---|---|
-| `point(color, size, hit_radius)` | `glm::vec2` (NDC) | POINT_LIST | Single point. Hit region is a circle. |
-| `crosshair(arm_len, color, thickness, hit_radius)` | `glm::vec2` (NDC) | LINE_LIST | Two crossing segments. |
-| `position_picker(bounds, color, size)` | `glm::vec2 [0,1]²` | POINT_LIST | Maps unit square to NDC bounds. |
+| Function                                           | T                  | Carries                                                         |
+| -------------------------------------------------- | ------------------ | --------------------------------------------------------------- |
+| `point(color, size, hit_radius)`                   | `glm::vec2` (NDC)  | Hover, writing the cursor position. Hit region is a circle.     |
+| `crosshair(arm_len, color, thickness, hit_radius)` | `glm::vec2` (NDC)  | Hover, writing the cursor position.                             |
+| `position_picker(bounds, color, size)`             | `glm::vec2 [0,1]²` | Drag mapping cursor to unit-square coordinates over the bounds. |
 
-### Drawable canvas
+---
 
-`drawable_canvas` renders a `vector<float>` of N samples as a LINE_LIST polyline across the canvas bounds. Sample values are in [0, 1] mapped to the Y axis.
-
-`wire_canvas_drag` registers the drag interaction in one call: it maps NDC cursor position to sample index and amplitude, interpolates between the previous and current index to fill gaps under fast drag, and increments `state->version` to trigger `sync()`.
-
-```cpp
-constexpr Kinesis::AABB2D bounds { glm::vec2(-0.8F, -0.6F), glm::vec2(0.8F, 0.6F) };
-constexpr uint32_t k_n = 256;
-
-auto el = Portal::Forma::create_element<std::vector<float>>(
-    surface,
-    Portal::Forma::Geometry::drawable_canvas(bounds),
-    std::vector<float>(k_n, 0.5F),
-    Portal::Graphics::PrimitiveTopology::LINE_LIST);
-
-Portal::Forma::Geometry::wire_canvas_drag(surface.ctx(), el.element.id, el.state, bounds);
-```
-
-The state vector routes to any bulk float consumer via Bridge:
+Any factory whose first parameter is an `AABB2D` accepts an anchor instead
+through `Geometry::at`:
 
 ```cpp
-// Wavetable / envelope - direct to AudioWriteProcessor
-auto writer = std::make_shared<Buffers::AudioWriteProcessor>();
-auto audio_buf = std::make_shared<Buffers::AudioBuffer>(0, k_n);
-audio_buf->set_default_processor(writer);
-register_audio_buffer(audio_buf, 0);
-Portal::Forma::bridge().at(el.state).write(writer);
+auto fader = Portal::Forma::create(surface, Geometry::horizontal_fader(track, 0.04F), 0.5F);
 
-// IIR coefficient array
-auto iir = vega.IIR(rand, a_coefs, b_coefs) | Audio[0];
-Portal::Forma::bridge().at(el.state).write(
-    [iir](std::span<const float> s) {
-        std::vector<double> coefs(s.begin(), s.end());
-        iir->setBCoefficients(coefs);
-    });
+// a meter occupying the fader's own region
+auto meter = Portal::Forma::create(surface, Geometry::at(fader, Geometry::level_meter), 0.F);
 ```
+
+`at` works for any factory, including yours. Anything exposing `bounds()`
+serves as the anchor: `Mapped<T>`, `Collapsible`, `ValueRow`, `ValueGroup`.
 
 ---
 
@@ -388,12 +425,10 @@ el.set_text("active", Portal::Text::PressParams { .render_bounds = { 256, 48 } }
 
 ## Mapped\<T\> : typed dynamic geometry
 
-When geometry must update in response to a changing value, use
-`create_element<T>`. The geometry function converts the current `T` into
-vertex bytes and is rerun automatically when the value changes.
+When geometry must update in response to a changing value, write a geometry function and pass it to create.
 
 ```cpp
-auto el = Portal::Forma::create_element<float>(
+auto el = Portal::Forma::create<float>(
     surface,
     [track](float v, std::vector<uint8_t>& out, Portal::Forma::Element& elem) {
         float right = track.min.x + v * track.width();
@@ -405,15 +440,22 @@ auto el = Portal::Forma::create_element<float>(
         } });
         elem.bounds_hint = track;
     },
-    0.0F,
-    Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP);
+    0.0F);
 ```
 
-The geometry function receives the current value, a byte buffer to write into,
-and a mutable `Element&`. Writing `elem.bounds_hint` or `elem.contains` inside
-the geometry function updates the spatial description as the shape changes.
-The `Surface`-accepting overload of `create_element` runs one `sync()` on
-construction so bounds and containment are live before the first frame.
+The geometry function receives the current value, a byte buffer to write into, and a mutable `Element&`.
+Writing `elem.bounds_hint` or `elem.contains` inside the geometry function updates the spatial description as the shape changes.
+A raw geometry function converts to a `Form<T>` with default topology and capacity and no interaction,
+so pass topology explicitly by constructing the Form yourself when the vertex kind is not `TRIANGLE_STRIP`:
+
+```cpp
+Portal::Forma::Geometry::Form<float> form {
+    std::move(my_geometry_fn),
+    Portal::Graphics::PrimitiveTopology::LINE_LIST,
+    4 * sizeof(Kakshya::LineVertex),
+};
+auto el = Portal::Forma::create(surface, std::move(form), 0.F);
+```
 
 `el.state` is the `shared_ptr<MappedState<T>>`. Write a new value from any
 thread via `el.state->write(v)`. The geometry function reruns on the next
@@ -528,17 +570,8 @@ Portal::Forma::bridge().at(el.state)
 ```cpp
 constexpr Kinesis::AABB2D track { glm::vec2(-0.8F, -0.08F), glm::vec2(0.8F, 0.08F) };
 
-auto el = Portal::Forma::create_element<float>(
-    surface,
-    Portal::Forma::Geometry::horizontal_fader(track, 0.04F),
-    0.5F,
-    Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP);
-
-surface.ctx().on_drag(el.element.id, IO::MouseButtons::Left,
-    [state = el.state, track](uint32_t, glm::vec2 ndc) {
-        state->write(std::clamp(
-            (ndc.x - track.min.x) / track.width(), 0.F, 1.F));
-    });
+auto el = Portal::Forma::create(
+    surface, Portal::Forma::Geometry::horizontal_fader(track, 0.04F), 0.5F);
 
 auto constant = vega.Constant(0.0) | Audio[0];
 Portal::Forma::bridge().at(el.state).write(constant);
@@ -546,33 +579,81 @@ Portal::Forma::bridge().at(el.state).write(constant);
 
 ---
 
+## Layout
+
+`Kinesis::place` computes a region positioned against an anchor.
+
+```cpp
+constexpr Kinesis::AABB2D fader { { -0.8F, -0.05F }, { 0.8F, 0.05F } };
+
+const auto label = Kinesis::place(fader, Kinesis::Side::Below, 0.F, 0.05F,
+    0.01F, Kinesis::Align::Span);
+
+const auto readout = Kinesis::place(fader, Kinesis::Side::Right, 0.2F, 0.1F, 0.02F);
+```
+
+`Side` is `Right`, `Left`, `Above`, `Below`, or `Over`. `Align` controls the
+cross axis: `Center`, `Start`, `End`, or `Span`, where `Span` matches the
+anchor's full cross-axis extent and ignores the corresponding size argument.
+
+The anchor may be any object exposing `bounds()`, so a placed element anchors
+the next one directly:
+
+```cpp
+auto fader = Portal::Forma::create(surface, Geometry::horizontal_fader(track, 0.04F), 0.5F);
+const auto below = Kinesis::place(fader, Kinesis::Side::Below, 0.F, 0.05F, 0.01F, Kinesis::Align::Span);
+```
+
+`LayoutCursor` advances a Y baseline and can be scoped to a column:
+
+```cpp
+Portal::Forma::LayoutCursor left  { 1.F, -0.95F, -0.05F };
+Portal::Forma::LayoutCursor right { 1.F,  0.05F,  0.95F };
+
+const auto a = left.advance(0.08F);
+const auto b = right.advance(0.08F);
+
+left.sync_to(right);   // both resume from the lower of the two baselines
+```
+
+`Surface` produces named screen regions without NDC arithmetic:
+
+```cpp
+const auto corner = surface.top_right(0.28F, 0.13F);
+const auto status = surface.bottom_strip(0.04F);
+const auto panel  = surface.top_left(0.35F, 0.8F);
+
+Portal::Forma::LayoutCursor cursor { panel.max.y, panel.min.x, panel.max.x };
+```
+
+`top_left`, `top_right`, `bottom_left`, `bottom_right`, `top_strip`,
+`bottom_strip`, `left_strip`, `right_strip`, `center_rect`, and `full`.
+
 ## Quick examples
 
 ### Mouse follower
 
+The Form carries hover-follow, so the point tracks the cursor with no callback registration.
+
 ```cpp
-auto el = Portal::Forma::create_element<glm::vec2>(
+auto el = Portal::Forma::create(
     surface,
     Portal::Forma::Geometry::point({ 0.2F, 0.8F, 1.0F }, 14.0F, 0.04F),
-    glm::vec2 { 0.F, 0.F },
-    Portal::Graphics::PrimitiveTopology::POINT_LIST);
-
-surface.ctx().on_move(el.element.id, [state = el.state](uint32_t, glm::vec2 ndc) {
-    state->write(ndc);
-});
+    glm::vec2 { 0.F, 0.F });
 ```
 
 ### Radial indicator
 
+The Form carries angular drag, so dragging anywhere sweeps the indicator to the cursor's angle.
+
 ```cpp
-auto el = Portal::Forma::create_element<float>(
+auto el = Portal::Forma::create(
     surface,
     Portal::Forma::Geometry::radial(
-        { 0.F, 0.F }, 0.3F,
+        Kinesis::AABB2D::from_ndc({ 0.F, 0.F }, glm::vec2(0.3F)),
         glm::radians(225.F), glm::radians(-45.F),
         { 1.F, 0.8F, 0.2F }),
-    0.5F,
-    Portal::Graphics::PrimitiveTopology::LINE_LIST);
+    0.5F);
 ```
 
 ### Horizontal fader
@@ -580,11 +661,8 @@ auto el = Portal::Forma::create_element<float>(
 ```cpp
 constexpr Kinesis::AABB2D track { glm::vec2(-0.6F, -0.05F), glm::vec2(0.6F, 0.05F) };
 
-auto el = Portal::Forma::create_element<float>(
-    surface,
-    Portal::Forma::Geometry::horizontal_fader(track, 0.04F),
-    0.5F,
-    Portal::Graphics::PrimitiveTopology::TRIANGLE_STRIP);
+auto el = Portal::Forma::create(
+    surface, Portal::Forma::Geometry::horizontal_fader(track, 0.04F), 0.5F);
 ```
 
 ### 2D position picker
@@ -592,18 +670,10 @@ auto el = Portal::Forma::create_element<float>(
 ```cpp
 constexpr Kinesis::AABB2D area { glm::vec2(-0.5F, -0.5F), glm::vec2(0.5F, 0.5F) };
 
-auto el = Portal::Forma::create_element<glm::vec2>(
+auto el = Portal::Forma::create(
     surface,
     Portal::Forma::Geometry::position_picker(area, { 0.9F, 0.4F, 0.1F }, 10.F),
-    glm::vec2 { 0.5F, 0.5F },
-    Portal::Graphics::PrimitiveTopology::POINT_LIST);
-
-surface.ctx().on_drag(el.element.id, IO::MouseButtons::Left,
-    [state = el.state, area](uint32_t, glm::vec2 ndc) {
-        state->write(glm::clamp(
-            (ndc - area.min) / glm::vec2(area.width(), area.height()),
-            glm::vec2(0.F), glm::vec2(1.F)));
-    });
+    glm::vec2 { 0.5F, 0.5F });
 ```
 
 ### Labeled interactive button

--- a/src/MayaFlux/Kinesis/Spatial/Bounds.hpp
+++ b/src/MayaFlux/Kinesis/Spatial/Bounds.hpp
@@ -490,4 +490,139 @@ subtract_bounds(
     };
 }
 
+/**
+ * @brief Direction of a placed region relative to its anchor.
+ *
+ * Over ignores the gap argument and centers the new region on the anchor.
+ */
+enum class Side : uint8_t {
+    Right,
+    Left,
+    Above,
+    Below,
+    Over,
+};
+
+/**
+ * @brief Cross-axis alignment of a placed region against its anchor.
+ *
+ * Start and End refer to the anchor's leading and trailing edge on the cross
+ * axis: min.x and max.x for vertical placement, max.y and min.y for
+ * horizontal placement, so Start is always the visually upper or leftward
+ * edge in NDC. Span matches the anchor's full cross-axis extent and ignores
+ * the corresponding size argument.
+ */
+enum class Align : uint8_t {
+    Center,
+    Start,
+    End,
+    Span,
+};
+
+/**
+ * @brief Compute a region of size (@p w, @p h) positioned relative to @p anchor.
+ *
+ * @param anchor Region to place against.
+ * @param side   Direction of placement.
+ * @param w      Width in NDC units. Ignored when @p side is vertical and
+ *               @p align is Span.
+ * @param h      Height in NDC units. Ignored when @p side is horizontal and
+ *               @p align is Span.
+ * @param gap    Separation from the anchor edge. Ignored for Side::Over.
+ * @param align  Cross-axis alignment.
+ */
+[[nodiscard]] inline AABB2D place(
+    AABB2D anchor, Side side, float w, float h,
+    float gap = 0.F, Align align = Align::Center) noexcept
+{
+    const glm::vec2 c = anchor.center();
+
+    if (side == Side::Over) {
+        return { .min = { c.x - w * 0.5F, c.y - h * 0.5F },
+            .max = { c.x + w * 0.5F, c.y + h * 0.5F } };
+    }
+
+    if (side == Side::Below || side == Side::Above) {
+        float x0 {};
+        float x1 {};
+        switch (align) {
+        case Align::Center:
+            x0 = c.x - w * 0.5F;
+            x1 = c.x + w * 0.5F;
+            break;
+        case Align::Start:
+            x0 = anchor.min.x;
+            x1 = anchor.min.x + w;
+            break;
+        case Align::End:
+            x0 = anchor.max.x - w;
+            x1 = anchor.max.x;
+            break;
+        case Align::Span:
+            x0 = anchor.min.x;
+            x1 = anchor.max.x;
+            break;
+        }
+        return side == Side::Below
+            ? AABB2D { .min = { x0, anchor.min.y - gap - h }, .max = { x1, anchor.min.y - gap } }
+            : AABB2D { .min = { x0, anchor.max.y + gap }, .max = { x1, anchor.max.y + gap + h } };
+    }
+
+    float y0 {};
+    float y1 {};
+    switch (align) {
+    case Align::Center:
+        y0 = c.y - h * 0.5F;
+        y1 = c.y + h * 0.5F;
+        break;
+    case Align::Start:
+        y0 = anchor.max.y - h;
+        y1 = anchor.max.y;
+        break;
+    case Align::End:
+        y0 = anchor.min.y;
+        y1 = anchor.min.y + h;
+        break;
+    case Align::Span:
+        y0 = anchor.min.y;
+        y1 = anchor.max.y;
+        break;
+    }
+    return side == Side::Right
+        ? AABB2D { .min = { anchor.max.x + gap, y0 }, .max = { anchor.max.x + gap + w, y1 } }
+        : AABB2D { .min = { anchor.min.x - gap - w, y0 }, .max = { anchor.min.x - gap, y1 } };
+}
+
+// =============================================================================
+// HasBounds
+// =============================================================================
+
+/**
+ * @brief Any type carrying a spatial footprint usable as a placement anchor.
+ *
+ * Satisfied by Portal::Forma::Mapped<T>, Collapsible, ValueGroup, and
+ * ValueRow. AABB2D itself does not satisfy it, so the overloads below never
+ * collide with the AABB2D-taking primaries.
+ */
+template <typename T>
+concept HasBounds = requires(const T& t) {
+    { t.bounds() } -> std::convertible_to<AABB2D>;
+};
+
+/// @brief Extract the anchor region from any HasBounds object.
+template <HasBounds T>
+[[nodiscard]] AABB2D bounds_of(const T& obj)
+{
+    return obj.bounds();
+}
+
+/// @brief place() accepting any HasBounds anchor.
+template <HasBounds A>
+[[nodiscard]] AABB2D place(
+    const A& anchor, Side side, float w, float h,
+    float gap = 0.F, Align align = Align::Center)
+{
+    return place(bounds_of(anchor), side, w, h, gap, align);
+}
+
 } // namespace MayaFlux::Kinesis

--- a/src/MayaFlux/Kinesis/Spatial/Projection.hpp
+++ b/src/MayaFlux/Kinesis/Spatial/Projection.hpp
@@ -1,0 +1,202 @@
+#pragma once
+
+#include "Bounds.hpp"
+
+namespace MayaFlux::Kinesis {
+
+/**
+ * @file Projection.hpp
+ * @brief NDC-to-value mappings, inverse to the forward placement performed by
+ *        geometry functions.
+ *
+ * Each function returns a callable suitable for direct use as the projection
+ * argument of Portal::Forma::Geometry::wire_drag. They are pure: no window,
+ * no context, no element. A projection paired with the geometry function that
+ * shares its parameters is what makes a control draggable.
+ */
+
+/**
+ * @brief Fraction along one axis of @p bounds, inverse to fader placement.
+ *
+ * horizontal_fader and vertical_fader place the handle's leading edge at
+ * @c min + value * (extent - handle_extent), so the handle centre travels a
+ * span shorter than the track by one handle. This subtracts half a handle
+ * before dividing by the reduced span, so the handle centre tracks the cursor
+ * across the whole range rather than lagging by up to half a handle at the
+ * extremes.
+ *
+ * Pass @p handle_extent of zero for mappings with no handle inset, such as a
+ * level_meter used as a scrub region.
+ *
+ * @param bounds        Track region in NDC.
+ * @param handle_extent Handle width for horizontal, height for vertical.
+ * @param horizontal    True to map the x axis, false for y.
+ * @return Callable producing a value in [0, 1].
+ */
+[[nodiscard]] inline std::function<float(glm::vec2)>
+axis_fraction(AABB2D bounds, float handle_extent = 0.F, bool horizontal = true) noexcept
+{
+    const float extent = horizontal ? bounds.width() : bounds.height();
+    const float span = extent - handle_extent;
+    const float origin = horizontal ? bounds.min.x : bounds.min.y;
+    const float half = handle_extent * 0.5F;
+
+    return [origin, half, span, horizontal](glm::vec2 p) -> float {
+        if (span <= 0.F)
+            return 0.F;
+        const float pos = horizontal ? p.x : p.y;
+        return std::clamp((pos - origin - half) / span, 0.F, 1.F);
+    };
+}
+
+/**
+ * @brief Unit-square coordinates of a point within @p bounds.
+ *
+ * Inverse to position_picker, which maps [0,1]² onto the region.
+ *
+ * @param bounds Region in NDC.
+ * @return Callable producing a value in [0, 1]².
+ */
+[[nodiscard]] inline std::function<glm::vec2(glm::vec2)>
+unit_square(AABB2D bounds) noexcept
+{
+    const glm::vec2 origin = bounds.min;
+    const glm::vec2 extent { bounds.width(), bounds.height() };
+
+    return [origin, extent](glm::vec2 p) -> glm::vec2 {
+        if (extent.x <= 0.F || extent.y <= 0.F)
+            return glm::vec2(0.F);
+        return glm::clamp((p - origin) / extent, glm::vec2(0.F), glm::vec2(1.F));
+    };
+}
+
+/**
+ * @brief Fraction along an angular sweep about @p center.
+ *
+ * Inverse to radial, which places the indicator at
+ * @c angle_start + value * (angle_end - angle_start). Handles sweeps in
+ * either direction and sweeps crossing the atan2 discontinuity. The cursor's
+ * distance from the centre is ignored, so the control remains responsive
+ * outside the drawn radius, which is what a knob gesture expects.
+ *
+ * Points at the exact centre return zero rather than an undefined angle.
+ *
+ * @param center      Sweep centre in NDC.
+ * @param angle_start Angle in radians corresponding to value 0.
+ * @param angle_end   Angle in radians corresponding to value 1.
+ * @return Callable producing a value in [0, 1].
+ */
+[[nodiscard]] inline std::function<float(glm::vec2)>
+angle_fraction(glm::vec2 center, float angle_start, float angle_end) noexcept
+{
+    const float delta = angle_end - angle_start;
+
+    return [center, angle_start, delta](glm::vec2 p) -> float {
+        constexpr float k_two_pi = 6.283185307179586F;
+
+        if (std::abs(delta) < 1e-6F)
+            return 0.F;
+
+        const glm::vec2 d = p - center;
+        if (glm::dot(d, d) < 1e-12F)
+            return 0.F;
+
+        float rel = std::fmod(std::atan2(d.y, d.x) - angle_start, k_two_pi);
+        if (delta > 0.F && rel < 0.F) {
+            rel += k_two_pi;
+        } else if (delta < 0.F && rel > 0.F) {
+            rel -= k_two_pi;
+        }
+
+        return std::clamp(rel / delta, 0.F, 1.F);
+    };
+}
+
+/**
+ * @brief angle_fraction centred on a region.
+ *
+ * Companion to the region-taking radial overload, which derives its centre
+ * from the region in the same way.
+ */
+[[nodiscard]] inline std::function<float(glm::vec2)>
+angle_fraction(AABB2D region, float angle_start, float angle_end) noexcept
+{
+    return angle_fraction(region.center(), angle_start, angle_end);
+}
+
+/**
+ * @brief Normalized arc-length position of the closest point on a polyline.
+ *
+ * Inverse to stroke_slider, which places the handle at a fraction of the
+ * path's total arc length. Finds the nearest point across all segments and
+ * returns its cumulative length divided by the total, so the handle follows
+ * the cursor along the path regardless of how far off the path it strays.
+ *
+ * Cumulative lengths are computed once and captured; the returned callable
+ * allocates nothing per invocation.
+ *
+ * @param points Ordered polyline vertices in NDC. Copied into the closure.
+ * @return Callable producing a value in [0, 1]. Returns 0 for paths with
+ *         fewer than two points or zero total length.
+ */
+[[nodiscard]] inline std::function<float(glm::vec2)>
+path_fraction(std::span<const glm::vec2> points)
+{
+    std::vector<glm::vec2> pts(points.begin(), points.end());
+    std::vector<float> cumulative(pts.size(), 0.F);
+
+    for (size_t i = 1; i < pts.size(); ++i)
+        cumulative[i] = cumulative[i - 1] + glm::length(pts[i] - pts[i - 1]);
+
+    const float total = pts.empty() ? 0.F : cumulative.back();
+
+    return [pts = std::move(pts), cumulative = std::move(cumulative), total](
+               glm::vec2 p) -> float {
+        if (pts.size() < 2 || total <= 0.F)
+            return 0.F;
+
+        float best_d2 = std::numeric_limits<float>::max();
+        float best_s = 0.F;
+
+        for (size_t i = 0; i + 1 < pts.size(); ++i) {
+            const glm::vec2 a = pts[i];
+            const glm::vec2 ab = pts[i + 1] - a;
+            const float len2 = glm::dot(ab, ab);
+
+            const float t = len2 > 1e-12F
+                ? glm::clamp(glm::dot(p - a, ab) / len2, 0.F, 1.F)
+                : 0.F;
+
+            const glm::vec2 diff = p - (a + t * ab);
+            const float d2 = glm::dot(diff, diff);
+
+            if (d2 < best_d2) {
+                best_d2 = d2;
+                best_s = cumulative[i] + t * std::sqrt(len2);
+            }
+        }
+
+        return std::clamp(best_s / total, 0.F, 1.F);
+    };
+}
+
+/**
+ * @brief Rescale a normalized projection onto an arbitrary range.
+ *
+ * Composes over any callable producing [0, 1], so a fader, knob, or stroke
+ * slider can drive a frequency, gain, or index without the call site
+ * repeating the remap.
+ *
+ * @param norm Projection producing a value in [0, 1].
+ * @param lo   Value corresponding to 0.
+ * @param hi   Value corresponding to 1.
+ */
+[[nodiscard]] inline std::function<float(glm::vec2)>
+scaled(std::function<float(glm::vec2)> norm, float lo, float hi)
+{
+    return [norm = std::move(norm), lo, hi](glm::vec2 p) -> float {
+        return lo + norm(p) * (hi - lo);
+    };
+}
+
+} // namespace MayaFlux::Kinesis

--- a/src/MayaFlux/MayaFlux.hpp
+++ b/src/MayaFlux/MayaFlux.hpp
@@ -147,7 +147,7 @@
 #include "Portal/Text/Text.hpp"
 
 #include "Portal/Forma/Forma.hpp"
-#include "Portal/Forma/Primitives/Geometry.hpp"
+#include "Portal/Forma/Primitives/FormFactory.hpp"
 
 #include "Portal/System/System.hpp"
 

--- a/src/MayaFlux/Portal/Forma/Context.cpp
+++ b/src/MayaFlux/Portal/Forma/Context.cpp
@@ -168,7 +168,21 @@ Context& Context::key_step(
     });
 
     return *this;
-} 
+}
+
+Context& Context::wire_drag(
+    uint32_t id,
+    std::function<void(glm::vec2)> sink,
+    IO::MouseButtons btn)
+{
+    if (!sink)
+        return *this;
+
+    on_drag(id, btn,
+        [sink = std::move(sink)](uint32_t, glm::vec2 ndc) { sink(ndc); });
+
+    return *this;
+}
 
 // =============================================================================
 // Handler registration / cancellation

--- a/src/MayaFlux/Portal/Forma/Context.hpp
+++ b/src/MayaFlux/Portal/Forma/Context.hpp
@@ -210,6 +210,23 @@ public:
         float clamp_min = 0.0F,
         float clamp_max = 1.0F);
 
+    /**
+     * @brief Register a drag handler receiving only the cursor position.
+     *
+     * Thin composition over on_drag for callers that already know the element
+     * id and have no use for it in the callback. The sink performs whatever
+     * mapping and write the gesture implies.
+     *
+     * @param id   Element id.
+     * @param sink Called with the current NDC cursor position on each drag event.
+     * @param btn  Mouse button that must be held.
+     * @return *this for chaining.
+     */
+    Context& wire_drag(
+        uint32_t id,
+        std::function<void(glm::vec2)> sink,
+        IO::MouseButtons btn = IO::MouseButtons::Left);
+
     // =========================================================================
     // State query
     // =========================================================================

--- a/src/MayaFlux/Portal/Forma/Forma.cpp
+++ b/src/MayaFlux/Portal/Forma/Forma.cpp
@@ -27,62 +27,6 @@ namespace {
     constexpr uint32_t k_inspect_w = 480;
     constexpr uint32_t k_inspect_h = 900;
 
-    constexpr size_t k_text_label_capacity = static_cast<size_t>(6) * sizeof(Kakshya::MeshVertex);
-    constexpr size_t k_rect_capacity = static_cast<size_t>(4) * sizeof(Kakshya::Vertex);
-
-    void place_plot_adornments(
-        Surface& surface,
-        const Plot::SeriesSpec& spec,
-        uint32_t relate_to)
-    {
-        const auto& win = surface.window();
-        auto& atelier = internal::atelier();
-
-        for (const auto& label : spec.labels) {
-            auto buf = atelier.create_buffer(
-                win,
-                k_text_label_capacity,
-                Graphics::PrimitiveTopology::TRIANGLE_LIST,
-                {},
-                { { "text", nullptr } });
-            (void)Plot::place_label(surface, std::move(buf), label, relate_to);
-        }
-
-        for (const auto& ticks : spec.tick_labels) {
-            for (const auto& label : Plot::plot_tick_labels(ticks)) {
-                auto buf = atelier.create_buffer(
-                    win,
-                    k_text_label_capacity,
-                    Graphics::PrimitiveTopology::TRIANGLE_LIST,
-                    {},
-                    { { "text", nullptr } });
-                (void)Plot::place_label(surface, std::move(buf), label, relate_to);
-            }
-        }
-
-        if (spec.legend) {
-            auto layout = Plot::layout_legend(*spec.legend);
-
-            for (const auto& swatch : layout.swatches) {
-                auto buf = atelier.create_buffer(
-                    win,
-                    k_rect_capacity,
-                    Graphics::PrimitiveTopology::TRIANGLE_STRIP);
-                (void)Plot::place_rect(surface, std::move(buf), swatch, relate_to);
-            }
-
-            for (const auto& label : layout.labels) {
-                auto buf = atelier.create_buffer(
-                    win,
-                    k_text_label_capacity,
-                    Graphics::PrimitiveTopology::TRIANGLE_LIST,
-                    {},
-                    { { "text", nullptr } });
-                (void)Plot::place_label(surface, std::move(buf), label, relate_to);
-            }
-        }
-    }
-
 } // namespace
 
 // =============================================================================
@@ -192,7 +136,7 @@ plot(
         surface.layer().relate(mapped.element.id, bg_id);
         surface.layer().send_to_back(bg_id);
 
-        place_plot_adornments(surface, spec, mapped.element.id);
+        internal::atelier().place_adornments(surface, spec, mapped.element.id);
 
         return { std::move(mapped), std::move(surface) };
     }
@@ -200,7 +144,7 @@ plot(
     auto buf = atelier.create_buffer(window, spec.capacity_for(N), spec.topology);
     auto mapped = Plot::place(surface, std::move(buf), spec, std::move(container));
 
-    place_plot_adornments(surface, spec, mapped.element.id);
+    internal::atelier().place_adornments(surface, spec, mapped.element.id);
 
     return { std::move(mapped), std::move(surface) };
 }

--- a/src/MayaFlux/Portal/Forma/Forma.cpp
+++ b/src/MayaFlux/Portal/Forma/Forma.cpp
@@ -18,14 +18,6 @@
 namespace MayaFlux::Portal::Forma {
 
 namespace {
-    bool g_initialized {};
-    std::shared_ptr<Nodes::NodeGraphManager> g_node_graph_manager;
-    std::shared_ptr<Buffers::BufferManager> g_buffer_manager;
-    std::shared_ptr<Vruta::TaskScheduler> g_scheduler;
-    std::shared_ptr<Vruta::EventManager> g_event_manager;
-    std::shared_ptr<Core::WindowManager> g_window_manager;
-    std::unique_ptr<Bridge> g_bridge;
-    std::unique_ptr<Inspector> g_inspect;
 
     std::shared_ptr<Core::Window> g_inspect_nodes_window;
     std::shared_ptr<Core::Window> g_inspect_buffers_window;
@@ -44,27 +36,26 @@ namespace {
         uint32_t relate_to)
     {
         const auto& win = surface.window();
+        auto& atelier = internal::atelier();
 
         for (const auto& label : spec.labels) {
-            auto buf = internal::create_buffer_impl(
+            auto buf = atelier.create_buffer(
                 win,
                 k_text_label_capacity,
                 Graphics::PrimitiveTopology::TRIANGLE_LIST,
                 {},
                 { { "text", nullptr } });
-
             (void)Plot::place_label(surface, std::move(buf), label, relate_to);
         }
 
         for (const auto& ticks : spec.tick_labels) {
             for (const auto& label : Plot::plot_tick_labels(ticks)) {
-                auto buf = internal::create_buffer_impl(
+                auto buf = atelier.create_buffer(
                     win,
                     k_text_label_capacity,
                     Graphics::PrimitiveTopology::TRIANGLE_LIST,
                     {},
                     { { "text", nullptr } });
-
                 (void)Plot::place_label(surface, std::move(buf), label, relate_to);
             }
         }
@@ -73,57 +64,26 @@ namespace {
             auto layout = Plot::layout_legend(*spec.legend);
 
             for (const auto& swatch : layout.swatches) {
-                auto buf = internal::create_buffer_impl(
+                auto buf = atelier.create_buffer(
                     win,
                     k_rect_capacity,
                     Graphics::PrimitiveTopology::TRIANGLE_STRIP);
-
                 (void)Plot::place_rect(surface, std::move(buf), swatch, relate_to);
             }
 
             for (const auto& label : layout.labels) {
-                auto buf = internal::create_buffer_impl(
+                auto buf = atelier.create_buffer(
                     win,
                     k_text_label_capacity,
                     Graphics::PrimitiveTopology::TRIANGLE_LIST,
                     {},
                     { { "text", nullptr } });
-
                 (void)Plot::place_label(surface, std::move(buf), label, relate_to);
             }
         }
     }
 
 } // namespace
-
-namespace internal {
-
-    std::shared_ptr<Buffers::FormaBuffer> create_buffer_impl(
-        std::shared_ptr<Core::Window> window,
-        size_t capacity,
-        Graphics::PrimitiveTopology topology,
-        const std::string& texture_binding,
-        std::vector<std::pair<std::string, std::shared_ptr<Core::VKImage>>> additional_textures)
-    {
-        auto buf = std::make_shared<Buffers::FormaBuffer>(capacity, topology);
-        g_buffer_manager->add_buffer(buf, Buffers::ProcessingToken::GRAPHICS_BACKEND);
-
-        if (!additional_textures.empty()) {
-            buf->setup_rendering({
-                .target_window = std::move(window),
-                .additional_textures = std::move(additional_textures),
-            });
-        } else if (!texture_binding.empty()) {
-            buf->setup_rendering({
-                .target_window = std::move(window),
-                .default_texture_binding = texture_binding,
-            });
-        } else {
-            buf->setup_rendering({ .target_window = std::move(window) });
-        }
-        return buf;
-    }
-} // namespace internal
 
 // =============================================================================
 // Lifecycle
@@ -136,79 +96,40 @@ bool initialize(
     std::shared_ptr<Vruta::EventManager> event_manager,
     std::shared_ptr<Core::WindowManager> window_manager)
 {
-    if (g_initialized) {
-        MF_WARN(Journal::Component::Portal, Journal::Context::API,
-            "Portal::Forma already initialized");
-        return true;
-    }
-
-    g_node_graph_manager = std::move(node_graph_manager);
-    g_buffer_manager = std::move(buffer_manager);
-    g_scheduler = std::move(scheduler);
-    g_event_manager = std::move(event_manager);
-    g_window_manager = std::move(window_manager);
-    g_bridge = std::make_unique<Bridge>(*g_scheduler, *g_buffer_manager);
-    g_inspect = std::make_unique<Inspector>(*g_node_graph_manager, *g_buffer_manager, *g_scheduler, *g_event_manager);
-    g_initialized = true;
-
-    MF_INFO(Journal::Component::Portal, Journal::Context::API,
-        "Portal::Forma initialized");
-    return true;
-}
-
-Inspector& inspector()
-{
-    if (!g_initialized) {
-        error<std::runtime_error>(Journal::Component::Portal, Journal::Context::API, std::source_location::current(),
-            "Portal::Forma not initialized - cannot get inspector");
-    }
-    return *g_inspect;
+    return internal::atelier().initialize(
+        std::move(node_graph_manager), std::move(buffer_manager),
+        std::move(scheduler), std::move(event_manager), std::move(window_manager));
 }
 
 void shutdown()
 {
-    if (!g_initialized) {
-        return;
-    }
-
-    g_bridge.reset();
-    g_inspect.reset();
-    g_node_graph_manager = nullptr;
-    g_buffer_manager = nullptr;
-    g_scheduler = nullptr;
-    g_event_manager = nullptr;
-    g_window_manager = nullptr;
-    g_initialized = false;
+    internal::atelier().shutdown();
 
     g_inspect_nodes_window.reset();
     g_inspect_buffers_window.reset();
     g_inspect_scheduler_window.reset();
     g_inspect_events_window.reset();
-
-    MF_INFO(Journal::Component::Portal, Journal::Context::API,
-        "Portal::Forma shutdown");
 }
 
-bool is_initialized()
-{
-    return g_initialized;
-}
+bool is_initialized() { return internal::atelier().is_initialized(); }
+
+Bridge& bridge() { return internal::atelier().bridge(); }
+
+Inspector& inspector() { return internal::atelier().inspector(); }
 
 // =============================================================================
 // Layer
 // =============================================================================
 
 std::pair<std::shared_ptr<Layer>, std::shared_ptr<Context>>
-create_layer(
-    const std::shared_ptr<Core::Window>& window,
-    std::string name)
+create_layer(const std::shared_ptr<Core::Window>& window, std::string name)
 {
-    auto layer = std::make_shared<Layer>();
-    auto ctx = std::make_shared<Context>(layer, window, *g_event_manager, std::move(name));
+    return internal::atelier().create_layer(window, std::move(name));
+}
 
-    MayaFlux::store(ctx);
-
-    return { std::move(layer), std::move(ctx) };
+Surface create_surface(std::shared_ptr<Core::Window> window, std::string name)
+{
+    return internal::atelier().create_surface(std::move(window), std::move(name));
 }
 
 // =============================================================================
@@ -220,7 +141,8 @@ std::shared_ptr<Buffers::FormaBuffer> create_buffer(
     Graphics::PrimitiveTopology topology,
     const std::string& texture_binding)
 {
-    return internal::create_buffer_impl(std::move(window), internal::k_capacity_bytes, topology, texture_binding);
+    return internal::atelier().create_buffer(
+        std::move(window), internal::k_capacity_bytes, topology, texture_binding);
 }
 
 std::shared_ptr<Buffers::FormaBuffer> create_buffer(
@@ -228,15 +150,9 @@ std::shared_ptr<Buffers::FormaBuffer> create_buffer(
     Graphics::PrimitiveTopology topology,
     std::vector<std::pair<std::string, std::shared_ptr<Core::VKImage>>> additional_textures)
 {
-    return internal::create_buffer_impl(std::move(window), internal::k_capacity_bytes, topology, {}, std::move(additional_textures));
-}
-
-Surface create_surface(
-    std::shared_ptr<Core::Window> window,
-    std::string name)
-{
-    auto [layer, ctx] = create_layer(window, std::move(name));
-    return { std::move(window), std::move(layer), std::move(ctx) };
+    return internal::atelier().create_buffer(
+        std::move(window), internal::k_capacity_bytes, topology, {},
+        std::move(additional_textures));
 }
 
 // =============================================================================
@@ -255,14 +171,15 @@ plot(
         ? container->series_size(0)
         : 0;
 
-    auto window = g_window_manager->create_window(
-        Core::WindowCreateInfo { .title = std::move(title), .width = width, .height = height });
-    window->show();
+    auto& atelier = internal::atelier();
 
-    auto surface = create_surface(window, window->get_create_info().title);
+    auto window = atelier.create_window(
+        Core::WindowCreateInfo { .title = std::move(title), .width = width, .height = height });
+
+    auto surface = atelier.create_surface(window, window->get_create_info().title);
 
     if (spec.background_fn) {
-        auto bg = create_element<float>(
+        auto bg = atelier.create_element<float>(
             surface.layer(), window,
             *spec.background_fn,
             0.F,
@@ -270,7 +187,7 @@ plot(
             static_cast<size_t>(4) * Kakshya::VertexLayout::for_meshes().stride_bytes);
 
         const auto bg_id = bg.element.id;
-        auto buf = internal::create_buffer_impl(window, spec.capacity_for(N), spec.topology);
+        auto buf = atelier.create_buffer(window, spec.capacity_for(N), spec.topology);
         auto mapped = Plot::place(surface, std::move(buf), spec, std::move(container));
         surface.layer().relate(mapped.element.id, bg_id);
         surface.layer().send_to_back(bg_id);
@@ -280,7 +197,7 @@ plot(
         return { std::move(mapped), std::move(surface) };
     }
 
-    auto buf = internal::create_buffer_impl(window, spec.capacity_for(N), spec.topology);
+    auto buf = atelier.create_buffer(window, spec.capacity_for(N), spec.topology);
     auto mapped = Plot::place(surface, std::move(buf), spec, std::move(container));
 
     place_plot_adornments(surface, spec, mapped.element.id);
@@ -292,24 +209,22 @@ plot(
 // Bridge
 // =============================================================================
 
-Bridge& bridge()
-{
-    return *g_bridge;
-}
-
 void inspect_node_graph()
 {
     if (g_inspect_nodes_window) {
         g_inspect_nodes_window->show();
         return;
     }
-    g_inspect_nodes_window = g_window_manager->create_window(
+
+    auto& atelier = internal::atelier();
+
+    g_inspect_nodes_window = atelier.create_window(
         Core::WindowCreateInfo { .title = "NodeGraphManager", .width = k_inspect_w, .height = k_inspect_h });
-    g_inspect_nodes_window->show();
-    auto surface = create_surface(g_inspect_nodes_window, "NodeGraphManager");
+
+    auto surface = atelier.create_surface(g_inspect_nodes_window, "NodeGraphManager");
     LayoutCursor cursor;
-    auto& result = g_inspect->node_graph_manager(surface, cursor);
-    g_bridge->spawn_sync(result.group.header.header_id, [&result] { result.tap_all(); });
+    auto& result = atelier.inspector().node_graph_manager(surface, cursor);
+    atelier.bridge().spawn_sync(result.group.header.header_id, [&result] { result.tap_all(); });
 }
 
 void inspect_buffers()
@@ -318,13 +233,16 @@ void inspect_buffers()
         g_inspect_buffers_window->show();
         return;
     }
-    g_inspect_buffers_window = g_window_manager->create_window(
+
+    auto& atelier = internal::atelier();
+
+    g_inspect_buffers_window = atelier.create_window(
         Core::WindowCreateInfo { .title = "BufferManager", .width = k_inspect_w, .height = k_inspect_h });
-    g_inspect_buffers_window->show();
-    auto surface = create_surface(g_inspect_buffers_window, "BufferManager");
+
+    auto surface = atelier.create_surface(g_inspect_buffers_window, "BufferManager");
     LayoutCursor cursor;
-    auto& result = g_inspect->buffer_manager(surface, cursor);
-    g_bridge->spawn_sync(result.group.header.header_id, [&result] { result.tap_all(); });
+    auto& result = atelier.inspector().buffer_manager(surface, cursor);
+    atelier.bridge().spawn_sync(result.group.header.header_id, [&result] { result.tap_all(); });
 }
 
 void inspect_scheduler()
@@ -333,13 +251,16 @@ void inspect_scheduler()
         g_inspect_scheduler_window->show();
         return;
     }
-    g_inspect_scheduler_window = g_window_manager->create_window(
+
+    auto& atelier = internal::atelier();
+
+    g_inspect_scheduler_window = atelier.create_window(
         Core::WindowCreateInfo { .title = "TaskScheduler", .width = k_inspect_w, .height = k_inspect_h });
-    g_inspect_scheduler_window->show();
-    auto surface = create_surface(g_inspect_scheduler_window, "TaskScheduler");
+
+    auto surface = atelier.create_surface(g_inspect_scheduler_window, "TaskScheduler");
     LayoutCursor cursor;
-    auto& result = g_inspect->scheduler(surface, cursor);
-    g_bridge->spawn_sync(result.group.header.header_id, [&result] { result.tap_all(); });
+    auto& result = atelier.inspector().scheduler(surface, cursor);
+    atelier.bridge().spawn_sync(result.group.header.header_id, [&result] { result.tap_all(); });
 }
 
 void inspect_events()
@@ -348,60 +269,71 @@ void inspect_events()
         g_inspect_events_window->show();
         return;
     }
-    g_inspect_events_window = g_window_manager->create_window(
+
+    auto& atelier = internal::atelier();
+
+    g_inspect_events_window = atelier.create_window(
         Core::WindowCreateInfo { .title = "EventManager", .width = k_inspect_w, .height = k_inspect_h });
-    g_inspect_events_window->show();
-    auto surface = create_surface(g_inspect_events_window, "EventManager");
+
+    auto surface = atelier.create_surface(g_inspect_events_window, "EventManager");
     LayoutCursor cursor;
-    auto& result = g_inspect->event_manager(surface, cursor);
-    g_bridge->spawn_sync(result.group.header.header_id, [&result] { result.tap_all(); });
+    auto& result = atelier.inspector().event_manager(surface, cursor);
+    atelier.bridge().spawn_sync(result.group.header.header_id, [&result] { result.tap_all(); });
 }
 
 void inspect(const std::shared_ptr<Nodes::Node>& node)
 {
+    auto& atelier = internal::atelier();
     const std::string title = Reflect::short_dynamic_type_name(node);
-    auto window = g_window_manager->create_window(
+
+    auto window = atelier.create_window(
         Core::WindowCreateInfo { .title = title, .width = k_inspect_w, .height = k_inspect_h });
-    window->show();
-    auto surface = create_surface(window, title);
+
+    auto surface = atelier.create_surface(window, title);
     LayoutCursor cursor;
-    auto result = std::make_shared<InspectResult>(g_inspect->node(node, surface, cursor));
-    g_bridge->spawn_sync(result->group.header.header_id, [result] { result->tap_all(); });
+    auto result = std::make_shared<InspectResult>(atelier.inspector().node(node, surface, cursor));
+    atelier.bridge().spawn_sync(result->group.header.header_id, [result] { result->tap_all(); });
 }
 
 void inspect(const std::shared_ptr<Buffers::Buffer>& buf)
 {
+    auto& atelier = internal::atelier();
     const std::string title = Reflect::short_dynamic_type_name(buf);
-    auto window = g_window_manager->create_window(
+
+    auto window = atelier.create_window(
         Core::WindowCreateInfo { .title = title, .width = k_inspect_w, .height = k_inspect_h });
-    window->show();
-    auto surface = create_surface(window, title);
+
+    auto surface = atelier.create_surface(window, title);
     LayoutCursor cursor;
-    auto result = std::make_shared<InspectResult>(g_inspect->buffer(buf, surface, cursor));
-    g_bridge->spawn_sync(result->group.header.header_id, [result] { result->tap_all(); });
+    auto result = std::make_shared<InspectResult>(atelier.inspector().buffer(buf, surface, cursor));
+    atelier.bridge().spawn_sync(result->group.header.header_id, [result] { result->tap_all(); });
 }
 
 void inspect(const std::shared_ptr<Nodes::Network::NodeNetwork>& net)
 {
-    auto window = g_window_manager->create_window(
+    auto& atelier = internal::atelier();
+
+    auto window = atelier.create_window(
         Core::WindowCreateInfo { .title = "NodeNetwork", .width = k_inspect_w, .height = k_inspect_h });
-    window->show();
-    auto surface = create_surface(window, "NodeNetwork");
+
+    auto surface = atelier.create_surface(window, "NodeNetwork");
     LayoutCursor cursor;
-    auto result = std::make_shared<InspectResult>(g_inspect->node_network(net, surface, cursor));
-    g_bridge->spawn_sync(result->group.header.header_id, [result] { result->tap_all(); });
+    auto result = std::make_shared<InspectResult>(atelier.inspector().node_network(net, surface, cursor));
+    atelier.bridge().spawn_sync(result->group.header.header_id, [result] { result->tap_all(); });
 }
 
 void inspect(const std::shared_ptr<Vruta::Event>& ev, std::string_view name)
 {
+    auto& atelier = internal::atelier();
     const std::string title = name.empty() ? "Event" : "Event: " + std::string(name);
-    auto window = g_window_manager->create_window(
+
+    auto window = atelier.create_window(
         Core::WindowCreateInfo { .title = title, .width = k_inspect_w, .height = k_inspect_h });
-    window->show();
-    auto surface = create_surface(window, title);
+
+    auto surface = atelier.create_surface(window, title);
     LayoutCursor cursor;
-    auto result = std::make_shared<InspectResult>(g_inspect->event(ev, name, surface, cursor));
-    g_bridge->spawn_sync(result->group.header.header_id, [result] { result->tap_all(); });
+    auto result = std::make_shared<InspectResult>(atelier.inspector().event(ev, name, surface, cursor));
+    atelier.bridge().spawn_sync(result->group.header.header_id, [result] { result->tap_all(); });
 }
 
 } // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Forma.hpp
+++ b/src/MayaFlux/Portal/Forma/Forma.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Internal/Atelier.hpp"
+#include "Primitives/Geometry.hpp"
 
 namespace MayaFlux::Vruta {
 class Event;
@@ -253,6 +254,47 @@ template <typename T>
     return internal::atelier().create_element<T>(
         layer, std::move(window), std::move(geom), std::move(initial),
         topology, capacity, std::move(project));
+}
+
+/**
+ * @brief Realize a Form on @p surface.
+ *
+ * Builds the buffer at the Form's capacity and topology, registers the
+ * element, syncs so the geometry function's bounds_hint and contains reach
+ * the Layer before the first frame, then runs the Form's interaction wiring.
+ *
+ * A bare GeometryFn converts to a Form, so this also serves as the simplest
+ * element construction path for a caller's own geometry.
+ *
+ * @tparam T       MappedState value type.
+ * @param surface  Canvas to register on.
+ * @param form     Geometry, topology, capacity, and interaction.
+ * @param initial  Starting value written into MappedState.
+ * @param project  Optional T to float projection for outbound readers.
+ * @return Fully constructed Mapped<T>, wired.
+ */
+template <typename T>
+[[nodiscard]] Mapped<T> create(
+    Surface& surface,
+    Geometry::Form<T> form,
+    T initial,
+    std::function<float(T)> project = {})
+{
+    auto mapped = internal::atelier().create_element<T>(
+        surface.layer(), surface.window(),
+        std::move(form.geometry), std::move(initial),
+        form.topology, form.capacity, std::move(project));
+
+    mapped.sync();
+    if (mapped.element.bounds_hint)
+        surface.layer().set_bounds(mapped.element.id, *mapped.element.bounds_hint);
+    if (mapped.element.contains)
+        surface.layer().set_contains(mapped.element.id, mapped.element.contains);
+
+    if (form.wire)
+        form.wire(surface.ctx(), mapped.element.id, mapped.state);
+
+    return mapped;
 }
 
 /**

--- a/src/MayaFlux/Portal/Forma/Forma.hpp
+++ b/src/MayaFlux/Portal/Forma/Forma.hpp
@@ -1,55 +1,14 @@
 #pragma once
 
-#include "Bridge.hpp"
 #include "Plot/Plot.hpp"
-#include "Surface.hpp"
 
-namespace MayaFlux::Nodes {
-class NodeGraphManager;
-}
-
-namespace MayaFlux::Core {
-class Window;
-class WindowManager;
-struct WindowCreateInfo;
-}
+#include "Internal/Atelier.hpp"
 
 namespace MayaFlux::Vruta {
-class TaskScheduler;
-class EventManager;
 class Event;
 }
 
-namespace MayaFlux::Buffers {
-class BufferManager;
-}
-
 namespace MayaFlux::Portal::Forma {
-
-class Inspector;
-
-// =============================================================================
-// Internal
-// =============================================================================
-
-namespace internal {
-
-    /**
-     * @brief Core buffer construction — capacity-explicit path for internal use.
-     *
-     * Called by public create_buffer overloads and by internal .cpp callers
-     * (plot, Collapsible) that know their capacity upfront.
-     */
-    [[nodiscard]] MAYAFLUX_API std::shared_ptr<Buffers::FormaBuffer> create_buffer_impl(
-        std::shared_ptr<Core::Window> window,
-        size_t capacity,
-        Graphics::PrimitiveTopology topology,
-        const std::string& texture_binding = {},
-        std::vector<std::pair<std::string, std::shared_ptr<Core::VKImage>>> additional_textures = {});
-
-    constexpr size_t k_capacity_bytes = 4096;
-
-} // namespace internal
 
 /**
  * @file Forma.hpp
@@ -220,7 +179,7 @@ template <typename V>
 {
     using Vertex = std::ranges::range_value_t<V>;
     const size_t cap = std::ranges::size(vertices) * sizeof(Vertex);
-    auto buf = internal::create_buffer_impl(std::move(window), cap, topology);
+    auto buf = internal::atelier().create_buffer(std::move(window), cap, topology);
     buf->submit(vertices);
     return buf;
 }
@@ -233,7 +192,7 @@ template <typename V>
     const V& vertex,
     Graphics::PrimitiveTopology topology = Graphics::PrimitiveTopology::TRIANGLE_STRIP)
 {
-    auto buf = internal::create_buffer_impl(std::move(window), sizeof(V), topology);
+    auto buf = internal::atelier().create_buffer(std::move(window), sizeof(V), topology);
     buf->submit(vertex);
     return buf;
 }
@@ -293,11 +252,9 @@ template <typename T>
     size_t capacity = internal::k_capacity_bytes,
     std::function<float(T)> project = {})
 {
-    auto buf = create_buffer(std::move(window), capacity, topology);
-    auto mapped = make_mapped<T>(initial, std::move(geom), buf);
-    mapped.element.id = layer.add(mapped.element);
-    bridge().register_element(mapped, std::move(project));
-    return mapped;
+    return internal::atelier().create_element<T>(
+        layer, std::move(window), std::move(geom), std::move(initial),
+        topology, capacity, std::move(project));
 }
 
 /**
@@ -337,18 +294,8 @@ template <typename T>
     Graphics::PrimitiveTopology topology = Graphics::PrimitiveTopology::TRIANGLE_STRIP,
     std::function<float(T)> project = {})
 {
-    auto mapped = create_element<T>(
-        surface.layer(), surface.window(),
-        std::move(geom), std::move(initial),
-        topology, internal::k_capacity_bytes, std::move(project));
-
-    mapped.sync();
-    if (mapped.element.bounds_hint)
-        surface.layer().set_bounds(mapped.element.id, *mapped.element.bounds_hint);
-    if (mapped.element.contains)
-        surface.layer().set_contains(mapped.element.id, mapped.element.contains);
-
-    return mapped;
+    return internal::atelier().create_element<T>(
+        surface, std::move(geom), std::move(initial), topology, std::move(project));
 }
 
 /**

--- a/src/MayaFlux/Portal/Forma/Forma.hpp
+++ b/src/MayaFlux/Portal/Forma/Forma.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "Plot/Plot.hpp"
-
 #include "Internal/Atelier.hpp"
 
 namespace MayaFlux::Vruta {

--- a/src/MayaFlux/Portal/Forma/Inspect/QueryUtils.cpp
+++ b/src/MayaFlux/Portal/Forma/Inspect/QueryUtils.cpp
@@ -131,6 +131,18 @@ ValueRow make_value_row(
     };
 }
 
+ValueRow make_value_row(
+    const ValueSpec& spec,
+    RowBuffer row_buf,
+    Surface& surface,
+    LayoutCursor& cursor,
+    float row_h,
+    glm::vec3 bg)
+{
+    return make_value_row(spec, std::move(row_buf), surface, cursor,
+        cursor.x_min(), cursor.x_max(), row_h, bg);
+}
+
 ValueGroup make_value_group(
     std::span<const ValueSpec> values,
     RowBuffer header_buf,
@@ -161,6 +173,19 @@ ValueGroup make_value_group(
         .header = std::move(header),
         .rows = std::move(rows),
     };
+}
+
+ValueGroup make_value_group(
+    std::span<const ValueSpec> values,
+    RowBuffer header_buf,
+    std::span<const RowBuffer> row_bufs,
+    Surface& surface,
+    LayoutCursor& cursor,
+    float row_h,
+    bool initially_open)
+{
+    return make_value_group(values, std::move(header_buf), row_bufs,
+        surface, cursor, cursor.x_min(), cursor.x_max(), row_h, initially_open);
 }
 
 } // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Inspect/QueryUtils.cpp
+++ b/src/MayaFlux/Portal/Forma/Inspect/QueryUtils.cpp
@@ -84,6 +84,7 @@ ValueRow make_value_row(
     const float top = cursor.y();
     const float bot = top - row_h;
     cursor.advance(row_h);
+    const Kinesis::AABB2D row_rect { .min = { x_min, bot }, .max = { x_max, top } };
 
     const uint32_t stride = Kakshya::VertexLayout::for_meshes().stride_bytes;
     std::vector<uint8_t> bytes(static_cast<size_t>(12) * stride, 0);
@@ -99,7 +100,7 @@ ValueRow make_value_row(
 
     Element el;
     el.buffer = row_buf.buf;
-    el.bounds_hint = Kinesis::AABB2D { .min = { x_min, bot }, .max = { x_max, top } };
+    el.bounds_hint = row_rect;
     el.interactive = false;
     el.name = spec.label;
     const uint32_t id = surface.layer().add(el);
@@ -126,6 +127,7 @@ ValueRow make_value_row(
         .buf = std::move(row_buf.buf),
         .text = std::move(row_buf.text_image),
         .link = std::move(link),
+        .row_bounds = row_rect,
     };
 }
 

--- a/src/MayaFlux/Portal/Forma/Inspect/QueryUtils.hpp
+++ b/src/MayaFlux/Portal/Forma/Inspect/QueryUtils.hpp
@@ -122,6 +122,20 @@ struct ValueGroup {
     glm::vec3 bg = glm::vec3(0.15F));
 
 /**
+ * @brief make_value_row using the cursor's column extents.
+ *
+ * Equivalent to the explicit-extent overload with x_min and x_max taken
+ * from @p cursor.
+ */
+[[nodiscard]] ValueRow make_value_row(
+    const ValueSpec& spec,
+    RowBuffer row_buf,
+    Surface& surface,
+    LayoutCursor& cursor,
+    float row_h,
+    glm::vec3 bg = glm::vec3(0.15F));
+
+/**
  * @brief Construct a collapsible header followed by N value rows under it.
  *
  * The header and all row buffers are pre-created by the caller. Once
@@ -145,6 +159,21 @@ struct ValueGroup {
     Surface& surface,
     LayoutCursor& cursor,
     float x_min, float x_max, float row_h,
+    bool initially_open = false);
+
+/**
+ * @brief make_value_group using the cursor's column extents.
+ *
+ * Equivalent to the explicit-extent overload with x_min and x_max taken
+ * from @p cursor.
+ */
+[[nodiscard]] ValueGroup make_value_group(
+    std::span<const ValueSpec> values,
+    RowBuffer header_buf,
+    std::span<const RowBuffer> row_bufs,
+    Surface& surface,
+    LayoutCursor& cursor,
+    float row_h,
     bool initially_open = false);
 
 } // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Inspect/QueryUtils.hpp
+++ b/src/MayaFlux/Portal/Forma/Inspect/QueryUtils.hpp
@@ -46,6 +46,12 @@ struct ValueRow {
     std::shared_ptr<Buffers::FormaBuffer> buf;
     std::shared_ptr<Core::VKImage> text;
     Link link;
+
+    /// @brief NDC region occupied by this row. Valid after make_value_row.
+    Kinesis::AABB2D row_bounds {};
+
+    /// @brief Row region, satisfying Kinesis::HasBounds.
+    [[nodiscard]] Kinesis::AABB2D bounds() const noexcept { return row_bounds; }
 };
 
 /**
@@ -57,6 +63,22 @@ struct ValueRow {
 struct ValueGroup {
     Collapsible header;
     std::vector<ValueRow> rows;
+
+    /**
+     * @brief Union of the header strip and every row region.
+     *
+     * Collapses to the header region alone when the group has no rows.
+     */
+    [[nodiscard]] Kinesis::AABB2D bounds() const noexcept
+    {
+        Kinesis::AABB2D b = header.bounds();
+        for (const auto& r : rows) {
+            const auto rb = r.bounds();
+            b.min = glm::min(b.min, rb.min);
+            b.max = glm::max(b.max, rb.max);
+        }
+        return b;
+    }
 };
 
 /**

--- a/src/MayaFlux/Portal/Forma/Internal/Atelier.cpp
+++ b/src/MayaFlux/Portal/Forma/Internal/Atelier.cpp
@@ -1,0 +1,147 @@
+#include "Atelier.hpp"
+
+#include "MayaFlux/Portal/Forma/Inspect/Inspector.hpp"
+
+#include "MayaFlux/Buffers/BufferManager.hpp"
+#include "MayaFlux/Core/Windowing/WindowManager.hpp"
+#include "MayaFlux/Journal/Archivist.hpp"
+#include "MayaFlux/Nodes/NodeGraphManager.hpp"
+#include "MayaFlux/Transitive/Memory/Persist.hpp"
+#include "MayaFlux/Vruta/EventManager.hpp"
+#include "MayaFlux/Vruta/Scheduler.hpp"
+
+namespace MayaFlux::Portal::Forma::internal {
+
+// =============================================================================
+// Lifecycle
+// =============================================================================
+
+Atelier::Atelier() = default;
+Atelier::~Atelier() = default;
+
+bool Atelier::initialize(
+    std::shared_ptr<Nodes::NodeGraphManager> node_graph_manager,
+    std::shared_ptr<Buffers::BufferManager> buffer_manager,
+    std::shared_ptr<Vruta::TaskScheduler> scheduler,
+    std::shared_ptr<Vruta::EventManager> event_manager,
+    std::shared_ptr<Core::WindowManager> window_manager)
+{
+    if (m_initialized) {
+        MF_WARN(Journal::Component::Portal, Journal::Context::API,
+            "Portal::Forma already initialized");
+        return true;
+    }
+
+    m_node_graph_manager = std::move(node_graph_manager);
+    m_buffer_manager = std::move(buffer_manager);
+    m_scheduler = std::move(scheduler);
+    m_event_manager = std::move(event_manager);
+    m_window_manager = std::move(window_manager);
+
+    m_bridge = std::make_unique<Bridge>(*m_scheduler, *m_buffer_manager);
+    m_inspect = std::make_unique<Inspector>(
+        *m_node_graph_manager, *m_buffer_manager, *m_scheduler, *m_event_manager);
+
+    m_initialized = true;
+
+    MF_INFO(Journal::Component::Portal, Journal::Context::API,
+        "Portal::Forma initialized");
+    return true;
+}
+
+void Atelier::shutdown()
+{
+    if (!m_initialized)
+        return;
+
+    m_bridge.reset();
+    m_inspect.reset();
+
+    m_node_graph_manager = nullptr;
+    m_buffer_manager = nullptr;
+    m_scheduler = nullptr;
+    m_event_manager = nullptr;
+    m_window_manager = nullptr;
+
+    m_initialized = false;
+
+    MF_INFO(Journal::Component::Portal, Journal::Context::API,
+        "Portal::Forma shutdown");
+}
+
+Bridge& Atelier::bridge()
+{
+    if (!m_initialized) {
+        error<std::runtime_error>(Journal::Component::Portal, Journal::Context::API,
+            std::source_location::current(),
+            "Portal::Forma not initialized - cannot get bridge");
+    }
+    return *m_bridge;
+}
+
+Inspector& Atelier::inspector()
+{
+    if (!m_initialized) {
+        error<std::runtime_error>(Journal::Component::Portal, Journal::Context::API,
+            std::source_location::current(),
+            "Portal::Forma not initialized - cannot get inspector");
+    }
+    return *m_inspect;
+}
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+std::shared_ptr<Core::Window> Atelier::create_window(const Core::WindowCreateInfo& info)
+{
+    auto window = m_window_manager->create_window(info);
+    window->show();
+    return window;
+}
+
+std::shared_ptr<Buffers::FormaBuffer> Atelier::create_buffer(
+    std::shared_ptr<Core::Window> window,
+    size_t capacity,
+    Graphics::PrimitiveTopology topology,
+    const std::string& texture_binding,
+    std::vector<std::pair<std::string, std::shared_ptr<Core::VKImage>>> additional_textures)
+{
+    auto buf = std::make_shared<Buffers::FormaBuffer>(capacity, topology);
+    m_buffer_manager->add_buffer(buf, Buffers::ProcessingToken::GRAPHICS_BACKEND);
+
+    if (!additional_textures.empty()) {
+        buf->setup_rendering({
+            .target_window = std::move(window),
+            .additional_textures = std::move(additional_textures),
+        });
+    } else if (!texture_binding.empty()) {
+        buf->setup_rendering({
+            .target_window = std::move(window),
+            .default_texture_binding = texture_binding,
+        });
+    } else {
+        buf->setup_rendering({ .target_window = std::move(window) });
+    }
+
+    return buf;
+}
+
+std::pair<std::shared_ptr<Layer>, std::shared_ptr<Context>>
+Atelier::create_layer(const std::shared_ptr<Core::Window>& window, std::string name)
+{
+    auto layer = std::make_shared<Layer>();
+    auto ctx = std::make_shared<Context>(layer, window, *m_event_manager, std::move(name));
+
+    MayaFlux::store(ctx);
+
+    return { std::move(layer), std::move(ctx) };
+}
+
+Surface Atelier::create_surface(std::shared_ptr<Core::Window> window, std::string name)
+{
+    auto [layer, ctx] = create_layer(window, std::move(name));
+    return { std::move(window), std::move(layer), std::move(ctx) };
+}
+
+} // namespace MayaFlux::Portal::Forma::internal

--- a/src/MayaFlux/Portal/Forma/Internal/Atelier.cpp
+++ b/src/MayaFlux/Portal/Forma/Internal/Atelier.cpp
@@ -12,6 +12,11 @@
 
 namespace MayaFlux::Portal::Forma::internal {
 
+namespace {
+    constexpr size_t k_text_label_capacity = static_cast<size_t>(6) * sizeof(Kakshya::MeshVertex);
+    constexpr size_t k_rect_capacity = static_cast<size_t>(4) * sizeof(Kakshya::Vertex);
+}
+
 // =============================================================================
 // Lifecycle
 // =============================================================================
@@ -142,6 +147,58 @@ Surface Atelier::create_surface(std::shared_ptr<Core::Window> window, std::strin
 {
     auto [layer, ctx] = create_layer(window, std::move(name));
     return { std::move(window), std::move(layer), std::move(ctx) };
+}
+
+void Atelier::place_adornments(
+    Surface& surface,
+    const Plot::SeriesSpec& spec,
+    uint32_t relate_to)
+{
+    const auto& win = surface.window();
+
+    for (const auto& label : spec.labels) {
+        auto buf = create_buffer(
+            win,
+            k_text_label_capacity,
+            Graphics::PrimitiveTopology::TRIANGLE_LIST,
+            {},
+            { { "text", nullptr } });
+        (void)Plot::place_label(surface, std::move(buf), label, relate_to);
+    }
+
+    for (const auto& ticks : spec.tick_labels) {
+        for (const auto& label : Plot::plot_tick_labels(ticks)) {
+            auto buf = create_buffer(
+                win,
+                k_text_label_capacity,
+                Graphics::PrimitiveTopology::TRIANGLE_LIST,
+                {},
+                { { "text", nullptr } });
+            (void)Plot::place_label(surface, std::move(buf), label, relate_to);
+        }
+    }
+
+    if (spec.legend) {
+        auto layout = Plot::layout_legend(*spec.legend);
+
+        for (const auto& swatch : layout.swatches) {
+            auto buf = create_buffer(
+                win,
+                k_rect_capacity,
+                Graphics::PrimitiveTopology::TRIANGLE_STRIP);
+            (void)Plot::place_rect(surface, std::move(buf), swatch, relate_to);
+        }
+
+        for (const auto& label : layout.labels) {
+            auto buf = create_buffer(
+                win,
+                k_text_label_capacity,
+                Graphics::PrimitiveTopology::TRIANGLE_LIST,
+                {},
+                { { "text", nullptr } });
+            (void)Plot::place_label(surface, std::move(buf), label, relate_to);
+        }
+    }
 }
 
 } // namespace MayaFlux::Portal::Forma::internal

--- a/src/MayaFlux/Portal/Forma/Internal/Atelier.hpp
+++ b/src/MayaFlux/Portal/Forma/Internal/Atelier.hpp
@@ -1,0 +1,207 @@
+#pragma once
+
+#include "MayaFlux/Portal/Forma/Bridge.hpp"
+#include "MayaFlux/Portal/Forma/Primitives/Mapped.hpp"
+#include "MayaFlux/Portal/Forma/Surface.hpp"
+
+namespace MayaFlux::Nodes {
+class NodeGraphManager;
+}
+
+namespace MayaFlux::Core {
+class Window;
+class WindowManager;
+struct WindowCreateInfo;
+}
+
+namespace MayaFlux::Vruta {
+class TaskScheduler;
+class EventManager;
+}
+
+namespace MayaFlux::Buffers {
+class BufferManager;
+}
+
+namespace MayaFlux::Portal::Forma {
+
+class Inspector;
+
+namespace internal {
+
+    constexpr size_t k_capacity_bytes = 4096;
+
+    /**
+     * @class Atelier
+     * @brief Process-wide Forma workshop. Not part of the public surface.
+     *
+     * Holds the engine references stored by Portal::Forma::initialize and
+     * owns every construction path that depends on them: buffers, layers,
+     * contexts, surfaces, elements, windows.
+     *
+     * Everything under Internal/ is implementation detail and carries no
+     * stability guarantee. The public entry points in Forma.hpp are thin
+     * wrappers over the methods here. User code calls those, not these.
+     *
+     * Lifetime follows the Portal::Graphics singleton contract: the Meyers
+     * instance is never destroyed, and shutdown() releases the held
+     * references explicitly before static teardown.
+     */
+    class MAYAFLUX_API Atelier {
+    public:
+        static Atelier& instance()
+        {
+            static Atelier a;
+            return a;
+        }
+
+        Atelier(const Atelier&) = delete;
+        Atelier& operator=(const Atelier&) = delete;
+        Atelier(Atelier&&) = delete;
+        Atelier& operator=(Atelier&&) = delete;
+
+        // =====================================================================
+        // Lifecycle
+        // =====================================================================
+
+        bool initialize(
+            std::shared_ptr<Nodes::NodeGraphManager> node_graph_manager,
+            std::shared_ptr<Buffers::BufferManager> buffer_manager,
+            std::shared_ptr<Vruta::TaskScheduler> scheduler,
+            std::shared_ptr<Vruta::EventManager> event_manager,
+            std::shared_ptr<Core::WindowManager> window_manager);
+
+        void shutdown();
+
+        [[nodiscard]] bool is_initialized() const noexcept { return m_initialized; }
+
+        /**
+         * @brief Bridge instance constructed during initialize.
+         * @throws std::runtime_error if called before initialize().
+         */
+        [[nodiscard]] Bridge& bridge();
+
+        /**
+         * @brief Inspector instance constructed during initialize.
+         * @throws std::runtime_error if called before initialize().
+         */
+        [[nodiscard]] Inspector& inspector();
+
+        // =====================================================================
+        // Construction
+        // =====================================================================
+
+        /**
+         * @brief Create a window through the stored WindowManager and show it.
+         *
+         * Present so that callers needing a window do not reach the manager
+         * directly.
+         */
+        [[nodiscard]] std::shared_ptr<Core::Window> create_window(
+            const Core::WindowCreateInfo& info);
+
+        /**
+         * @brief Capacity-explicit FormaBuffer construction.
+         *
+         * The single buffer construction path. Registers with the stored
+         * BufferManager under GRAPHICS_BACKEND and calls setup_rendering
+         * with whichever texture configuration was requested.
+         */
+        [[nodiscard]] std::shared_ptr<Buffers::FormaBuffer> create_buffer(
+            std::shared_ptr<Core::Window> window,
+            size_t capacity,
+            Graphics::PrimitiveTopology topology,
+            const std::string& texture_binding = {},
+            std::vector<std::pair<std::string, std::shared_ptr<Core::VKImage>>>
+                additional_textures = {});
+
+        /**
+         * @brief Construct a Layer and a Context wired to @p window.
+         *
+         * The Context is stored so its event coroutines outlive the call.
+         */
+        [[nodiscard]] std::pair<std::shared_ptr<Layer>, std::shared_ptr<Context>>
+        create_layer(const std::shared_ptr<Core::Window>& window, std::string name);
+
+        /// @brief create_layer plus ownership of the window, as a Surface.
+        [[nodiscard]] Surface create_surface(
+            std::shared_ptr<Core::Window> window, std::string name);
+
+        /**
+         * @brief Build a FormaBuffer, construct a Mapped<T>, register the
+         *        element on @p layer, and register it with the Bridge.
+         *
+         * @tparam T       MappedState value type.
+         * @param layer    Layer to register the element on.
+         * @param window   Target window for rendering.
+         * @param geom     Geometry function producing vertex bytes from T.
+         * @param initial  Starting value written into MappedState.
+         * @param topology Primitive topology for the FormaBuffer.
+         * @param capacity Initial FormaBuffer capacity in bytes.
+         * @param project  Optional T to float projection for outbound readers.
+         */
+        template <typename T>
+        [[nodiscard]] Mapped<T> create_element(
+            Layer& layer,
+            std::shared_ptr<Core::Window> window,
+            GeometryFn<T> geom,
+            T initial,
+            Graphics::PrimitiveTopology topology = Graphics::PrimitiveTopology::TRIANGLE_STRIP,
+            size_t capacity = k_capacity_bytes,
+            std::function<float(T)> project = {})
+        {
+            auto buf = create_buffer(std::move(window), capacity, topology);
+            auto mapped = make_mapped<T>(std::move(initial), std::move(geom), std::move(buf));
+            mapped.element.id = layer.add(mapped.element);
+            bridge().register_element(mapped, std::move(project));
+            return mapped;
+        }
+
+        /**
+         * @brief create_element against a Surface, followed by one sync so
+         *        bounds_hint and contains from the geometry function reach
+         *        the Layer before the first frame.
+         */
+        template <typename T>
+        [[nodiscard]] Mapped<T> create_element(
+            Surface& surface,
+            GeometryFn<T> geom,
+            T initial,
+            Graphics::PrimitiveTopology topology = Graphics::PrimitiveTopology::TRIANGLE_STRIP,
+            std::function<float(T)> project = {})
+        {
+            auto mapped = create_element<T>(
+                surface.layer(), surface.window(),
+                std::move(geom), std::move(initial),
+                topology, k_capacity_bytes, std::move(project));
+
+            mapped.sync();
+            if (mapped.element.bounds_hint)
+                surface.layer().set_bounds(mapped.element.id, *mapped.element.bounds_hint);
+            if (mapped.element.contains)
+                surface.layer().set_contains(mapped.element.id, mapped.element.contains);
+
+            return mapped;
+        }
+
+    private:
+        Atelier();
+        ~Atelier();
+
+        std::shared_ptr<Nodes::NodeGraphManager> m_node_graph_manager;
+        std::shared_ptr<Buffers::BufferManager> m_buffer_manager;
+        std::shared_ptr<Vruta::TaskScheduler> m_scheduler;
+        std::shared_ptr<Vruta::EventManager> m_event_manager;
+        std::shared_ptr<Core::WindowManager> m_window_manager;
+
+        std::unique_ptr<Bridge> m_bridge;
+        std::unique_ptr<Inspector> m_inspect;
+
+        bool m_initialized {};
+    };
+
+    /// @brief Accessor for the process-wide Atelier.
+    inline Atelier& atelier() { return Atelier::instance(); }
+
+} // namespace internal
+} // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Internal/Atelier.hpp
+++ b/src/MayaFlux/Portal/Forma/Internal/Atelier.hpp
@@ -4,6 +4,8 @@
 #include "MayaFlux/Portal/Forma/Primitives/Mapped.hpp"
 #include "MayaFlux/Portal/Forma/Surface.hpp"
 
+#include "MayaFlux/Portal/Forma/Plot/Plot.hpp"
+
 namespace MayaFlux::Nodes {
 class NodeGraphManager;
 }
@@ -183,6 +185,27 @@ namespace internal {
 
             return mapped;
         }
+
+        /**
+         * @brief Create and place every adornment declared on @p spec.
+         *
+         * Builds one buffer per axis label, tick label, legend swatch, and
+         * legend label, then hands each to the corresponding Plot placement
+         * function. Each adornment is related to @p relate_to so removal and
+         * visibility cascade from the series element.
+         *
+         * Lives here rather than in Plot because it constructs buffers,
+         * which requires the BufferManager. Plot composes placement from
+         * arguments it is given.
+         *
+         * @param surface   Surface to place on.
+         * @param spec      Series spec carrying the adornment declarations.
+         * @param relate_to Element id the adornments are related to.
+         */
+        void place_adornments(
+            Surface& surface,
+            const Plot::SeriesSpec& spec,
+            uint32_t relate_to);
 
     private:
         Atelier();

--- a/src/MayaFlux/Portal/Forma/Primitives/Collapsible.cpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/Collapsible.cpp
@@ -108,6 +108,11 @@ Collapsible& Collapsible::place(
             m.sync();
         });
 
+    header_bounds = Kinesis::AABB2D {
+        .min = { x_min, cursor.y() },
+        .max = { x_max, y_top },
+    };
+
     header_id = hid;
     open = open_state;
     cursor_out = cursor;

--- a/src/MayaFlux/Portal/Forma/Primitives/Collapsible.cpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/Collapsible.cpp
@@ -119,6 +119,16 @@ Collapsible& Collapsible::place(
     return *this;
 }
 
+Collapsible& Collapsible::place(
+    std::shared_ptr<Buffers::FormaBuffer> in_buf,
+    Surface& surface,
+    LayoutCursor& cursor,
+    float row_h)
+{
+    return place(std::move(in_buf), surface, cursor,
+        cursor.x_min(), cursor.x_max(), row_h);
+}
+
 void Collapsible::attach(Layer& layer, uint32_t body_id) const
 {
     layer.relate(header_id, body_id);

--- a/src/MayaFlux/Portal/Forma/Primitives/Collapsible.hpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/Collapsible.hpp
@@ -134,6 +134,26 @@ struct Collapsible {
         LayoutCursor& cursor,
         float x_min, float x_max, float row_h);
 
+    /**
+     * @brief Register the header element using the cursor's column extents.
+     *
+     * Equivalent to the explicit-extent overload with x_min and x_max taken
+     * from @p cursor. Use with a column-scoped LayoutCursor so the header
+     * spans exactly the column the cursor advances within.
+     *
+     * @param buf     Pre-created FormaBuffer sized for this header.
+     * @param surface Surface to register the header on.
+     * @param cursor  Layout cursor. Supplies column extents and is advanced
+     *                by @p row_h on return.
+     * @param row_h   Header strip height in NDC units.
+     * @return *this, with results populated.
+     */
+    MAYAFLUX_API Collapsible& place(
+        std::shared_ptr<Buffers::FormaBuffer> buf,
+        Surface& surface,
+        LayoutCursor& cursor,
+        float row_h);
+
     // =========================================================================
     // Post-placement helpers
     // =========================================================================

--- a/src/MayaFlux/Portal/Forma/Primitives/Collapsible.hpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/Collapsible.hpp
@@ -53,6 +53,12 @@ struct Collapsible {
     /// @brief Cursor positioned below the header, ready for body elements. Valid after place().
     LayoutCursor cursor_out;
 
+    /// @brief NDC region occupied by the header strip. Valid after place().
+    Kinesis::AABB2D header_bounds {};
+
+    /// @brief Header strip region, satisfying Kinesis::HasBounds.
+    [[nodiscard]] Kinesis::AABB2D bounds() const noexcept { return header_bounds; }
+
     // =========================================================================
     // Configuration - set before place()
     // =========================================================================

--- a/src/MayaFlux/Portal/Forma/Primitives/FormFactory.cpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/FormFactory.cpp
@@ -117,7 +117,7 @@ Form<glm::vec2> point(
     return { std::move(fn),
         Graphics::PrimitiveTopology::POINT_LIST,
         sizeof(Kakshya::PointVertex),
-        drag_with<glm::vec2>([](glm::vec2 ndc) { return ndc; }) };
+        follow_move() };
 }
 
 Form<glm::vec2> position_picker(
@@ -329,7 +329,7 @@ Form<glm::vec2> crosshair(
     return { std::move(fn),
         Graphics::PrimitiveTopology::LINE_LIST,
         static_cast<size_t>(4) * sizeof(Kakshya::LineVertex),
-        drag_with<glm::vec2>([](glm::vec2 ndc) { return ndc; }) };
+        follow_move() };
 }
 
 Form<std::vector<float>> drawable_canvas(

--- a/src/MayaFlux/Portal/Forma/Primitives/FormFactory.cpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/FormFactory.cpp
@@ -1,8 +1,7 @@
-#include "Geometry.hpp"
+#include "FormFactory.hpp"
 
 #include "MayaFlux/Kinesis/Geometry2D.hpp"
 #include "MayaFlux/Kinesis/GeometryPrimitives.hpp"
-#include "MayaFlux/Portal/Forma/Context.hpp"
 
 namespace MayaFlux::Portal::Forma::Geometry {
 
@@ -59,19 +58,21 @@ GeometryFn<float> vertical_fader(
 }
 
 GeometryFn<float> radial(
-    glm::vec2 center,
-    float radius,
+    Kinesis::AABB2D region,
     float angle_start,
     float angle_end,
     glm::vec3 color)
 {
+    const glm::vec2 center = region.center();
+    const float radius = std::min(region.width(), region.height()) * 0.5F;
+
     return [center, radius, angle_start, angle_end, color](
                float v, std::vector<uint8_t>& out, Element& el) {
-        float angle = angle_start + v * (angle_end - angle_start);
-        glm::vec2 tip = center + radius * glm::vec2(std::cos(angle), std::sin(angle));
+        const float angle = angle_start + v * (angle_end - angle_start);
+        const glm::vec2 tip = center + radius * glm::vec2(std::cos(angle), std::sin(angle));
 
         using V = Kakshya::LineVertex;
-        std::vector<V> verts = {
+        const std::vector<V> verts = {
             { .position = { center.x, center.y, 0 }, .color = color },
             { .position = { tip.x, tip.y, 0 }, .color = color },
         };
@@ -81,17 +82,6 @@ GeometryFn<float> radial(
         el.bounds_hint = Kinesis::AABB2D::from_ndc(center, glm::vec2(radius));
         el.contains = Kinesis::circular_bounds(center, radius);
     };
-}
-
-GeometryFn<float> radial(
-    Kinesis::AABB2D region,
-    float angle_start,
-    float angle_end,
-    glm::vec3 color)
-{
-    return radial(region.center(),
-        std::min(region.width(), region.height()) * 0.5F,
-        angle_start, angle_end, color);
 }
 
 GeometryFn<glm::vec2> point(

--- a/src/MayaFlux/Portal/Forma/Primitives/FormFactory.cpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/FormFactory.cpp
@@ -5,14 +5,14 @@
 
 namespace MayaFlux::Portal::Forma::Geometry {
 
-GeometryFn<float> horizontal_fader(
+Form<float> horizontal_fader(
     Kinesis::AABB2D bounds,
     float handle_w,
     glm::vec3 track_color,
     glm::vec3 handle_color)
 {
-    return [bounds, handle_w, track_color, handle_color](
-               float v, std::vector<uint8_t>& out, Element& el) {
+    GeometryFn<float> fn = [bounds, handle_w, track_color, handle_color](
+                               float v, std::vector<uint8_t>& out, Element& el) {
         float x = bounds.min.x + v * (bounds.width() - handle_w);
         float yt = bounds.min.y + bounds.height() * 0.35F;
         float yb = bounds.min.y + bounds.height() * 0.65F;
@@ -29,16 +29,21 @@ GeometryFn<float> horizontal_fader(
         el.bounds_hint = handle;
         el.contains = {};
     };
+
+    return { std::move(fn),
+        Graphics::PrimitiveTopology::TRIANGLE_STRIP,
+        static_cast<size_t>(8) * sizeof(Kakshya::MeshVertex),
+        drag_with<float>(Kinesis::axis_fraction(bounds, handle_w, true)) };
 }
 
-GeometryFn<float> vertical_fader(
+Form<float> vertical_fader(
     Kinesis::AABB2D bounds,
     float handle_h,
     glm::vec3 track_color,
     glm::vec3 handle_color)
 {
-    return [bounds, handle_h, track_color, handle_color](
-               float v, std::vector<uint8_t>& out, Element& el) {
+    GeometryFn<float> fn = [bounds, handle_h, track_color, handle_color](
+                               float v, std::vector<uint8_t>& out, Element& el) {
         const float y = bounds.min.y + v * (bounds.height() - handle_h);
         const float xl = bounds.min.x + bounds.width() * 0.35F;
         const float xr = bounds.min.x + bounds.width() * 0.65F;
@@ -55,9 +60,14 @@ GeometryFn<float> vertical_fader(
         el.bounds_hint = handle;
         el.contains = {};
     };
+
+    return { std::move(fn),
+        Graphics::PrimitiveTopology::TRIANGLE_STRIP,
+        static_cast<size_t>(8) * sizeof(Kakshya::MeshVertex),
+        drag_with<float>(Kinesis::axis_fraction(bounds, handle_h, false)) };
 }
 
-GeometryFn<float> radial(
+Form<float> radial(
     Kinesis::AABB2D region,
     float angle_start,
     float angle_end,
@@ -66,8 +76,8 @@ GeometryFn<float> radial(
     const glm::vec2 center = region.center();
     const float radius = std::min(region.width(), region.height()) * 0.5F;
 
-    return [center, radius, angle_start, angle_end, color](
-               float v, std::vector<uint8_t>& out, Element& el) {
+    GeometryFn<float> fn = [center, radius, angle_start, angle_end, color](
+                               float v, std::vector<uint8_t>& out, Element& el) {
         const float angle = angle_start + v * (angle_end - angle_start);
         const glm::vec2 tip = center + radius * glm::vec2(std::cos(angle), std::sin(angle));
 
@@ -82,14 +92,19 @@ GeometryFn<float> radial(
         el.bounds_hint = Kinesis::AABB2D::from_ndc(center, glm::vec2(radius));
         el.contains = Kinesis::circular_bounds(center, radius);
     };
+
+    return { std::move(fn),
+        Graphics::PrimitiveTopology::LINE_LIST,
+        static_cast<size_t>(2) * sizeof(Kakshya::LineVertex),
+        drag_with<float>(Kinesis::angle_fraction(center, angle_start, angle_end)) };
 }
 
-GeometryFn<glm::vec2> point(
+Form<glm::vec2> point(
     glm::vec3 color,
     float size,
     float hit_radius)
 {
-    return [color, size, hit_radius](glm::vec2 pos, std::vector<uint8_t>& out, Element& el) {
+    GeometryFn<glm::vec2> fn = [color, size, hit_radius](glm::vec2 pos, std::vector<uint8_t>& out, Element& el) {
         write_verts(out, Kakshya::PointVertex {
                              .position = { pos.x, pos.y, 0.0F },
                              .color = color,
@@ -98,15 +113,20 @@ GeometryFn<glm::vec2> point(
         el.bounds_hint = Kinesis::AABB2D::from_ndc(pos, glm::vec2(hit_radius));
         el.contains = Kinesis::circular_bounds(pos, hit_radius);
     };
+
+    return { std::move(fn),
+        Graphics::PrimitiveTopology::POINT_LIST,
+        sizeof(Kakshya::PointVertex),
+        drag_with<glm::vec2>([](glm::vec2 ndc) { return ndc; }) };
 }
 
-GeometryFn<glm::vec2> position_picker(
+Form<glm::vec2> position_picker(
     Kinesis::AABB2D bounds,
     glm::vec3 color,
     float size)
 {
-    return [bounds, color, size](
-               glm::vec2 v, std::vector<uint8_t>& out, Element& el) {
+    GeometryFn<glm::vec2> fn = [bounds, color, size](
+                                   glm::vec2 v, std::vector<uint8_t>& out, Element& el) {
         float x = bounds.min.x + v.x * bounds.width();
         float y = bounds.min.y + v.y * bounds.height();
 
@@ -125,9 +145,14 @@ GeometryFn<glm::vec2> position_picker(
                 bounds.max,
                 glm::vec2(bounds.min.x, bounds.max.y) } });
     };
+
+    return { std::move(fn),
+        Graphics::PrimitiveTopology::POINT_LIST,
+        sizeof(Kakshya::PointVertex),
+        drag_with<glm::vec2>(Kinesis::unit_square(bounds)) };
 }
 
-GeometryFn<float> stroke_slider(
+Form<float> stroke_slider(
     std::span<const glm::vec2> path,
     std::shared_ptr<Buffers::FormaBuffer> handle_buf,
     float half_thickness,
@@ -155,16 +180,19 @@ GeometryFn<float> stroke_slider(
     }
     aabb = aabb.expanded(half_thickness);
 
-    return [pts = std::move(pts),
-               seg_lengths = std::move(seg_lengths),
-               total_len,
-               aabb,
-               handle_buf = std::move(handle_buf),
-               half_thickness,
-               track_color,
-               fill_color,
-               handle_color,
-               handle_size](float v, std::vector<uint8_t>& out, Element& el) {
+    auto project = Kinesis::path_fraction(path);
+    const size_t cap = pts.size() * 4 * sizeof(Kakshya::LineVertex);
+
+    GeometryFn<float> fn = [pts = std::move(pts),
+                               seg_lengths = std::move(seg_lengths),
+                               total_len,
+                               aabb,
+                               handle_buf = std::move(handle_buf),
+                               half_thickness,
+                               track_color,
+                               fill_color,
+                               handle_color,
+                               handle_size](float v, std::vector<uint8_t>& out, Element& el) {
         if (pts.size() < 2) {
             out.clear();
             return;
@@ -217,29 +245,39 @@ GeometryFn<float> stroke_slider(
             handle_buf->submit(hbytes);
         }
     };
+
+    return { std::move(fn),
+        Graphics::PrimitiveTopology::LINE_LIST,
+        cap,
+        drag_with<float>(std::move(project)) };
 }
 
-GeometryFn<bool> toggle(
+Form<bool> toggle(
     Kinesis::AABB2D region,
     glm::vec3 color_off,
     glm::vec3 color_on)
 {
-    return [region, color_off, color_on](
-               bool v, std::vector<uint8_t>& out, Element& el) {
+    GeometryFn<bool> fn = [region, color_off, color_on](
+                              bool v, std::vector<uint8_t>& out, Element& el) {
         write_verts(out, Kakshya::to_mesh_vertices(Kinesis::filled_rect(region, v ? color_on : color_off)));
         el.bounds_hint = region;
         el.contains = {};
     };
+
+    return { std::move(fn),
+        Graphics::PrimitiveTopology::TRIANGLE_STRIP,
+        static_cast<size_t>(4) * sizeof(Kakshya::MeshVertex),
+        press_flip() };
 }
 
-GeometryFn<float> level_meter(
+Form<float> level_meter(
     Kinesis::AABB2D bounds,
     bool horizontal,
     glm::vec3 fill_color,
     glm::vec3 track_color)
 {
-    return [bounds, horizontal, fill_color, track_color](
-               float v, std::vector<uint8_t>& out, Element& el) {
+    GeometryFn<float> fn = [bounds, horizontal, fill_color, track_color](
+                               float v, std::vector<uint8_t>& out, Element& el) {
         const float t = std::clamp(v, 0.F, 1.F);
 
         Kinesis::AABB2D fill {}, remainder {};
@@ -262,16 +300,20 @@ GeometryFn<float> level_meter(
         el.bounds_hint = bounds;
         el.contains = {};
     };
+
+    return { std::move(fn),
+        Graphics::PrimitiveTopology::TRIANGLE_STRIP,
+        static_cast<size_t>(8) * sizeof(Kakshya::MeshVertex) };
 }
 
-GeometryFn<glm::vec2> crosshair(
+Form<glm::vec2> crosshair(
     float arm_len,
     glm::vec3 color,
     float thickness,
     float hit_radius)
 {
-    return [arm_len, color, thickness, hit_radius](
-               glm::vec2 pos, std::vector<uint8_t>& out, Element& el) {
+    GeometryFn<glm::vec2> fn = [arm_len, color, thickness, hit_radius](
+                                   glm::vec2 pos, std::vector<uint8_t>& out, Element& el) {
         using V = Kakshya::LineVertex;
         const std::array<V, 4> verts { {
             { .position = { pos.x - arm_len, pos.y, 0.F }, .color = color, .thickness = thickness },
@@ -283,15 +325,20 @@ GeometryFn<glm::vec2> crosshair(
         el.bounds_hint = Kinesis::AABB2D::from_ndc(pos, glm::vec2(arm_len));
         el.contains = Kinesis::circular_bounds(pos, hit_radius);
     };
+
+    return { std::move(fn),
+        Graphics::PrimitiveTopology::LINE_LIST,
+        static_cast<size_t>(4) * sizeof(Kakshya::LineVertex),
+        drag_with<glm::vec2>([](glm::vec2 ndc) { return ndc; }) };
 }
 
-GeometryFn<std::vector<float>> drawable_canvas(
+Form<std::vector<float>> drawable_canvas(
     Kinesis::AABB2D bounds,
     glm::vec3 color,
     float thickness)
 {
-    return [bounds, color, thickness](
-               const std::vector<float>& v, std::vector<uint8_t>& out, Element& el) {
+    GeometryFn<std::vector<float>> fn = [bounds, color, thickness](
+                                            const std::vector<float>& v, std::vector<uint8_t>& out, Element& el) {
         if (v.size() < 2) {
             out.clear();
             el.bounds_hint = bounds;
@@ -330,6 +377,11 @@ GeometryFn<std::vector<float>> drawable_canvas(
                 bounds.max,
                 glm::vec2(bounds.min.x, bounds.max.y) } });
     };
+
+    Form<std::vector<float>> form { std::move(fn) };
+    form.topology = Graphics::PrimitiveTopology::LINE_LIST;
+    form.wire = paint_over(bounds);
+    return form;
 }
 
 void wire_canvas_drag(

--- a/src/MayaFlux/Portal/Forma/Primitives/FormFactory.hpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/FormFactory.hpp
@@ -1,0 +1,396 @@
+#pragma once
+
+#include "Geometry.hpp"
+
+#include "MayaFlux/Portal/Forma/Context.hpp"
+
+namespace MayaFlux::Portal::Forma::Geometry {
+
+/**
+ * @brief Register a drag handler writing a projected cursor position to @p state.
+ *
+ * The projection carries the geometry-specific mapping.
+ * Kinesis::Projection supplies the inverses matching the geometry functions
+ * above: axis_fraction for the faders, unit_square for position_picker,
+ * angle_fraction for radial, path_fraction for stroke_slider.
+ *
+ * @param ctx     Context owning the element's callbacks.
+ * @param id      Element id returned from create_element.
+ * @param state   MappedState written on each drag event.
+ * @param project NDC to value mapping.
+ * @param btn     Mouse button that must be held.
+ */
+template <typename T>
+void wire_drag(
+    Context& ctx,
+    uint32_t id,
+    std::shared_ptr<MappedState<T>> state,
+    std::function<T(glm::vec2)> project,
+    IO::MouseButtons btn = IO::MouseButtons::Left)
+{
+    if (!state || !project)
+        return;
+
+    ctx.wire_drag(
+        id,
+        [state = std::move(state), project = std::move(project)](glm::vec2 ndc) {
+            state->write(project(ndc));
+        },
+        btn);
+}
+
+/**
+ * @brief Wire drag interaction for a drawable canvas element.
+ *
+ * Registers a left-button drag callback on @p ctx that maps NDC cursor
+ * position to a sample index and amplitude, writes into @p state, and
+ * increments the version. Linear interpolation fills the range between the
+ * previously touched index and the current one, preventing sparse samples
+ * under fast drag.
+ *
+ * @param ctx     Context owning the element.
+ * @param id      Element id from the Mapped.
+ * @param state   MappedState<vector<float>> to write into.
+ * @param bounds  Canvas NDC bounds — must match those passed to drawable_canvas().
+ */
+MAYAFLUX_API void wire_canvas_drag(
+    Context& ctx,
+    uint32_t id,
+    std::shared_ptr<MappedState<std::vector<float>>> state,
+    Kinesis::AABB2D bounds);
+
+/**
+ * @brief Produce a Form::wire that registers a drag writing a projected
+ *        cursor position.
+ *
+ * @param project NDC to value mapping, from Kinesis::Projection.
+ * @param btn     Mouse button that must be held.
+ */
+template <typename T>
+[[nodiscard]] auto drag_with(
+    std::function<T(glm::vec2)> project,
+    IO::MouseButtons btn = IO::MouseButtons::Left)
+{
+    return [project = std::move(project), btn](
+               Context& ctx, uint32_t id, std::shared_ptr<MappedState<T>> state) {
+        wire_drag<T>(ctx, id, std::move(state), project, btn);
+    };
+}
+
+/**
+ * @brief Produce a Form::wire that registers a press flipping a bool state.
+ */
+[[nodiscard]] inline auto press_flip(IO::MouseButtons btn = IO::MouseButtons::Left)
+{
+    return [btn](Context& ctx, uint32_t id, std::shared_ptr<MappedState<bool>> state) {
+        ctx.on_press(id, btn, [state = std::move(state)](uint32_t, glm::vec2) {
+            state->write(!state->value);
+        });
+    };
+}
+
+/**
+ * @brief Produce a Form::wire that registers canvas painting over @p bounds.
+ */
+[[nodiscard]] inline auto paint_over(Kinesis::AABB2D bounds)
+{
+    return [bounds](Context& ctx, uint32_t id,
+               std::shared_ptr<MappedState<std::vector<float>>> state) {
+        wire_canvas_drag(ctx, id, std::move(state), bounds);
+    };
+}
+
+// =============================================================================
+// Horizontal fader
+//
+// Value in [0, 1] moves a handle quad along a track quad.
+// Two quads: track (static) and handle (value-driven).
+// Both written as TRIANGLE_STRIP pairs into a single buffer.
+//
+// Track: full extent of bounds.
+// Handle: small square at x = bounds.min.x + value * bounds.width().
+//
+// Hit region follows the handle, updated on every sync().
+// =============================================================================
+
+/**
+ * @brief Geometry function for a horizontal fader in NDC space.
+ * @param bounds      Full extent of the fader in NDC.
+ * @param handle_w    Handle width in NDC units.
+ * @param track_color Track quad color.
+ * @param handle_color Handle quad color.
+ */
+[[nodiscard]] MAYAFLUX_API GeometryFn<float> horizontal_fader(
+    Kinesis::AABB2D bounds,
+    float handle_w,
+    glm::vec3 track_color = glm::vec3(0.3F),
+    glm::vec3 handle_color = glm::vec3(0.9F));
+
+// =============================================================================
+// Vertical fader
+//
+// Symmetric counterpart to horizontal_fader. Value in [0, 1] moves a handle
+// quad upward along a track quad.
+//
+// Track: thin vertical band through the center of bounds.
+// Handle: small square at y = bounds.min.y + value * (bounds.height() - handle_h).
+//
+// Hit region follows the handle, updated on every sync().
+// Topology: TRIANGLE_STRIP (two quad pairs via to_mesh_vertices).
+// =============================================================================
+
+/**
+ * @brief Geometry function for a vertical fader in NDC space.
+ * @param bounds       Full extent of the fader in NDC.
+ * @param handle_h     Handle height in NDC units.
+ * @param track_color  Track quad color.
+ * @param handle_color Handle quad color.
+ */
+[[nodiscard]] MAYAFLUX_API GeometryFn<float> vertical_fader(
+    Kinesis::AABB2D bounds,
+    float handle_h,
+    glm::vec3 track_color = glm::vec3(0.3F),
+    glm::vec3 handle_color = glm::vec3(0.9F));
+
+// =============================================================================
+// Radial / arc
+//
+// Value in [0, 1] sweeps an indicator line around the centre of a region.
+// angle_start and angle_end in radians, measured from +X, CCW.
+// Produces a LINE_LIST of two vertices: centre to indicator tip.
+//
+// The radius is the region's smaller half-extent, so the sweep is inscribed
+// regardless of aspect. For a centre and radius, build the region with
+// Kinesis::AABB2D::from_ndc(centre, glm::vec2(radius)).
+// =============================================================================
+
+/**
+ * @brief Geometry function for a radial indicator in NDC space.
+ * @param region      NDC region the arc is inscribed in.
+ * @param angle_start Start angle in radians (value = 0).
+ * @param angle_end   End angle in radians (value = 1).
+ * @param color       Line color.
+ */
+[[nodiscard]] MAYAFLUX_API GeometryFn<float> radial(
+    Kinesis::AABB2D region,
+    float angle_start,
+    float angle_end,
+    glm::vec3 color = glm::vec3(0.9F));
+
+// =============================================================================
+// Point
+//
+// Value is glm::vec2 in NDC space. Produces a single POINT_LIST vertex.
+// Hit region is a circle centered on the point.
+// Use as a cursor follower, node handle, or any positioned point primitive.
+// =============================================================================
+
+/**
+ * @brief Geometry function for a positioned point in NDC space.
+ *
+ * Value type is glm::vec2 (NDC position). Renders a single PointVertex
+ * and sets a circular hit region centered on the position. Suitable as
+ * a cursor follower, node handle, or any draggable point primitive.
+ *
+ * @param color      Point color.
+ * @param size       Point size in pixels.
+ * @param hit_radius Hit region radius in NDC units.
+ */
+[[nodiscard]] MAYAFLUX_API GeometryFn<glm::vec2> point(
+    glm::vec3 color = glm::vec3(1.0F),
+    float size = 10.0F,
+    float hit_radius = 0.04F);
+
+// =============================================================================
+// 2D position picker
+//
+// Value is glm::vec2 in [0,1]x[0,1], mapped to a point inside bounds.
+// Produces a single POINT_LIST vertex at the mapped position.
+// =============================================================================
+
+/**
+ * @brief Geometry function for a 2D position picker in NDC space.
+ * @param bounds Full extent of the pick area in NDC.
+ * @param color  Point color.
+ * @param size   Point size in pixels.
+ */
+[[nodiscard]] MAYAFLUX_API GeometryFn<glm::vec2> position_picker(
+    Kinesis::AABB2D bounds,
+    glm::vec3 color = glm::vec3(0.9F),
+    float size = 8.0F);
+
+// =============================================================================
+// Stroke slider
+//
+// Value in [0, 1] positions a handle point along a user-supplied polyline.
+// Renders two layers: the full path as a LINE_LIST in track_color, a
+// highlighted prefix segment from path start to the handle position in
+// fill_color, and a PointVertex handle on a caller-supplied secondary buffer.
+//
+// The secondary buffer must be a POINT_LIST FormaBuffer registered with the
+// same BufferManager and window before this function is called. The caller
+// adds it as a separate Element and relates it to the path element via
+// Layer::relate_to so removal and visibility cascade.
+//
+// Hit region: stroke_bounds over the full path at half_thickness.
+// bounds_hint: tight AABB enclosing all path points.
+//
+// Topology for the path buffer: LINE_LIST.
+// Topology for the handle buffer: POINT_LIST.
+// =============================================================================
+
+/**
+ * @brief Geometry function for a value scrubber along an arbitrary polyline.
+ *
+ * Value in [0, 1] maps to arc-length position along @p path. The full path
+ * is rendered as a LINE_LIST in @p track_color; the prefix from the path
+ * start to the handle position is rendered in @p fill_color. The handle
+ * itself is a PointVertex submitted to @p handle_buf each sync.
+ *
+ * @param path           Ordered polyline vertices in NDC. Copied into closure.
+ * @param handle_buf     POINT_LIST FormaBuffer for the handle point.
+ *                       Must be registered and have setup_rendering called.
+ * @param half_thickness Hit region half-thickness in NDC units.
+ * @param track_color    Color of the full path.
+ * @param fill_color     Color of the prefix segment up to the handle.
+ * @param handle_color   Color of the handle point.
+ * @param handle_size    Handle point size in pixels.
+ */
+[[nodiscard]] MAYAFLUX_API GeometryFn<float> stroke_slider(
+    std::span<const glm::vec2> path,
+    std::shared_ptr<Buffers::FormaBuffer> handle_buf,
+    float half_thickness = 0.02F,
+    glm::vec3 track_color = glm::vec3(0.3F),
+    glm::vec3 fill_color = glm::vec3(0.2F, 0.6F, 1.0F),
+    glm::vec3 handle_color = glm::vec3(0.95F),
+    float handle_size = 10.0F);
+
+// =============================================================================
+// Toggle
+//
+// Value type: bool. Renders a filled rect in one of two colors.
+// The geometry function is purely visual — it carries no interaction.
+// The caller wires on_press to flip state->value:
+//
+//   surface.ctx().on_press(el.element.id, IO::MouseButtons::Left,
+//       [state = el.state](uint32_t, glm::vec2) {
+//           state->write(!state->value);
+//       });
+//
+// Topology: TRIANGLE_STRIP (4 MeshVertex via to_mesh_vertices).
+// =============================================================================
+
+/**
+ * @brief Geometry function for a boolean toggle in NDC space.
+ *
+ * Renders @p region as a filled rect in @p color_off or @p color_on based
+ * on the current bool value. Interaction is the caller's responsibility.
+ *
+ * @param region    NDC bounds of the toggle.
+ * @param color_off Fill color when false.
+ * @param color_on  Fill color when true.
+ */
+[[nodiscard]] MAYAFLUX_API GeometryFn<bool> toggle(
+    Kinesis::AABB2D region,
+    glm::vec3 color_off = glm::vec3(0.25F),
+    glm::vec3 color_on = glm::vec3(0.2F, 0.7F, 0.4F));
+
+// =============================================================================
+// Level meter
+//
+// Value type: float in [0, 1]. Renders a filled bar from the origin edge of
+// bounds proportional to the value, with the remainder as a second color.
+// No handle, no hit region. Suitable for audio level, progress, any scalar readout.
+//
+// Orientation:
+//   horizontal = true  - bar grows left to right
+//   horizontal = false - bar grows bottom to top
+//
+// Topology: TRIANGLE_STRIP (two quad pairs via to_mesh_vertices).
+// =============================================================================
+
+/**
+ * @brief Geometry function for a level meter in NDC space.
+ *
+ * No interaction. Drive from a node via bridge().at(el.state).bind(node).
+ *
+ * @param bounds      Full extent of the meter in NDC.
+ * @param horizontal  True for left-to-right fill, false for bottom-to-top.
+ * @param fill_color  Color of the active (filled) portion.
+ * @param track_color Color of the inactive remainder.
+ */
+[[nodiscard]] MAYAFLUX_API GeometryFn<float> level_meter(
+    Kinesis::AABB2D bounds,
+    bool horizontal = true,
+    glm::vec3 fill_color = glm::vec3(0.2F, 0.7F, 0.3F),
+    glm::vec3 track_color = glm::vec3(0.15F));
+
+// =============================================================================
+// Crosshair
+//
+// Value type: glm::vec2 (NDC position). Renders two LINE_LIST segments —
+// horizontal and vertical — crossing at the value position.
+// Hit region: circle centered on the position.
+//
+// Pairs naturally with position_picker sharing the same MappedState<glm::vec2>.
+// Topology: LINE_LIST (4 LineVertex).
+// =============================================================================
+
+/**
+ * @brief Geometry function for a crosshair indicator in NDC space.
+ *
+ * @param arm_len    Half-length of each arm in NDC units.
+ * @param color      Line color.
+ * @param thickness  Line thickness (maps to LineVertex::thickness).
+ * @param hit_radius Hit region radius in NDC units.
+ *
+ * @note Pass @c PrimitiveTopology::LINE_LIST explicitly to create_element —
+ *       the default TRIANGLE_STRIP will misinterpret the 4 vertices.
+ */
+[[nodiscard]] MAYAFLUX_API GeometryFn<glm::vec2> crosshair(
+    float arm_len = 0.04F,
+    glm::vec3 color = glm::vec3(0.9F),
+    float thickness = 1.F,
+    float hit_radius = 0.05F);
+
+// =============================================================================
+// Drawable canvas
+//
+// value is vector<float> of N samples in [0, 1] mapped to the Y axis.
+// X positions are distributed evenly across bounds.
+// Renders as LINE_LIST: N-1 segments connecting adjacent samples.
+//
+// on_drag callback pattern:
+//   ctx->on_drag(el.element.id, IO::MouseButtons::Left,
+//       [&el, bounds](uint32_t, glm::vec2 ndc) {
+//           auto& v = el.state->value;
+//           const float t = (ndc.x - bounds.min.x) / bounds.width();
+//           const size_t i = static_cast<size_t>(
+//               std::clamp(t, 0.F, 1.F) * (v.size() - 1));
+//           const float a = (ndc.y - bounds.min.y) / bounds.height();
+//           v[i] = std::clamp(a, 0.F, 1.F);
+//           ++el.state->version;
+//       });
+//
+// For sparse-sample prevention at high drag speed, interpolate between the
+// previous and current index before calling state->write().
+//
+// Topology: LINE_LIST.
+// =============================================================================
+
+/**
+ * @brief Geometry function for a drawable curve canvas in NDC space.
+ *
+ * Renders the sample vector as a LINE_LIST polyline. Each adjacent sample
+ * pair becomes one segment. The hit region covers the full canvas bounds.
+ *
+ * @param bounds      Canvas extent in NDC.
+ * @param color       Line color.
+ * @param thickness   LineVertex thickness value.
+ */
+[[nodiscard]] MAYAFLUX_API GeometryFn<std::vector<float>> drawable_canvas(
+    Kinesis::AABB2D bounds,
+    glm::vec3 color = glm::vec3(0.8F),
+    float thickness = 1.5F);
+
+} // namespace MayaFlux::Portal::Forma::Geometry

--- a/src/MayaFlux/Portal/Forma/Primitives/FormFactory.hpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/FormFactory.hpp
@@ -4,6 +4,8 @@
 
 #include "MayaFlux/Portal/Forma/Context.hpp"
 
+#include "MayaFlux/Kinesis/Spatial/Projection.hpp"
+
 namespace MayaFlux::Portal::Forma::Geometry {
 
 /**
@@ -120,7 +122,7 @@ template <typename T>
  * @param track_color Track quad color.
  * @param handle_color Handle quad color.
  */
-[[nodiscard]] MAYAFLUX_API GeometryFn<float> horizontal_fader(
+[[nodiscard]] MAYAFLUX_API Form<float> horizontal_fader(
     Kinesis::AABB2D bounds,
     float handle_w,
     glm::vec3 track_color = glm::vec3(0.3F),
@@ -146,7 +148,7 @@ template <typename T>
  * @param track_color  Track quad color.
  * @param handle_color Handle quad color.
  */
-[[nodiscard]] MAYAFLUX_API GeometryFn<float> vertical_fader(
+[[nodiscard]] MAYAFLUX_API Form<float> vertical_fader(
     Kinesis::AABB2D bounds,
     float handle_h,
     glm::vec3 track_color = glm::vec3(0.3F),
@@ -171,7 +173,7 @@ template <typename T>
  * @param angle_end   End angle in radians (value = 1).
  * @param color       Line color.
  */
-[[nodiscard]] MAYAFLUX_API GeometryFn<float> radial(
+[[nodiscard]] MAYAFLUX_API Form<float> radial(
     Kinesis::AABB2D region,
     float angle_start,
     float angle_end,
@@ -196,7 +198,7 @@ template <typename T>
  * @param size       Point size in pixels.
  * @param hit_radius Hit region radius in NDC units.
  */
-[[nodiscard]] MAYAFLUX_API GeometryFn<glm::vec2> point(
+[[nodiscard]] MAYAFLUX_API Form<glm::vec2> point(
     glm::vec3 color = glm::vec3(1.0F),
     float size = 10.0F,
     float hit_radius = 0.04F);
@@ -214,7 +216,7 @@ template <typename T>
  * @param color  Point color.
  * @param size   Point size in pixels.
  */
-[[nodiscard]] MAYAFLUX_API GeometryFn<glm::vec2> position_picker(
+[[nodiscard]] MAYAFLUX_API Form<glm::vec2> position_picker(
     Kinesis::AABB2D bounds,
     glm::vec3 color = glm::vec3(0.9F),
     float size = 8.0F);
@@ -256,7 +258,7 @@ template <typename T>
  * @param handle_color   Color of the handle point.
  * @param handle_size    Handle point size in pixels.
  */
-[[nodiscard]] MAYAFLUX_API GeometryFn<float> stroke_slider(
+[[nodiscard]] MAYAFLUX_API Form<float> stroke_slider(
     std::span<const glm::vec2> path,
     std::shared_ptr<Buffers::FormaBuffer> handle_buf,
     float half_thickness = 0.02F,
@@ -290,7 +292,7 @@ template <typename T>
  * @param color_off Fill color when false.
  * @param color_on  Fill color when true.
  */
-[[nodiscard]] MAYAFLUX_API GeometryFn<bool> toggle(
+[[nodiscard]] MAYAFLUX_API Form<bool> toggle(
     Kinesis::AABB2D region,
     glm::vec3 color_off = glm::vec3(0.25F),
     glm::vec3 color_on = glm::vec3(0.2F, 0.7F, 0.4F));
@@ -319,7 +321,7 @@ template <typename T>
  * @param fill_color  Color of the active (filled) portion.
  * @param track_color Color of the inactive remainder.
  */
-[[nodiscard]] MAYAFLUX_API GeometryFn<float> level_meter(
+[[nodiscard]] MAYAFLUX_API Form<float> level_meter(
     Kinesis::AABB2D bounds,
     bool horizontal = true,
     glm::vec3 fill_color = glm::vec3(0.2F, 0.7F, 0.3F),
@@ -343,11 +345,8 @@ template <typename T>
  * @param color      Line color.
  * @param thickness  Line thickness (maps to LineVertex::thickness).
  * @param hit_radius Hit region radius in NDC units.
- *
- * @note Pass @c PrimitiveTopology::LINE_LIST explicitly to create_element —
- *       the default TRIANGLE_STRIP will misinterpret the 4 vertices.
  */
-[[nodiscard]] MAYAFLUX_API GeometryFn<glm::vec2> crosshair(
+[[nodiscard]] MAYAFLUX_API Form<glm::vec2> crosshair(
     float arm_len = 0.04F,
     glm::vec3 color = glm::vec3(0.9F),
     float thickness = 1.F,
@@ -388,7 +387,7 @@ template <typename T>
  * @param color       Line color.
  * @param thickness   LineVertex thickness value.
  */
-[[nodiscard]] MAYAFLUX_API GeometryFn<std::vector<float>> drawable_canvas(
+[[nodiscard]] MAYAFLUX_API Form<std::vector<float>> drawable_canvas(
     Kinesis::AABB2D bounds,
     glm::vec3 color = glm::vec3(0.8F),
     float thickness = 1.5F);

--- a/src/MayaFlux/Portal/Forma/Primitives/FormFactory.hpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/FormFactory.hpp
@@ -102,6 +102,21 @@ template <typename T>
     };
 }
 
+/**
+ * @brief Produce a Form::wire that writes the cursor position on hover.
+ *
+ * No button held. For geometry whose value is an NDC position rather than
+ * a normalized parameter.
+ */
+[[nodiscard]] inline auto follow_move()
+{
+    return [](Context& ctx, uint32_t id, std::shared_ptr<MappedState<glm::vec2>> state) {
+        ctx.on_move(id, [state = std::move(state)](uint32_t, glm::vec2 ndc) {
+            state->write(ndc);
+        });
+    };
+}
+
 // =============================================================================
 // Horizontal fader
 //

--- a/src/MayaFlux/Portal/Forma/Primitives/Geometry.cpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/Geometry.cpp
@@ -83,6 +83,17 @@ GeometryFn<float> radial(
     };
 }
 
+GeometryFn<float> radial(
+    Kinesis::AABB2D region,
+    float angle_start,
+    float angle_end,
+    glm::vec3 color)
+{
+    return radial(region.center(),
+        std::min(region.width(), region.height()) * 0.5F,
+        angle_start, angle_end, color);
+}
+
 GeometryFn<glm::vec2> point(
     glm::vec3 color,
     float size,

--- a/src/MayaFlux/Portal/Forma/Primitives/Geometry.hpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/Geometry.hpp
@@ -118,6 +118,15 @@ struct Form {
         , wire(std::move(w))
     {
     }
+
+    /**
+     * @brief Implicit conversion to the underlying geometry function.
+     *
+     * This allows a Form to be passed directly to create_element, which
+     * accepts a GeometryFn. The default topology and capacity are used,
+     * and no interaction is registered.
+     */
+    operator const GeometryFn<T>&() const& { return geometry; }
 };
 
 /**

--- a/src/MayaFlux/Portal/Forma/Primitives/Geometry.hpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/Geometry.hpp
@@ -60,402 +60,90 @@ void write_verts(std::vector<uint8_t>& out, const V& v)
     std::memcpy(out.data(), &v, sizeof(v));
 }
 
-// =============================================================================
-// Horizontal fader
-//
-// Value in [0, 1] moves a handle quad along a track quad.
-// Two quads: track (static) and handle (value-driven).
-// Both written as TRIANGLE_STRIP pairs into a single buffer.
-//
-// Track: full extent of bounds.
-// Handle: small square at x = bounds.min.x + value * bounds.width().
-//
-// Hit region follows the handle, updated on every sync().
-// =============================================================================
+/**
+ * @struct Form
+ * @brief A geometry function plus everything its realization requires.
+ *
+ * A geometry function alone is not enough to construct an element. Its
+ * topology is fixed by the vertex kind it writes, its capacity by the
+ * vertex count, and its interaction by the forward placement it performs.
+ * All three are knowledge the geometry factory already has and the call
+ * site would otherwise restate. Form carries them together.
+ *
+ * Nothing enumerates the set of Forms. Any function returning one
+ * participates on equal footing with those in FormFactory.hpp, including
+ * ones written by the caller. There is no dispatch and no registry.
+ *
+ * A bare GeometryFn converts implicitly, yielding default topology,
+ * default capacity, and no interaction.
+ *
+ * @tparam T MappedState value type driving the geometry.
+ */
+template <typename T>
+struct Form {
+    /// @brief Writes vertex bytes for the current value.
+    GeometryFn<T> geometry;
+
+    /// @brief Topology matching the vertex kind @c geometry writes.
+    Graphics::PrimitiveTopology topology { Graphics::PrimitiveTopology::TRIANGLE_STRIP };
+
+    /// @brief FormaBuffer capacity in bytes for the vertex count @c geometry writes.
+    size_t capacity { 4096 };
+
+    /**
+     * @brief Registers interaction against the realized element.
+     *
+     * Called once after the element is registered, with the Context that
+     * owns its callbacks, the element id, and the state to write. Empty
+     * for non-interactive geometry.
+     */
+    std::function<void(Context&, uint32_t, std::shared_ptr<MappedState<T>>)> wire;
+
+    Form() = default;
+
+    /**
+     * @brief Adopt a bare geometry function with default topology and
+     *        capacity and no interaction.
+     */
+    Form(GeometryFn<T> fn)
+        : geometry(std::move(fn))
+    {
+    }
+
+    Form(GeometryFn<T> fn, Graphics::PrimitiveTopology topo, size_t cap,
+        std::function<void(Context&, uint32_t, std::shared_ptr<MappedState<T>>)> w = {})
+        : geometry(std::move(fn))
+        , topology(topo)
+        , capacity(cap)
+        , wire(std::move(w))
+    {
+    }
+};
 
 /**
- * @brief Geometry function for a horizontal fader in NDC space.
- * @param bounds      Full extent of the fader in NDC.
- * @param handle_w    Handle width in NDC units.
- * @param track_color Track quad color.
- * @param handle_color Handle quad color.
+ * @brief Call a bounds-taking factory with an anchor's region.
+ *
+ * Any factory whose first parameter is a Kinesis::AABB2D accepts any
+ * Kinesis::HasBounds object through this, including factories written by
+ * the caller. Nothing is enumerated and no geometry is privileged.
+ *
+ * Trailing factory defaults still apply; arguments passed here are
+ * forwarded in order after the derived bounds.
+ *
+ * @code
+ * auto fader = Forma::create(surface, Geometry::horizontal_fader(track, 0.04F), 0.5F);
+ * auto meter = Forma::create(surface, Geometry::at(fader, Geometry::level_meter), 0.F);
+ * @endcode
+ *
+ * @param anchor  Any object exposing bounds().
+ * @param factory Factory taking Kinesis::AABB2D as its first parameter.
+ * @param args    Remaining factory arguments.
  */
-[[nodiscard]] MAYAFLUX_API GeometryFn<float> horizontal_fader(
-    Kinesis::AABB2D bounds,
-    float handle_w,
-    glm::vec3 track_color = glm::vec3(0.3F),
-    glm::vec3 handle_color = glm::vec3(0.9F));
-
-// =============================================================================
-// Vertical fader
-//
-// Symmetric counterpart to horizontal_fader. Value in [0, 1] moves a handle
-// quad upward along a track quad.
-//
-// Track: thin vertical band through the center of bounds.
-// Handle: small square at y = bounds.min.y + value * (bounds.height() - handle_h).
-//
-// Hit region follows the handle, updated on every sync().
-// Topology: TRIANGLE_STRIP (two quad pairs via to_mesh_vertices).
-// =============================================================================
-
-/**
- * @brief Geometry function for a vertical fader in NDC space.
- * @param bounds       Full extent of the fader in NDC.
- * @param handle_h     Handle height in NDC units.
- * @param track_color  Track quad color.
- * @param handle_color Handle quad color.
- */
-[[nodiscard]] MAYAFLUX_API GeometryFn<float> vertical_fader(
-    Kinesis::AABB2D bounds,
-    float handle_h,
-    glm::vec3 track_color = glm::vec3(0.3F),
-    glm::vec3 handle_color = glm::vec3(0.9F));
-
-// =============================================================================
-// Radial / arc
-//
-// Value in [0, 1] sweeps an indicator line around a center point.
-// angle_start and angle_end in radians, measured from +X, CCW.
-// Produces a LINE_LIST of two vertices: center to indicator tip.
-// =============================================================================
-
-/**
- * @brief Geometry function for a radial indicator in NDC space.
- * @param center      Arc center in NDC.
- * @param radius      Arc radius in NDC units.
- * @param angle_start Start angle in radians (value = 0).
- * @param angle_end   End angle in radians (value = 1).
- * @param color       Line color.
- */
-[[nodiscard]] MAYAFLUX_API GeometryFn<float> radial(
-    glm::vec2 center,
-    float radius,
-    float angle_start,
-    float angle_end,
-    glm::vec3 color = glm::vec3(0.9F));
-
-/**
- * @brief Region-taking radial indicator.
- *
- * Centers the arc on @p region and derives the radius from the region's
- * smaller half-extent, so the sweep is inscribed regardless of aspect.
- *
- * @param region      NDC region the arc is inscribed in.
- * @param angle_start Start angle in radians (value = 0).
- * @param angle_end   End angle in radians (value = 1).
- * @param color       Line color.
- */
-[[nodiscard]] MAYAFLUX_API GeometryFn<float> radial(
-    Kinesis::AABB2D region,
-    float angle_start,
-    float angle_end,
-    glm::vec3 color = glm::vec3(0.9F));
-
-// =============================================================================
-// Point
-//
-// Value is glm::vec2 in NDC space. Produces a single POINT_LIST vertex.
-// Hit region is a circle centered on the point.
-// Use as a cursor follower, node handle, or any positioned point primitive.
-// =============================================================================
-
-/**
- * @brief Geometry function for a positioned point in NDC space.
- *
- * Value type is glm::vec2 (NDC position). Renders a single PointVertex
- * and sets a circular hit region centered on the position. Suitable as
- * a cursor follower, node handle, or any draggable point primitive.
- *
- * @param color      Point color.
- * @param size       Point size in pixels.
- * @param hit_radius Hit region radius in NDC units.
- */
-[[nodiscard]] MAYAFLUX_API GeometryFn<glm::vec2> point(
-    glm::vec3 color = glm::vec3(1.0F),
-    float size = 10.0F,
-    float hit_radius = 0.04F);
-
-// =============================================================================
-// 2D position picker
-//
-// Value is glm::vec2 in [0,1]x[0,1], mapped to a point inside bounds.
-// Produces a single POINT_LIST vertex at the mapped position.
-// =============================================================================
-
-/**
- * @brief Geometry function for a 2D position picker in NDC space.
- * @param bounds Full extent of the pick area in NDC.
- * @param color  Point color.
- * @param size   Point size in pixels.
- */
-[[nodiscard]] MAYAFLUX_API GeometryFn<glm::vec2> position_picker(
-    Kinesis::AABB2D bounds,
-    glm::vec3 color = glm::vec3(0.9F),
-    float size = 8.0F);
-
-// =============================================================================
-// Stroke slider
-//
-// Value in [0, 1] positions a handle point along a user-supplied polyline.
-// Renders two layers: the full path as a LINE_LIST in track_color, a
-// highlighted prefix segment from path start to the handle position in
-// fill_color, and a PointVertex handle on a caller-supplied secondary buffer.
-//
-// The secondary buffer must be a POINT_LIST FormaBuffer registered with the
-// same BufferManager and window before this function is called. The caller
-// adds it as a separate Element and relates it to the path element via
-// Layer::relate_to so removal and visibility cascade.
-//
-// Hit region: stroke_bounds over the full path at half_thickness.
-// bounds_hint: tight AABB enclosing all path points.
-//
-// Topology for the path buffer: LINE_LIST.
-// Topology for the handle buffer: POINT_LIST.
-// =============================================================================
-
-/**
- * @brief Geometry function for a value scrubber along an arbitrary polyline.
- *
- * Value in [0, 1] maps to arc-length position along @p path. The full path
- * is rendered as a LINE_LIST in @p track_color; the prefix from the path
- * start to the handle position is rendered in @p fill_color. The handle
- * itself is a PointVertex submitted to @p handle_buf each sync.
- *
- * @param path           Ordered polyline vertices in NDC. Copied into closure.
- * @param handle_buf     POINT_LIST FormaBuffer for the handle point.
- *                       Must be registered and have setup_rendering called.
- * @param half_thickness Hit region half-thickness in NDC units.
- * @param track_color    Color of the full path.
- * @param fill_color     Color of the prefix segment up to the handle.
- * @param handle_color   Color of the handle point.
- * @param handle_size    Handle point size in pixels.
- */
-[[nodiscard]] MAYAFLUX_API GeometryFn<float> stroke_slider(
-    std::span<const glm::vec2> path,
-    std::shared_ptr<Buffers::FormaBuffer> handle_buf,
-    float half_thickness = 0.02F,
-    glm::vec3 track_color = glm::vec3(0.3F),
-    glm::vec3 fill_color = glm::vec3(0.2F, 0.6F, 1.0F),
-    glm::vec3 handle_color = glm::vec3(0.95F),
-    float handle_size = 10.0F);
-
-// =============================================================================
-// Toggle
-//
-// Value type: bool. Renders a filled rect in one of two colors.
-// The geometry function is purely visual — it carries no interaction.
-// The caller wires on_press to flip state->value:
-//
-//   surface.ctx().on_press(el.element.id, IO::MouseButtons::Left,
-//       [state = el.state](uint32_t, glm::vec2) {
-//           state->write(!state->value);
-//       });
-//
-// Topology: TRIANGLE_STRIP (4 MeshVertex via to_mesh_vertices).
-// =============================================================================
-
-/**
- * @brief Geometry function for a boolean toggle in NDC space.
- *
- * Renders @p region as a filled rect in @p color_off or @p color_on based
- * on the current bool value. Interaction is the caller's responsibility.
- *
- * @param region    NDC bounds of the toggle.
- * @param color_off Fill color when false.
- * @param color_on  Fill color when true.
- */
-[[nodiscard]] MAYAFLUX_API GeometryFn<bool> toggle(
-    Kinesis::AABB2D region,
-    glm::vec3 color_off = glm::vec3(0.25F),
-    glm::vec3 color_on = glm::vec3(0.2F, 0.7F, 0.4F));
-
-// =============================================================================
-// Level meter
-//
-// Value type: float in [0, 1]. Renders a filled bar from the origin edge of
-// bounds proportional to the value, with the remainder as a second color.
-// No handle, no hit region. Suitable for audio level, progress, any scalar readout.
-//
-// Orientation:
-//   horizontal = true  - bar grows left to right
-//   horizontal = false - bar grows bottom to top
-//
-// Topology: TRIANGLE_STRIP (two quad pairs via to_mesh_vertices).
-// =============================================================================
-
-/**
- * @brief Geometry function for a level meter in NDC space.
- *
- * No interaction. Drive from a node via bridge().at(el.state).bind(node).
- *
- * @param bounds      Full extent of the meter in NDC.
- * @param horizontal  True for left-to-right fill, false for bottom-to-top.
- * @param fill_color  Color of the active (filled) portion.
- * @param track_color Color of the inactive remainder.
- */
-[[nodiscard]] MAYAFLUX_API GeometryFn<float> level_meter(
-    Kinesis::AABB2D bounds,
-    bool horizontal = true,
-    glm::vec3 fill_color = glm::vec3(0.2F, 0.7F, 0.3F),
-    glm::vec3 track_color = glm::vec3(0.15F));
-
-// =============================================================================
-// Crosshair
-//
-// Value type: glm::vec2 (NDC position). Renders two LINE_LIST segments —
-// horizontal and vertical — crossing at the value position.
-// Hit region: circle centered on the position.
-//
-// Pairs naturally with position_picker sharing the same MappedState<glm::vec2>.
-// Topology: LINE_LIST (4 LineVertex).
-// =============================================================================
-
-/**
- * @brief Geometry function for a crosshair indicator in NDC space.
- *
- * @param arm_len    Half-length of each arm in NDC units.
- * @param color      Line color.
- * @param thickness  Line thickness (maps to LineVertex::thickness).
- * @param hit_radius Hit region radius in NDC units.
- *
- * @note Pass @c PrimitiveTopology::LINE_LIST explicitly to create_element —
- *       the default TRIANGLE_STRIP will misinterpret the 4 vertices.
- */
-[[nodiscard]] MAYAFLUX_API GeometryFn<glm::vec2> crosshair(
-    float arm_len = 0.04F,
-    glm::vec3 color = glm::vec3(0.9F),
-    float thickness = 1.F,
-    float hit_radius = 0.05F);
-
-// =============================================================================
-// Drawable canvas
-//
-// value is vector<float> of N samples in [0, 1] mapped to the Y axis.
-// X positions are distributed evenly across bounds.
-// Renders as LINE_LIST: N-1 segments connecting adjacent samples.
-//
-// on_drag callback pattern:
-//   ctx->on_drag(el.element.id, IO::MouseButtons::Left,
-//       [&el, bounds](uint32_t, glm::vec2 ndc) {
-//           auto& v = el.state->value;
-//           const float t = (ndc.x - bounds.min.x) / bounds.width();
-//           const size_t i = static_cast<size_t>(
-//               std::clamp(t, 0.F, 1.F) * (v.size() - 1));
-//           const float a = (ndc.y - bounds.min.y) / bounds.height();
-//           v[i] = std::clamp(a, 0.F, 1.F);
-//           ++el.state->version;
-//       });
-//
-// For sparse-sample prevention at high drag speed, interpolate between the
-// previous and current index before calling state->write().
-//
-// Topology: LINE_LIST.
-// =============================================================================
-
-/**
- * @brief Geometry function for a drawable curve canvas in NDC space.
- *
- * Renders the sample vector as a LINE_LIST polyline. Each adjacent sample
- * pair becomes one segment. The hit region covers the full canvas bounds.
- *
- * @param bounds      Canvas extent in NDC.
- * @param color       Line color.
- * @param thickness   LineVertex thickness value.
- */
-[[nodiscard]] MAYAFLUX_API GeometryFn<std::vector<float>> drawable_canvas(
-    Kinesis::AABB2D bounds,
-    glm::vec3 color = glm::vec3(0.8F),
-    float thickness = 1.5F);
-
-/**
- * @brief Wire drag interaction for a drawable canvas element.
- *
- * Registers a left-button drag callback on @p ctx that maps NDC cursor
- * position to a sample index and amplitude, writes into @p state, and
- * increments the version. Linear interpolation fills the range between the
- * previously touched index and the current one, preventing sparse samples
- * under fast drag.
- *
- * @param ctx     Context owning the element.
- * @param id      Element id from the Mapped.
- * @param state   MappedState<vector<float>> to write into.
- * @param bounds  Canvas NDC bounds — must match those passed to drawable_canvas().
- */
-MAYAFLUX_API void wire_canvas_drag(
-    Context& ctx,
-    uint32_t id,
-    std::shared_ptr<MappedState<std::vector<float>>> state,
-    Kinesis::AABB2D bounds);
-
-// =============================================================================
-// HasBounds overloads
-//
-// Thin wrappers accepting any Kinesis::HasBounds anchor in place of an
-// explicit AABB2D. Kinesis::AABB2D does not satisfy HasBounds, so these
-// never compete with the primaries above.
-// =============================================================================
-
-template <Kinesis::HasBounds B>
-[[nodiscard]] GeometryFn<float> horizontal_fader(
-    const B& anchor, float handle_w,
-    glm::vec3 track_color = glm::vec3(0.3F),
-    glm::vec3 handle_color = glm::vec3(0.9F))
+template <Kinesis::HasBounds B, typename F, typename... Args>
+[[nodiscard]] auto at(const B& anchor, F&& factory, Args&&... args)
+    -> decltype(std::forward<F>(factory)(Kinesis::bounds_of(anchor), std::forward<Args>(args)...))
 {
-    return horizontal_fader(Kinesis::bounds_of(anchor), handle_w, track_color, handle_color);
-}
-
-template <Kinesis::HasBounds B>
-[[nodiscard]] GeometryFn<float> vertical_fader(
-    const B& anchor, float handle_h,
-    glm::vec3 track_color = glm::vec3(0.3F),
-    glm::vec3 handle_color = glm::vec3(0.9F))
-{
-    return vertical_fader(Kinesis::bounds_of(anchor), handle_h, track_color, handle_color);
-}
-
-template <Kinesis::HasBounds B>
-[[nodiscard]] GeometryFn<bool> toggle(
-    const B& anchor,
-    glm::vec3 color_off = glm::vec3(0.25F),
-    glm::vec3 color_on = glm::vec3(0.2F, 0.7F, 0.4F))
-{
-    return toggle(Kinesis::bounds_of(anchor), color_off, color_on);
-}
-
-template <Kinesis::HasBounds B>
-[[nodiscard]] GeometryFn<float> level_meter(
-    const B& anchor, bool horizontal = true,
-    glm::vec3 fill_color = glm::vec3(0.2F, 0.7F, 0.3F),
-    glm::vec3 track_color = glm::vec3(0.15F))
-{
-    return level_meter(Kinesis::bounds_of(anchor), horizontal, fill_color, track_color);
-}
-
-template <Kinesis::HasBounds B>
-[[nodiscard]] GeometryFn<glm::vec2> position_picker(
-    const B& anchor,
-    glm::vec3 color = glm::vec3(0.9F),
-    float size = 8.0F)
-{
-    return position_picker(Kinesis::bounds_of(anchor), color, size);
-}
-
-template <Kinesis::HasBounds B>
-[[nodiscard]] GeometryFn<std::vector<float>> drawable_canvas(
-    const B& anchor,
-    glm::vec3 color = glm::vec3(0.8F),
-    float thickness = 1.5F)
-{
-    return drawable_canvas(Kinesis::bounds_of(anchor), color, thickness);
-}
-
-template <Kinesis::HasBounds B>
-[[nodiscard]] GeometryFn<float> radial(
-    const B& anchor, float angle_start, float angle_end,
-    glm::vec3 color = glm::vec3(0.9F))
-{
-    return radial(Kinesis::bounds_of(anchor), angle_start, angle_end, color);
+    return std::forward<F>(factory)(Kinesis::bounds_of(anchor), std::forward<Args>(args)...);
 }
 
 } // namespace MayaFlux::Portal::Forma::Geometry

--- a/src/MayaFlux/Portal/Forma/Primitives/Geometry.hpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/Geometry.hpp
@@ -135,6 +135,23 @@ void write_verts(std::vector<uint8_t>& out, const V& v)
     float angle_end,
     glm::vec3 color = glm::vec3(0.9F));
 
+/**
+ * @brief Region-taking radial indicator.
+ *
+ * Centers the arc on @p region and derives the radius from the region's
+ * smaller half-extent, so the sweep is inscribed regardless of aspect.
+ *
+ * @param region      NDC region the arc is inscribed in.
+ * @param angle_start Start angle in radians (value = 0).
+ * @param angle_end   End angle in radians (value = 1).
+ * @param color       Line color.
+ */
+[[nodiscard]] MAYAFLUX_API GeometryFn<float> radial(
+    Kinesis::AABB2D region,
+    float angle_start,
+    float angle_end,
+    glm::vec3 color = glm::vec3(0.9F));
+
 // =============================================================================
 // Point
 //
@@ -370,5 +387,75 @@ MAYAFLUX_API void wire_canvas_drag(
     uint32_t id,
     std::shared_ptr<MappedState<std::vector<float>>> state,
     Kinesis::AABB2D bounds);
+
+// =============================================================================
+// HasBounds overloads
+//
+// Thin wrappers accepting any Kinesis::HasBounds anchor in place of an
+// explicit AABB2D. Kinesis::AABB2D does not satisfy HasBounds, so these
+// never compete with the primaries above.
+// =============================================================================
+
+template <Kinesis::HasBounds B>
+[[nodiscard]] GeometryFn<float> horizontal_fader(
+    const B& anchor, float handle_w,
+    glm::vec3 track_color = glm::vec3(0.3F),
+    glm::vec3 handle_color = glm::vec3(0.9F))
+{
+    return horizontal_fader(Kinesis::bounds_of(anchor), handle_w, track_color, handle_color);
+}
+
+template <Kinesis::HasBounds B>
+[[nodiscard]] GeometryFn<float> vertical_fader(
+    const B& anchor, float handle_h,
+    glm::vec3 track_color = glm::vec3(0.3F),
+    glm::vec3 handle_color = glm::vec3(0.9F))
+{
+    return vertical_fader(Kinesis::bounds_of(anchor), handle_h, track_color, handle_color);
+}
+
+template <Kinesis::HasBounds B>
+[[nodiscard]] GeometryFn<bool> toggle(
+    const B& anchor,
+    glm::vec3 color_off = glm::vec3(0.25F),
+    glm::vec3 color_on = glm::vec3(0.2F, 0.7F, 0.4F))
+{
+    return toggle(Kinesis::bounds_of(anchor), color_off, color_on);
+}
+
+template <Kinesis::HasBounds B>
+[[nodiscard]] GeometryFn<float> level_meter(
+    const B& anchor, bool horizontal = true,
+    glm::vec3 fill_color = glm::vec3(0.2F, 0.7F, 0.3F),
+    glm::vec3 track_color = glm::vec3(0.15F))
+{
+    return level_meter(Kinesis::bounds_of(anchor), horizontal, fill_color, track_color);
+}
+
+template <Kinesis::HasBounds B>
+[[nodiscard]] GeometryFn<glm::vec2> position_picker(
+    const B& anchor,
+    glm::vec3 color = glm::vec3(0.9F),
+    float size = 8.0F)
+{
+    return position_picker(Kinesis::bounds_of(anchor), color, size);
+}
+
+template <Kinesis::HasBounds B>
+[[nodiscard]] GeometryFn<std::vector<float>> drawable_canvas(
+    const B& anchor,
+    glm::vec3 color = glm::vec3(0.8F),
+    float thickness = 1.5F)
+{
+    return drawable_canvas(Kinesis::bounds_of(anchor), color, thickness);
+}
+
+template <Kinesis::HasBounds B>
+[[nodiscard]] GeometryFn<float> radial(
+    const B& anchor, float angle_start, float angle_end,
+    glm::vec3 color = glm::vec3(0.9F))
+{
+    return radial(Kinesis::bounds_of(anchor), angle_start, angle_end, color);
+}
 
 } // namespace MayaFlux::Portal::Forma::Geometry

--- a/src/MayaFlux/Portal/Forma/Primitives/LayoutCursor.hpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/LayoutCursor.hpp
@@ -24,7 +24,20 @@ public:
     {
     }
 
-    explicit LayoutCursor(float y_start)
+    /**
+     * @brief Construct a cursor at @p y_start scoped to a horizontal column.
+     *
+     * Bounds returned by advance() span [@p x_min, @p x_max] rather than the
+     * full NDC width. The default extents reproduce the previous behaviour,
+     * so existing call sites are unaffected.
+     *
+     * @param y_start Starting NDC Y baseline.
+     * @param x_min   Left edge of the column in NDC.
+     * @param x_max   Right edge of the column in NDC.
+     */
+    explicit LayoutCursor(float y_start, float x_min = -1.F, float x_max = 1.F)
+        : m_x_min(x_min)
+        , m_x_max(x_max)
     {
         m_state = std::make_shared<MappedState<float>>();
         m_state->write(y_start);
@@ -38,16 +51,37 @@ public:
 
     [[nodiscard]] float y() const { return m_state->value; }
 
+    [[nodiscard]] float x_min() const noexcept { return m_x_min; }
+    [[nodiscard]] float x_max() const noexcept { return m_x_max; }
+
+    /**
+     * @brief Reset both cursors to the lower of their two current Y values.
+     *
+     * Used after a row spanning several columns so that independent column
+     * cursors resume from a common baseline.
+     *
+     * @note LayoutCursor copies share one MappedState. Calling sync_to on two
+     *       cursors copied from one another is a no-op, since both already
+     *       reference the same baseline.
+     */
+    void sync_to(LayoutCursor& other)
+    {
+        const float y = std::min(m_state->value, other.m_state->value);
+        m_state->write(y);
+        other.m_state->write(y);
+    }
+
     /**
      * @brief Advance the cursor downward by @p height and return the NDC
-     *        AABB occupied by the primitive just placed.
+     *        AABB occupied by the primitive just placed, scoped to the
+     *        cursor's column extents.
      */
     Kinesis::AABB2D advance(float height)
     {
         const float top = m_state->value;
         const float bot = top - height;
         m_state->write(bot);
-        return Kinesis::AABB2D { .min = { -1.F, bot }, .max = { 1.F, top } };
+        return Kinesis::AABB2D { .min = { m_x_min, bot }, .max = { m_x_max, top } };
     }
 
     /**
@@ -63,6 +97,8 @@ public:
 
 private:
     std::shared_ptr<MappedState<float>> m_state;
+    float m_x_min { -1.F };
+    float m_x_max { 1.F };
 };
 
 } // namespace MayaFlux::Portal::Forma

--- a/src/MayaFlux/Portal/Forma/Primitives/Mapped.hpp
+++ b/src/MayaFlux/Portal/Forma/Primitives/Mapped.hpp
@@ -107,6 +107,17 @@ struct Mapped {
     bool force_redraw_on_sync { false };
 
     /**
+     * @brief Current spatial footprint, satisfying Kinesis::HasBounds.
+     *
+     * Returns the element's bounds_hint as last written by the geometry
+     * function, or a zero region when the geometry function sets none.
+     */
+    [[nodiscard]] Kinesis::AABB2D bounds() const noexcept
+    {
+        return element.bounds_hint.value_or(Kinesis::AABB2D {});
+    }
+
+    /**
      * @brief Call once per graphics tick.
      *
      * If state->version has advanced since last_version, invokes geometry_fn

--- a/src/MayaFlux/Portal/Forma/Surface.hpp
+++ b/src/MayaFlux/Portal/Forma/Surface.hpp
@@ -157,6 +157,91 @@ public:
      */
     Layer::Slot add(Element element) { return m_layer->add(std::move(element)); }
 
+    // =========================================================================
+    // Named regions
+    // =========================================================================
+
+    /**
+     * @brief Rect of size (@p w, @p h) at the top-left corner, inset by @p margin.
+     * @param w      Width in NDC units.
+     * @param h      Height in NDC units.
+     * @param margin Inset from both screen edges in NDC units.
+     */
+    [[nodiscard]] Kinesis::AABB2D top_left(float w, float h, float margin = 0.02F) const noexcept
+    {
+        return { .min = { -1.F + margin, 1.F - margin - h },
+            .max = { -1.F + margin + w, 1.F - margin } };
+    }
+
+    /// @copydoc top_left
+    [[nodiscard]] Kinesis::AABB2D top_right(float w, float h, float margin = 0.02F) const noexcept
+    {
+        return { .min = { 1.F - margin - w, 1.F - margin - h },
+            .max = { 1.F - margin, 1.F - margin } };
+    }
+
+    /// @copydoc top_left
+    [[nodiscard]] Kinesis::AABB2D bottom_left(float w, float h, float margin = 0.02F) const noexcept
+    {
+        return { .min = { -1.F + margin, -1.F + margin },
+            .max = { -1.F + margin + w, -1.F + margin + h } };
+    }
+
+    /// @copydoc top_left
+    [[nodiscard]] Kinesis::AABB2D bottom_right(float w, float h, float margin = 0.02F) const noexcept
+    {
+        return { .min = { 1.F - margin - w, -1.F + margin },
+            .max = { 1.F - margin, -1.F + margin + h } };
+    }
+
+    /**
+     * @brief Full-width strip of height @p h along the top edge.
+     * @param h      Strip height in NDC units.
+     * @param margin Inset from the top and side edges in NDC units.
+     */
+    [[nodiscard]] Kinesis::AABB2D top_strip(float h, float margin = 0.F) const noexcept
+    {
+        return { .min = { -1.F + margin, 1.F - margin - h },
+            .max = { 1.F - margin, 1.F - margin } };
+    }
+
+    /// @copydoc top_strip
+    [[nodiscard]] Kinesis::AABB2D bottom_strip(float h, float margin = 0.F) const noexcept
+    {
+        return { .min = { -1.F + margin, -1.F + margin },
+            .max = { 1.F - margin, -1.F + margin + h } };
+    }
+
+    /**
+     * @brief Full-height strip of width @p w along the left edge.
+     * @param w      Strip width in NDC units.
+     * @param margin Inset from the left and vertical edges in NDC units.
+     */
+    [[nodiscard]] Kinesis::AABB2D left_strip(float w, float margin = 0.F) const noexcept
+    {
+        return { .min = { -1.F + margin, -1.F + margin },
+            .max = { -1.F + margin + w, 1.F - margin } };
+    }
+
+    /// @copydoc left_strip
+    [[nodiscard]] Kinesis::AABB2D right_strip(float w, float margin = 0.F) const noexcept
+    {
+        return { .min = { 1.F - margin - w, -1.F + margin },
+            .max = { 1.F - margin, 1.F - margin } };
+    }
+
+    /// @brief Rect of size (@p w, @p h) centered on the NDC origin.
+    [[nodiscard]] Kinesis::AABB2D center_rect(float w, float h) const noexcept
+    {
+        return { .min = { -w * 0.5F, -h * 0.5F }, .max = { w * 0.5F, h * 0.5F } };
+    }
+
+    /// @brief The entire NDC surface.
+    [[nodiscard]] Kinesis::AABB2D full() const noexcept
+    {
+        return { .min = glm::vec2(-1.F), .max = glm::vec2(1.F) };
+    }
+
 private:
     std::shared_ptr<Core::Window> m_window;
     std::shared_ptr<Layer> m_layer;


### PR DESCRIPTION
Building a fader in Forma used to take four calls: create the element, pass the topology, register the drag, wire the output. Three of those four were things the geometry function already knew. `horizontal_fader(track, 0.04F)` knows it writes eight `MeshVertex` as a triangle strip. It knows the handle travels `width - handle_w`, so it knows the inverse mapping a drag needs. None of that reached the call site, so the call site restated it, and restated it slightly wrong: the drag mapping documented and used everywhere divided by the full track width, putting the handle up to half a handle off the cursor at both extremes.

`Form<T>` is that knowledge, carried:

```cpp
template <typename T>
struct Form {
    GeometryFn<T> geometry;
    Portal::Graphics::PrimitiveTopology topology;
    size_t capacity;
    std::function<void(Context&, uint32_t, std::shared_ptr<MappedState<T>>)> wire;
};
```

and `Forma::create` realizes one:

```cpp
auto el = Portal::Forma::create(surface, Geometry::horizontal_fader(track, 0.04F), 0.5F);
```

One call. Correct topology, buffer sized to the vertex count, drag with the right inverse.

## Why this is not a widget layer

The obvious way to get one-call controls is `Forma::Fader{}.label(...).range(...).place(surface, bounds)`. We did not do that, and the reason matters.

A widget type encapsulates nothing. It sequences calls the user could sequence themselves, and every variation on the sequence becomes a parameter or a new type. Nine sliders to a UBO and one to a Constant node. Eight sliders and two toggles at different heights. Each case either grows the facade or forces the user back out of it, and at that point they are learning the facade rather than the substrate.

`Form` encapsulates something real: the correspondence between a forward placement and its inverse. That correspondence is a computation with a right answer, and it lives next to the code that defines the forward direction.

The test for anything new here is whether it computes something, not whether it saves typing.

## Nothing is privileged

There is no enum, no registry, no switch, no list of supported controls. `Form<T>` is a plain struct with public fields. Any function returning one participates identically to the shipped factories:

```cpp
Form<float> my_ring(Kinesis::AABB2D region, float thickness, glm::vec3 color);

auto ring = Portal::Forma::create(surface, my_ring(region, 0.01F, color), 0.F);
```

A bare `GeometryFn<T>` converts implicitly, so custom geometry passes to `create` unchanged and gets defaults.

Every field is overridable before realization, which is the escape hatch the whole design rests on:

```cpp
auto form = Geometry::horizontal_fader(track, 0.04F);
form.wire = Geometry::drag_with<float>(
    Kinesis::scaled(Kinesis::axis_fraction(track, 0.04F), 20.F, 20000.F));

auto cutoff = Portal::Forma::create(surface, std::move(form), 440.F);
```

or `form.wire = {}` to take interaction back entirely.

## Projections are separate and pure

`Kinesis/Spatial/Projection.hpp` holds the inverses: `axis_fraction`, `unit_square`, `angle_fraction`, `path_fraction`, and `scaled` for composing a range onto any of them. No window, no element, no context. They are testable standalone and they compose:

```cpp
Kinesis::scaled(Kinesis::axis_fraction(track, 0.04F), 20.F, 20000.F)
```

They are 2D today and the file is named for what it is, so 3D variants land alongside without a rename.

## Anchoring and layout

Element placement was NDC arithmetic at every call site. Three additions:

`Kinesis::place(anchor, Side, w, h, gap, Align)` positions a region against another. `Side` is `Right`, `Left`, `Above`, `Below`, `Over`; `Align` is `Center`, `Start`, `End`, `Span`. One function rather than nine named variants, because the variants were a cross product of two small enumerations.

`Kinesis::at(anchor, factory, args...)` forwards any `HasBounds` object's region to any factory taking an `AABB2D` first. It replaces seven per-factory overloads that implied a blessed set of geometries. `Mapped<T>`, `Collapsible`, `ValueRow`, and `ValueGroup` all expose `bounds()`.

`LayoutCursor` takes optional column extents at construction and gains `sync_to`, so multi-column layout is two cursors advancing independently rather than hand-built cell rects. `Collapsible::place`, `make_value_row`, and `make_value_group` gained overloads reading the column from the cursor.

`Surface` produces named screen regions: `top_left`, `top_right`, `bottom_strip`, `center_rect`, and the rest.

## Atelier

`Forma.cpp` held eight process-wide statics and every construction path that touched them, which meant `create_element` could only exist in `Forma.hpp`, which meant nothing below the umbrella could construct an element. That blocked putting control construction anywhere sensible.

`internal::Atelier` follows the `Portal::Graphics` pattern: a Meyers singleton owning the five engine references plus the `Bridge` and `Inspector`, exposing `create_window`, `create_buffer`, `create_layer`, `create_surface`, and both `create_element` overloads. `Forma.hpp` and `Forma.cpp` become wrappers. Everything under `Internal/` is implementation detail with no stability guarantee.

Plot adornment construction moved into `Atelier` as well, since it builds buffers and therefore needs the BufferManager. `Plot` composes placement from arguments it is given; it should not hold a buffer manager. The inspect chain stayed in `Forma.cpp`, because `Inspector` already builds itself from a Surface and a cursor, so the window and Surface creation around it is chaining rather than argument construction.

The public API did not change: same signatures, same semantics, same call sites.

## Header split

`Geometry.hpp` is now the contract: `GeometryFn`, `write_verts`, `Form`, `at`. `FormFactory.hpp` holds the shipped factories and the wiring helpers. `Geometry.hpp` pulls only `Mapped.hpp`; the `Context` chain lands in `FormFactory.hpp` where the wiring actually needs it.

## Breaking changes

**`radial` takes a region.** The `(center, radius, start, end, color)` overload is gone. Callers with a centre and radius write `Kinesis::AABB2D::from_ndc(center, glm::vec2(radius))`. The two-overload set could not participate in `at`, and one uniform signature was worth more than the convenience.

**`Geometry::` factories return `Form<T>` rather than `GeometryFn<T>`.** `Form` converts implicitly to `const GeometryFn<T>&`, so existing `create_element<T>(surface, Geometry::X(...), ...)` call sites compile unchanged and behave exactly as before, discarding topology, capacity, and wire. `T` does not deduce through a user conversion, so call sites keeping their explicit template argument are unaffected. All three test files and every documented example compile without edits.

**Seven `HasBounds` overloads removed** in favour of `at`.

**`Geometry::wire_canvas_drag` moved** from `Geometry.hpp` to `FormFactory.hpp`. Same name, same namespace; only the include changes.

## Behaviour changes worth noticing

`point` and `crosshair` carry hover-follow rather than drag. Both hold NDC positions rather than normalized parameters, and every existing use writes them from `on_move`.

A knob built from `radial` is now an absolute control: the indicator points at the cursor rather than accumulating displacement. The relative feel is available by clearing `wire`.

`Context::on_press` keys its handlers by button, so registering a second press handler on the same button replaces a Form's. Documented, with the combine-in-one-handler pattern shown.

## Fixed along the way

The fader drag inverse, which appeared in four documented examples and was off by half a handle width at both extremes.

`FormaBuffer::submit` and its capacity constructor claimed bytes must not exceed capacity and that submit warns; `FormaProcessor` has grown the buffer to 1.5x and reallocated staging for some time.

Three documentation errors predating this work: `send_to_front` does not exist (`bring_to_front` does), `on_scroll` takes two trailing doubles, and the scroll example's `non_interactive()` backdrop can never receive scroll, since `hit_test` skips non-interactive elements and `handle_scroll` requires a hover.

## Docs

`Portal-Forma.md` gains a `Form` section and a `Layout` section, and its geometry tables now list what each Form carries rather than which topology to pass.

`Portal-Forma-UI-Patterns.md` maps the ImGui equivalents onto Forms. Checkbox, slider, knob, and canvas each collapse to one call. The knob example previously left `// project ndc onto path arc-length, write [0,1]` as a comment the reader could not implement; that is now `path_fraction`, carried.

The scroll section now states plainly that the `LayoutCursor` reflow it describes is not implemented by any shipped geometry function, since every factory captures its bounds by value. That capability is available to geometry you write yourself, and closing the gap for the shipped ones is a separate question.

## Not in scope

`stroke_slider` still requires a caller-supplied handle buffer. It is the only geometry with an intrinsic second buffer, and one caller does not justify a fourth `Form` field.

`drawable_canvas` cannot compute its capacity, since the vertex count depends on the runtime vector length. It takes the default and the buffer grows once on the first sync. A `samples` parameter would avoid that reallocation and is worth doing when the signature is next touched.