### PR TITLE
GPU selection: choose and pin the device, with presentation checked up front

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -35,6 +35,14 @@ A complete file covering all four sections plus journal:
   },
   "graphics": {
     "target_frame_rate": 60,
+    "backend_info": {
+      "device_preference": 0,
+      "device_index": -1,
+      "device_uuid": "",
+      "device_name": "",
+      "require_presentation": true,
+      "strict_device_selection": false
+    },
     "surface_info": {
       "format": "B8G8R8A8_SRGB",
       "color_space": "SRGB_NONLINEAR",
@@ -144,6 +152,86 @@ The windowing backend (`GLFW` on macOS, `WAYLAND` on Linux, `WINDOWS` on Windows
 On macOS, `gfx.glfw_preinit_config` exposes GLFW pre-init hints.
 
 Key repeat timing for native backends (Wayland, Win32) is in `gfx.key_repeat_config`.
+
+### GPU selection
+
+On a machine with more than one GPU, `gfx.backend_info` decides which one the
+engine runs on. Every enumerated device is logged during startup with
+the information needed to pin it: (example)
+
+```log
+GPU [0] AMD Radeon RX 7900 XTX (RADV NAVI31) | type=DiscreteGpu driver=MesaRadv (radv)
+api=1.4.354 | uuid=00000000030000000000000000000000 | gfx=0 compute=1 transfer=0 |
+present=gfx:yes mask:0x7 mesh=yes vram=24560MB pci_bus=3 | score=4623
+```
+
+Devices that cannot be used are listed too, with the reason: no graphics queue
+family, an API version below 1.3, no `VK_KHR_swapchain`, or no presentation
+support on the graphics queue family.
+
+```cpp
+void settings() {
+    auto& gfx = MayaFlux::Config::get_global_graphics_config();
+
+    // Prefer a device class. AUTO scores discrete above integrated above virtual.
+    gfx.backend_info.device_preference =
+        Core::GraphicsBackendInfo::DevicePreference::DISCRETE;
+
+    // Or pin one exactly, by the uuid from the startup log.
+    gfx.backend_info.device_uuid = "00000000030000000000000000000000";
+
+    // Or by a case-insensitive substring of the device name.
+    gfx.backend_info.device_name = "7900";
+
+    // Fail at startup rather than falling back if the selector matches nothing.
+    gfx.backend_info.strict_device_selection = true;
+}
+```
+
+Selectors apply in precedence order: `device_index`, `device_uuid`,
+`device_name`, then `device_preference` as a scoring bias. `device_index` is
+an index into enumeration order, which is loader and driver dependent, so it
+is a debugging escape hatch rather than a durable setting. `device_uuid` is
+the only selector stable across driver updates and enumeration reordering.
+
+`DevicePreference` options: `AUTO`, `DISCRETE`, `INTEGRATED`, `VIRTUAL`,
+`EXTERNAL`. In JSON these are integers in that order, since the enum does not
+currently serialise to a string.
+
+`EXTERNAL` is a heuristic rather than a device class. Vulkan reports a
+Thunderbolt eGPU as a discrete GPU, indistinguishable from a built-in one, so
+`EXTERNAL` means discrete weighted toward the highest PCI bus number, on the
+reasoning that an externally attached device sits behind a PCIe switch well
+above the root complex. It needs `VK_EXT_pci_bus_info`, which is common on
+Linux and rare elsewhere; without it, `EXTERNAL` behaves as `DISCRETE`.
+
+Set `require_presentation` to false for headless and compute-only work,
+including any run with `windowing_backend` set to `NONE`. With it true, a
+device whose graphics queue family cannot present is rejected.
+
+`MAYAFLUX_GPU` overrides the config at runtime without a rebuild. An
+all-digits value is an index, anything else a name substring:
+
+```sh
+MAYAFLUX_GPU=1 ./my_piece
+MAYAFLUX_GPU=intel ./my_piece
+```
+
+Selection composes below driver-level filtering rather than overriding it.
+`VK_DRIVER_FILES`, `MESA_VK_DEVICE_SELECT`, `DRI_PRIME`, and
+`__NV_PRIME_RENDER_OFFLOAD` all act before the engine sees the device list, so
+if a GPU is missing from the startup log entirely, one of those is the reason.
+
+### Device extensions
+
+`required_extensions` and `optional_extensions` on `gfx.backend_info` request
+Vulkan device extensions beyond what the engine enables itself. A required
+extension the device does not support fails at startup with the name; an
+unsupported optional one is skipped with a warning.
+
+```cpp
+gfx.backend_info.optional_extensions = { "VK_EXT_memory_budget" };
+```
 
 ---
 

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.cpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/BackendWindowHandler.cpp
@@ -574,9 +574,9 @@ bool BackendWindowHandler::register_window(const std::shared_ptr<Window>& window
         return false;
     }
 
-    if (!m_context.update_present_family(surface)) {
+    if (!m_context.graphics_family_can_present(surface)) {
         MF_RT_ERROR(Journal::Component::Core, Journal::Context::GraphicsCallback,
-            "No presentation support for window '{}'", window->get_create_info().title);
+            "Graphics queue family cannot present to window '{}'", window->get_create_info().title);
         m_context.destroy_surface(surface);
         return false;
     }

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKContext.cpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKContext.cpp
@@ -58,7 +58,7 @@ bool VKContext::initialize(const GlobalGraphicsConfig& graphics_config, bool ena
         return false;
     }
 
-    if (!m_device.initialize(m_instance.get_instance(), nullptr, m_graphics_config.backend_info)) {
+    if (!m_device.initialize(m_instance.get_instance(), m_graphics_config.backend_info)) {
         MF_ERROR(Journal::Component::Core, Journal::Context::GraphicsBackend,
             "Failed to initialize Vulkan device!");
         cleanup();

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKContext.cpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKContext.cpp
@@ -199,11 +199,6 @@ void VKContext::destroy_surface(vk::SurfaceKHR surface)
     }
 }
 
-bool VKContext::update_present_family(vk::SurfaceKHR surface)
-{
-    return m_device.update_presentation_queue(surface);
-}
-
 void VKContext::cleanup()
 {
     for (auto surface : m_surfaces) {

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKContext.hpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKContext.hpp
@@ -72,11 +72,30 @@ public:
     }
 
     /**
-     * @brief Update presentation support for a surface
+     * @brief Confirm the graphics family presents to a surface
      * @param surface Surface to check
      * @return true if presentation is supported
      */
-    bool update_present_family(vk::SurfaceKHR surface);
+    [[nodiscard]] bool graphics_family_can_present(vk::SurfaceKHR surface) const
+    {
+        return m_device.graphics_family_can_present(surface);
+    }
+
+    /**
+     * @brief Queue for a presentation-capable family
+     */
+    [[nodiscard]] vk::Queue get_present_queue(uint32_t family_index) const
+    {
+        return m_device.get_present_queue(family_index);
+    }
+
+    /**
+     * @brief Queue for the preferred presentation family
+     */
+    [[nodiscard]] vk::Queue get_preferred_present_queue() const
+    {
+        return m_device.get_preferred_present_queue();
+    }
 
     /**
      * @brief Create surface from window's native handles

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKDevice.cpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKDevice.cpp
@@ -21,7 +21,6 @@
 namespace MayaFlux::Core {
 
 namespace {
-
     /**
      * @brief Scratch native connection plus surfaceless presentation query.
      *
@@ -143,6 +142,7 @@ namespace {
         QueueFamilyIndices families;
         bool has_swapchain {};
         bool has_mesh_shader {};
+        uint32_t present_family_mask {};
         bool graphics_presents {};
         bool has_pci_info {};
         uint32_t pci_bus {};
@@ -208,6 +208,11 @@ VKDevice::VKDevice(VKDevice&& other) noexcept
     , m_compute_queue(other.m_compute_queue)
     , m_transfer_queue(other.m_transfer_queue)
     , m_queue_families(other.m_queue_families)
+    , m_graphics_presents(other.m_graphics_presents)
+    , m_present_queues(std::move(other.m_present_queues))
+    , m_device_name(std::move(other.m_device_name))
+    , m_device_uuid(other.m_device_uuid)
+    , m_supports_mesh_shaders(other.m_supports_mesh_shaders)
 {
     other.m_physical_device = VK_NULL_HANDLE;
     other.m_logical_device = VK_NULL_HANDLE;
@@ -226,6 +231,11 @@ VKDevice& VKDevice::operator=(VKDevice&& other) noexcept
         m_compute_queue = other.m_compute_queue;
         m_transfer_queue = other.m_transfer_queue;
         m_queue_families = other.m_queue_families;
+        m_graphics_presents = other.m_graphics_presents;
+        m_present_queues = std::move(other.m_present_queues);
+        m_device_name = std::move(other.m_device_name);
+        m_device_uuid = other.m_device_uuid;
+        m_supports_mesh_shaders = other.m_supports_mesh_shaders;
 
         other.m_physical_device = VK_NULL_HANDLE;
         other.m_logical_device = VK_NULL_HANDLE;
@@ -257,6 +267,11 @@ void VKDevice::cleanup()
     m_compute_queue = nullptr;
     m_transfer_queue = nullptr;
     m_queue_families = {};
+    m_present_queues.clear();
+    m_device_name.clear();
+    m_device_uuid = {};
+    m_graphics_presents = false;
+    m_supports_mesh_shaders = false;
 }
 
 bool VKDevice::pick_physical_device(vk::Instance instance, const GraphicsBackendInfo& backend_info)
@@ -349,8 +364,19 @@ bool VKDevice::pick_physical_device(vk::Instance instance, const GraphicsBackend
                 && mesh_features.taskShader == VK_TRUE;
         }
 
-        if (cand.families.graphics_family.has_value()) {
-            cand.graphics_presents = probe.supports(device, cand.families.graphics_family.value());
+        {
+            auto family_props = device.getQueueFamilyProperties();
+            const uint32_t probe_count = std::min<uint32_t>(static_cast<uint32_t>(family_props.size()), QueueFamilyIndices::MAX_TRACKED_FAMILIES);
+
+            for (uint32_t f = 0; f < probe_count; ++f) {
+                if (probe.supports(device, f))
+                    cand.present_family_mask |= (1U << f);
+            }
+
+            cand.families.present_family_mask = cand.present_family_mask;
+
+            if (cand.families.graphics_family.has_value())
+                cand.graphics_presents = cand.families.can_present(cand.families.graphics_family.value());
         }
 
         if (!cand.families.graphics_family.has_value()) {
@@ -403,7 +429,7 @@ bool VKDevice::pick_physical_device(vk::Instance instance, const GraphicsBackend
     for (const auto& cand : candidates) {
         MF_INFO(Journal::Component::Core, Journal::Context::GraphicsBackend,
             "GPU [{}] {} | type={} driver={} ({}) api={}.{}.{} | uuid={} | "
-            "gfx={} compute={} transfer={} | present={} mesh={} vram={}MB pci_bus={} | score={}{}{}",
+            "gfx={} compute={} transfer={} | present=gfx:{} mask:{:#x} mesh={} vram={}MB pci_bus={} | score={}{}{}",
             cand.index, cand.name, vk::to_string(cand.type),
             vk::to_string(cand.driver_id), cand.driver_name,
             VK_API_VERSION_MAJOR(cand.api_version),
@@ -414,6 +440,7 @@ bool VKDevice::pick_physical_device(vk::Instance instance, const GraphicsBackend
             cand.families.compute_family.has_value() ? std::to_string(cand.families.compute_family.value()) : "none",
             cand.families.transfer_family.has_value() ? std::to_string(cand.families.transfer_family.value()) : "none",
             cand.graphics_presents ? "yes" : "no",
+            cand.present_family_mask,
             cand.has_mesh_shader ? "yes" : "no",
             cand.device_local_bytes >> 20U,
             cand.has_pci_info ? std::to_string(cand.pci_bus) : "n/a",
@@ -513,7 +540,7 @@ bool VKDevice::pick_physical_device(vk::Instance instance, const GraphicsBackend
     m_device_name = selected->name;
     m_device_uuid = selected->uuid;
 
-    MF_INFO(Journal::Component::Core, Journal::Context::GraphicsBackend,
+    MF_LOG(Journal::Component::Core, Journal::Context::GraphicsBackend,
         "Selected GPU [{}] {} by {} (uuid={}, score={})",
         selected->index, selected->name, selection_basis, selected->uuid_hex, selected->score);
 
@@ -554,47 +581,26 @@ QueueFamilyIndices VKDevice::find_queue_families(vk::PhysicalDevice device)
     return indices;
 }
 
-bool VKDevice::update_presentation_queue(vk::SurfaceKHR surface)
+bool VKDevice::graphics_family_can_present(vk::SurfaceKHR surface) const
 {
-    if (!surface) {
-        MF_WARN(Journal::Component::Core, Journal::Context::GraphicsBackend,
-            "No surface provided for presentation support check");
+    if (!surface || !m_queue_families.graphics_family.has_value())
         return false;
-    }
 
-    auto queue_families = m_physical_device.getQueueFamilyProperties();
+    return m_physical_device.getSurfaceSupportKHR(
+               m_queue_families.graphics_family.value(), surface)
+        == VK_TRUE;
+}
 
-    for (uint32_t i = 0; i < queue_families.size(); i++) {
-        if (queue_families[i].queueCount > 0) {
-            vk::Bool32 presentSupport = m_physical_device.getSurfaceSupportKHR(i, surface);
-            if (presentSupport) {
-                if (i == m_queue_families.graphics_family.value()) {
-                    m_queue_families.present_family = i;
-                    m_presentation_initialized = true;
-                    MF_INFO(Journal::Component::Core, Journal::Context::GraphicsBackend,
-                        "Graphics queue family {} supports presentation", i);
-                    return true;
-                }
-            }
-        }
-    }
+vk::Queue VKDevice::get_present_queue(uint32_t family_index) const
+{
+    auto it = m_present_queues.find(family_index);
+    return it != m_present_queues.end() ? it->second : nullptr;
+}
 
-    for (uint32_t i = 0; i < queue_families.size(); i++) {
-        if (queue_families[i].queueCount > 0) {
-            vk::Bool32 presentSupport = m_physical_device.getSurfaceSupportKHR(i, surface);
-            if (presentSupport) {
-                m_queue_families.present_family = i;
-                m_presentation_initialized = true;
-                MF_INFO(Journal::Component::Core, Journal::Context::GraphicsBackend,
-                    "Found presentation support in queue family {}", i);
-                return true;
-            }
-        }
-    }
-
-    MF_ERROR(Journal::Component::Core, Journal::Context::GraphicsBackend,
-        "No queue family with presentation support found!");
-    return false;
+vk::Queue VKDevice::get_preferred_present_queue() const
+{
+    auto family = m_queue_families.preferred_present_family();
+    return family.has_value() ? get_present_queue(family.value()) : nullptr;
 }
 
 void VKDevice::query_supported_extensions()
@@ -625,6 +631,11 @@ bool VKDevice::create_logical_device(vk::Instance /*instance*/, const GraphicsBa
 
     if (m_queue_families.transfer_family.has_value() && m_queue_families.transfer_family != m_queue_families.graphics_family) {
         unique_queue_families.insert(m_queue_families.transfer_family.value());
+    }
+
+    for (uint32_t f = 0; f < QueueFamilyIndices::MAX_TRACKED_FAMILIES; ++f) {
+        if (m_queue_families.can_present(f))
+            unique_queue_families.insert(f);
     }
 
     std::vector<vk::DeviceQueueCreateInfo> queue_create_infos;
@@ -719,6 +730,11 @@ bool VKDevice::create_logical_device(vk::Instance /*instance*/, const GraphicsBa
         m_transfer_queue = m_logical_device.getQueue(m_queue_families.transfer_family.value(), 0);
     } else {
         m_transfer_queue = m_graphics_queue;
+    }
+
+    for (uint32_t f = 0; f < QueueFamilyIndices::MAX_TRACKED_FAMILIES; ++f) {
+        if (m_queue_families.can_present(f))
+            m_present_queues[f] = m_logical_device.getQueue(f, 0);
     }
 
     return true;

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKDevice.cpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKDevice.cpp
@@ -4,7 +4,197 @@
 
 #include "set"
 
+#ifdef GLFW_BACKEND
+#define GLFW_INCLUDE_VULKAN
+#include <GLFW/glfw3.h>
+#endif
+
+#if defined(WIN32_BACKEND)
+#include <vulkan/vulkan_win32.h>
+#endif
+
+#if defined(WAYLAND_BACKEND)
+#include <vulkan/vulkan_wayland.h>
+#include <wayland-client.h>
+#endif
+
 namespace MayaFlux::Core {
+
+namespace {
+
+    /**
+     * @brief Scratch native connection plus surfaceless presentation query.
+     *
+     * Device selection runs before any window exists, so
+     * vkGetPhysicalDeviceSurfaceSupportKHR is unavailable: it needs a surface,
+     * which needs a window. The platform entry points answer the same question
+     * from a native display connection instead.
+     *
+     * On Wayland no compositor connection exists at selection time either, since
+     * each WaylandWindow calls wl_display_connect in its own constructor. One
+     * scratch connection is opened for the selection pass and closed after; the
+     * query does not care which connection it is given.
+     *
+     * When the platform has no entry point, or the connection fails, available is
+     * false and supports() returns true for every family so selection proceeds
+     * unverified rather than rejecting every device.
+     */
+    struct PresentationProbe {
+        vk::Instance instance;
+        void* native_display {};
+        bool available {};
+        const char* mechanism { "unavailable" };
+
+        explicit PresentationProbe(vk::Instance inst)
+            : instance(inst)
+        {
+#if defined(GLFW_BACKEND)
+            available = glfwVulkanSupported() == GLFW_TRUE;
+            mechanism = available ? "glfw" : "unavailable";
+#elif defined(WIN32_BACKEND)
+            available = true;
+            mechanism = "win32";
+#elif defined(WAYLAND_BACKEND)
+            native_display = wl_display_connect(nullptr);
+            available = native_display != nullptr;
+            mechanism = available ? "wayland" : "unavailable";
+#endif
+        }
+
+        ~PresentationProbe()
+        {
+#if defined(WAYLAND_BACKEND)
+            if (native_display)
+                wl_display_disconnect(static_cast<wl_display*>(native_display));
+#endif
+        }
+
+        PresentationProbe(const PresentationProbe&) = delete;
+        PresentationProbe& operator=(const PresentationProbe&) = delete;
+        PresentationProbe(PresentationProbe&&) = delete;
+        PresentationProbe& operator=(PresentationProbe&&) = delete;
+
+        [[nodiscard]] bool supports(vk::PhysicalDevice device, uint32_t family_index) const
+        {
+            if (!available)
+                return true;
+
+#if defined(GLFW_BACKEND)
+            return glfwGetPhysicalDevicePresentationSupport(
+                       static_cast<VkInstance>(instance),
+                       static_cast<VkPhysicalDevice>(device),
+                       family_index)
+                == GLFW_TRUE;
+#elif defined(WIN32_BACKEND)
+            return vkGetPhysicalDeviceWin32PresentationSupportKHR(
+                       static_cast<VkPhysicalDevice>(device), family_index)
+                == VK_TRUE;
+#elif defined(WAYLAND_BACKEND)
+            return vkGetPhysicalDeviceWaylandPresentationSupportKHR(
+                       static_cast<VkPhysicalDevice>(device), family_index,
+                       static_cast<wl_display*>(native_display))
+                == VK_TRUE;
+#else
+            return true;
+#endif
+        }
+    };
+
+    /** @brief Format a Vulkan UUID as 32 lowercase hex characters, no separators. */
+    std::string uuid_to_hex(const uint8_t* uuid)
+    {
+        std::string out;
+        out.reserve(VK_UUID_SIZE * 2);
+        for (size_t i = 0; i < VK_UUID_SIZE; ++i) {
+            out += std::format("{:02x}", uuid[i]);
+        }
+        return out;
+    }
+
+    /** @brief Case-insensitive substring test. */
+    bool contains_nocase(std::string_view haystack, std::string_view needle)
+    {
+        if (needle.empty() || needle.size() > haystack.size())
+            return false;
+
+        auto it = std::search(haystack.begin(), haystack.end(),
+            needle.begin(), needle.end(),
+            [](char a, char b) { return std::tolower(static_cast<unsigned char>(a)) == std::tolower(static_cast<unsigned char>(b)); });
+
+        return it != haystack.end();
+    }
+
+    /**
+     * @brief Everything selection needs to know about one enumerated device.
+     *
+     * Gathered in a single pass so that scoring, selector matching, and the
+     * candidate log all read the same values.
+     */
+    struct DeviceCandidate {
+        vk::PhysicalDevice device;
+        uint32_t index {};
+        std::string name;
+        std::string uuid_hex;
+        std::array<uint8_t, VK_UUID_SIZE> uuid {};
+        vk::PhysicalDeviceType type {};
+        uint32_t api_version {};
+        vk::DriverId driver_id {};
+        std::string driver_name;
+        QueueFamilyIndices families;
+        bool has_swapchain {};
+        bool has_mesh_shader {};
+        bool graphics_presents {};
+        bool has_pci_info {};
+        uint32_t pci_bus {};
+        uint64_t device_local_bytes {};
+        int64_t score {};
+        const char* reject_reason {};
+
+        [[nodiscard]] bool viable() const { return reject_reason == nullptr; }
+    };
+
+    /** @brief Base score by device class, before preference and capability bonuses. */
+    int64_t type_base_score(vk::PhysicalDeviceType type)
+    {
+        switch (type) {
+        case vk::PhysicalDeviceType::eDiscreteGpu:
+            return 4000;
+        case vk::PhysicalDeviceType::eIntegratedGpu:
+            return 2000;
+        case vk::PhysicalDeviceType::eVirtualGpu:
+            return 1000;
+        case vk::PhysicalDeviceType::eCpu:
+            return 100;
+        default:
+            return 500;
+        }
+    }
+
+    /**
+     * @brief Read MAYAFLUX_GPU, an all-digits value being an index and anything
+     *        else a name substring.
+     * @param out_index Receives the parsed index, or -1.
+     * @param out_name Receives the name substring, or empty.
+     * @return true if the variable was set and non-empty.
+     */
+    bool read_gpu_env(int32_t& out_index, std::string& out_name)
+    {
+        const char* raw = std::getenv("MAYAFLUX_GPU");
+        if (!raw || *raw == '\0')
+            return false;
+
+        std::string_view value(raw);
+        if (std::ranges::all_of(value, [](char c) { return std::isdigit(static_cast<unsigned char>(c)) != 0; })) {
+            out_index = static_cast<int32_t>(std::strtol(raw, nullptr, 10));
+            out_name.clear();
+        } else {
+            out_index = -1;
+            out_name = value;
+        }
+        return true;
+    }
+
+} // namespace
 
 VKDevice::~VKDevice()
 {
@@ -46,9 +236,9 @@ VKDevice& VKDevice::operator=(VKDevice&& other) noexcept
     return *this;
 }
 
-bool VKDevice::initialize(vk::Instance instance, vk::SurfaceKHR /*temp_surface*/, const GraphicsBackendInfo& backend_info)
+bool VKDevice::initialize(vk::Instance instance, const GraphicsBackendInfo& backend_info)
 {
-    if (!pick_physical_device(instance, nullptr)) {
+    if (!pick_physical_device(instance, backend_info)) {
         return false;
     }
 
@@ -69,10 +259,9 @@ void VKDevice::cleanup()
     m_queue_families = {};
 }
 
-bool VKDevice::pick_physical_device(vk::Instance instance, vk::SurfaceKHR /*temp_surface*/)
+bool VKDevice::pick_physical_device(vk::Instance instance, const GraphicsBackendInfo& backend_info)
 {
-    vk::Instance vk_instance(instance);
-    auto devices = vk_instance.enumeratePhysicalDevices();
+    auto devices = instance.enumeratePhysicalDevices();
 
     if (devices.empty()) {
         error<std::runtime_error>(Journal::Component::Core, Journal::Context::GraphicsBackend,
@@ -80,67 +269,258 @@ bool VKDevice::pick_physical_device(vk::Instance instance, vk::SurfaceKHR /*temp
             "Failed to find GPUs with Vulkan support!");
     }
 
-    for (const auto& device : devices) {
-        QueueFamilyIndices indices = find_queue_families(device, nullptr);
+    const PresentationProbe probe(instance);
 
-        if (indices.graphics_family.has_value()) {
-            auto available_extensions = device.enumerateDeviceExtensionProperties();
-            bool supports_swapchain = false;
-            bool supports_mesh_shader = false;
+    if (backend_info.require_presentation && !probe.available) {
+        MF_WARN(Journal::Component::Core, Journal::Context::GraphicsBackend,
+            "Presentation support cannot be verified on this platform; "
+            "device selection will not filter on it");
+    }
 
-            for (const auto& ext : available_extensions) {
-                if (strcmp(ext.extensionName, VK_KHR_SWAPCHAIN_EXTENSION_NAME) == 0) {
-                    supports_swapchain = true;
-                }
-                if (strcmp(ext.extensionName, VK_EXT_MESH_SHADER_EXTENSION_NAME) == 0) {
-                    supports_mesh_shader = true;
-                }
+    std::vector<DeviceCandidate> candidates;
+    candidates.reserve(devices.size());
+
+    for (uint32_t i = 0; i < devices.size(); ++i) {
+        const auto& device = devices[i];
+
+        DeviceCandidate cand;
+        cand.device = device;
+        cand.index = i;
+
+        auto available_extensions = device.enumerateDeviceExtensionProperties();
+        bool has_pci_ext = false;
+
+        for (const auto& ext : available_extensions) {
+            if (strcmp(ext.extensionName, VK_KHR_SWAPCHAIN_EXTENSION_NAME) == 0)
+                cand.has_swapchain = true;
+            if (strcmp(ext.extensionName, VK_EXT_MESH_SHADER_EXTENSION_NAME) == 0)
+                cand.has_mesh_shader = true;
+            if (strcmp(ext.extensionName, VK_EXT_PCI_BUS_INFO_EXTENSION_NAME) == 0)
+                has_pci_ext = true;
+        }
+
+        auto prop_chain = vk::StructureChain {
+            vk::PhysicalDeviceProperties2 {},
+            vk::PhysicalDeviceVulkan11Properties {},
+            vk::PhysicalDeviceVulkan12Properties {},
+            vk::PhysicalDevicePCIBusInfoPropertiesEXT {}
+        };
+
+        if (!has_pci_ext) {
+            prop_chain.unlink<vk::PhysicalDevicePCIBusInfoPropertiesEXT>();
+        }
+
+        device.getProperties2(&prop_chain.get<vk::PhysicalDeviceProperties2>());
+
+        const auto& props = prop_chain.get<vk::PhysicalDeviceProperties2>().properties;
+        const auto& props11 = prop_chain.get<vk::PhysicalDeviceVulkan11Properties>();
+        const auto& props12 = prop_chain.get<vk::PhysicalDeviceVulkan12Properties>();
+
+        cand.name = props.deviceName.data();
+        cand.type = props.deviceType;
+        cand.api_version = props.apiVersion;
+        cand.driver_id = props12.driverID;
+        cand.driver_name = props12.driverName.data();
+        std::copy_n(props11.deviceUUID.data(), VK_UUID_SIZE, cand.uuid.begin());
+        cand.uuid_hex = uuid_to_hex(cand.uuid.data());
+
+        if (has_pci_ext) {
+            cand.has_pci_info = true;
+            cand.pci_bus = prop_chain.get<vk::PhysicalDevicePCIBusInfoPropertiesEXT>().pciBus;
+        }
+
+        auto memory_props = device.getMemoryProperties();
+        for (uint32_t h = 0; h < memory_props.memoryHeapCount; ++h) {
+            if (memory_props.memoryHeaps[h].flags & vk::MemoryHeapFlagBits::eDeviceLocal) {
+                cand.device_local_bytes = std::max(cand.device_local_bytes,
+                    static_cast<uint64_t>(memory_props.memoryHeaps[h].size));
             }
+        }
 
-            if (!supports_swapchain) {
-                MF_WARN(Journal::Component::Core, Journal::Context::GraphicsBackend,
-                    "Physical device {} does not support VK_KHR_swapchain - skipping",
-                    device.getProperties().deviceName.data());
-                continue;
+        cand.families = find_queue_families(device);
+
+        if (cand.has_mesh_shader) {
+            vk::PhysicalDeviceMeshShaderFeaturesEXT mesh_features;
+            vk::PhysicalDeviceFeatures2 features;
+            features.pNext = &mesh_features;
+            device.getFeatures2(&features);
+
+            cand.has_mesh_shader = mesh_features.meshShader == VK_TRUE
+                && mesh_features.taskShader == VK_TRUE;
+        }
+
+        if (cand.families.graphics_family.has_value()) {
+            cand.graphics_presents = probe.supports(device, cand.families.graphics_family.value());
+        }
+
+        if (!cand.families.graphics_family.has_value()) {
+            cand.reject_reason = "no graphics queue family";
+        } else if (cand.api_version < VK_API_VERSION_1_3) {
+            cand.reject_reason = "device API version below 1.3";
+        } else if (!cand.has_swapchain) {
+            cand.reject_reason = "no VK_KHR_swapchain";
+        } else if (backend_info.require_presentation && !cand.graphics_presents) {
+            cand.reject_reason = "graphics family cannot present";
+        }
+
+        cand.score = type_base_score(cand.type);
+
+        switch (backend_info.device_preference) {
+        case GraphicsBackendInfo::DevicePreference::DISCRETE:
+            if (cand.type == vk::PhysicalDeviceType::eDiscreteGpu)
+                cand.score += 10000;
+            break;
+        case GraphicsBackendInfo::DevicePreference::INTEGRATED:
+            if (cand.type == vk::PhysicalDeviceType::eIntegratedGpu)
+                cand.score += 10000;
+            break;
+        case GraphicsBackendInfo::DevicePreference::VIRTUAL:
+            if (cand.type == vk::PhysicalDeviceType::eVirtualGpu)
+                cand.score += 10000;
+            break;
+        case GraphicsBackendInfo::DevicePreference::EXTERNAL:
+            if (cand.type == vk::PhysicalDeviceType::eDiscreteGpu) {
+                cand.score += 10000;
+                if (cand.has_pci_info)
+                    cand.score += static_cast<int64_t>(cand.pci_bus) * 4;
             }
+            break;
+        case GraphicsBackendInfo::DevicePreference::AUTO:
+        default:
+            break;
+        }
 
-            if (!supports_mesh_shader) {
-                MF_WARN(Journal::Component::Core, Journal::Context::GraphicsBackend,
-                    "Physical device {} does not support VK_EXT_mesh_shader - "
-                    "mesh shading features will be unavailable",
-                    device.getProperties().deviceName.data());
-            } else {
-                vk::PhysicalDeviceMeshShaderFeaturesEXT mesh_features;
-                vk::PhysicalDeviceFeatures2 temp_features;
-                temp_features.pNext = &mesh_features;
-                device.getFeatures2(&temp_features);
+        if (cand.graphics_presents)
+            cand.score += 500;
+        if (cand.has_mesh_shader)
+            cand.score += 100;
 
-                if (mesh_features.meshShader == VK_FALSE || mesh_features.taskShader == VK_FALSE) {
-                    MF_INFO(Journal::Component::Core, Journal::Context::GraphicsBackend,
-                        "Physical device {} supports VK_EXT_mesh_shader extension but features disabled",
-                        device.getProperties().deviceName.data());
-                    supports_mesh_shader = false;
-                }
+        cand.score += static_cast<int64_t>(cand.device_local_bytes >> 30U);
+
+        candidates.push_back(std::move(cand));
+    }
+
+    for (const auto& cand : candidates) {
+        MF_INFO(Journal::Component::Core, Journal::Context::GraphicsBackend,
+            "GPU [{}] {} | type={} driver={} ({}) api={}.{}.{} | uuid={} | "
+            "gfx={} compute={} transfer={} | present={} mesh={} vram={}MB pci_bus={} | score={}{}{}",
+            cand.index, cand.name, vk::to_string(cand.type),
+            vk::to_string(cand.driver_id), cand.driver_name,
+            VK_API_VERSION_MAJOR(cand.api_version),
+            VK_API_VERSION_MINOR(cand.api_version),
+            VK_API_VERSION_PATCH(cand.api_version),
+            cand.uuid_hex,
+            cand.families.graphics_family.has_value() ? std::to_string(cand.families.graphics_family.value()) : "none",
+            cand.families.compute_family.has_value() ? std::to_string(cand.families.compute_family.value()) : "none",
+            cand.families.transfer_family.has_value() ? std::to_string(cand.families.transfer_family.value()) : "none",
+            cand.graphics_presents ? "yes" : "no",
+            cand.has_mesh_shader ? "yes" : "no",
+            cand.device_local_bytes >> 20U,
+            cand.has_pci_info ? std::to_string(cand.pci_bus) : "n/a",
+            cand.score,
+            cand.viable() ? "" : " | REJECTED: ",
+            cand.reject_reason ? cand.reject_reason : "");
+    }
+
+    MF_INFO(Journal::Component::Core, Journal::Context::GraphicsBackend,
+        "Presentation probe mechanism: {}, require_presentation={}, device_preference={}",
+        probe.mechanism, backend_info.require_presentation ? "true" : "false",
+        Reflect::enum_to_string(backend_info.device_preference));
+
+    int32_t want_index = backend_info.device_index;
+    std::string want_name = backend_info.device_name;
+    std::string want_uuid = backend_info.device_uuid;
+
+    if (int32_t env_index = -1; read_gpu_env(env_index, want_name)) {
+        want_index = env_index;
+        want_uuid.clear();
+        MF_INFO(Journal::Component::Core, Journal::Context::GraphicsBackend,
+            "MAYAFLUX_GPU override active (index={}, name='{}')", want_index, want_name);
+    }
+
+    const DeviceCandidate* selected = nullptr;
+    const char* selection_basis = "score";
+
+    if (want_index >= 0) {
+        for (const auto& cand : candidates) {
+            if (static_cast<int32_t>(cand.index) == want_index && cand.viable()) {
+                selected = &cand;
+                selection_basis = "device_index";
+                break;
             }
-
-            m_physical_device = device;
-            m_queue_families = indices;
-            m_supports_mesh_shaders = supports_mesh_shader;
-
-            vk::PhysicalDeviceProperties props = device.getProperties();
-            MF_LOG(Journal::Component::Core, Journal::Context::GraphicsBackend,
-                "Selected GPU: {}", props.deviceName.data());
-            return true;
         }
     }
 
-    error<std::runtime_error>(Journal::Component::Core, Journal::Context::GraphicsBackend,
-        std::source_location::current(),
-        "Failed to find a suitable GPU!");
-    return false;
+    if (!selected && !want_uuid.empty()) {
+        for (const auto& cand : candidates) {
+            if (cand.uuid_hex == want_uuid && cand.viable()) {
+                selected = &cand;
+                selection_basis = "device_uuid";
+                break;
+            }
+        }
+    }
+
+    if (!selected && !want_name.empty()) {
+        for (const auto& cand : candidates) {
+            if (!cand.viable() || !contains_nocase(cand.name, want_name))
+                continue;
+            if (!selected || cand.score > selected->score) {
+                selected = &cand;
+                selection_basis = "device_name";
+            }
+        }
+    }
+
+    const bool selector_requested = want_index >= 0 || !want_uuid.empty() || !want_name.empty();
+
+    if (selector_requested && !selected) {
+        if (backend_info.strict_device_selection) {
+            error<std::runtime_error>(Journal::Component::Core, Journal::Context::GraphicsBackend,
+                std::source_location::current(),
+                "No viable physical device matched the requested selector "
+                "(index={}, uuid='{}', name='{}') and strict_device_selection is set",
+                want_index, want_uuid, want_name);
+        }
+
+        MF_WARN(Journal::Component::Core, Journal::Context::GraphicsBackend,
+            "No viable physical device matched the requested selector "
+            "(index={}, uuid='{}', name='{}'); falling back to score",
+            want_index, want_uuid, want_name);
+    }
+
+    if (!selected) {
+        for (const auto& cand : candidates) {
+            if (!cand.viable())
+                continue;
+            if (!selected || cand.score > selected->score)
+                selected = &cand;
+        }
+    }
+
+    if (!selected) {
+        error<std::runtime_error>(Journal::Component::Core, Journal::Context::GraphicsBackend,
+            std::source_location::current(),
+            "No suitable GPU found among {} enumerated device(s); "
+            "see the candidate list above for rejection reasons",
+            candidates.size());
+    }
+
+    m_physical_device = selected->device;
+    m_queue_families = selected->families;
+    m_supports_mesh_shaders = selected->has_mesh_shader;
+    m_graphics_presents = selected->graphics_presents;
+    m_device_name = selected->name;
+    m_device_uuid = selected->uuid;
+
+    MF_INFO(Journal::Component::Core, Journal::Context::GraphicsBackend,
+        "Selected GPU [{}] {} by {} (uuid={}, score={})",
+        selected->index, selected->name, selection_basis, selected->uuid_hex, selected->score);
+
+    return true;
 }
 
-QueueFamilyIndices VKDevice::find_queue_families(vk::PhysicalDevice device, vk::SurfaceKHR surface)
+QueueFamilyIndices VKDevice::find_queue_families(vk::PhysicalDevice device)
 {
     QueueFamilyIndices indices;
     auto queue_families = device.getQueueFamilyProperties();
@@ -157,15 +537,6 @@ QueueFamilyIndices VKDevice::find_queue_families(vk::PhysicalDevice device, vk::
 
         if (queue_family.queueCount > 0 && queue_family.queueFlags & vk::QueueFlagBits::eTransfer && !(queue_family.queueFlags & vk::QueueFlagBits::eGraphics) && !(queue_family.queueFlags & vk::QueueFlagBits::eCompute)) {
             indices.transfer_family = i;
-        }
-
-        if (surface && queue_family.queueCount > 0) {
-            vk::Bool32 presentSupport = device.getSurfaceSupportKHR(i, surface);
-            if (presentSupport) {
-                indices.present_family = i;
-                MF_INFO(Journal::Component::Core, Journal::Context::GraphicsBackend,
-                    "Found presentation support in queue family {}", i);
-            }
         }
 
         i++;

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKDevice.cpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKDevice.cpp
@@ -10,6 +10,14 @@
 #endif
 
 #if defined(WIN32_BACKEND)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+// Windows header should be included before vulkan_win32.h, dummy comment to prevent auto sort
 #include <vulkan/vulkan_win32.h>
 #endif
 

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKDevice.cpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKDevice.cpp
@@ -658,11 +658,16 @@ bool VKDevice::create_logical_device(vk::Instance /*instance*/, const GraphicsBa
 
     std::vector<const char*> device_extensions = { VK_KHR_SWAPCHAIN_EXTENSION_NAME };
 
+    auto supported_extensions = m_physical_device.enumerateDeviceExtensionProperties();
+
+    auto is_supported = [&supported_extensions](std::string_view name) {
+        return std::ranges::any_of(supported_extensions, [name](const auto& ext) {
+            return name == ext.extensionName.data();
+        });
+    };
+
 #ifdef MAYAFLUX_PLATFORM_MACOS
-    auto available_exts = m_physical_device.enumerateDeviceExtensionProperties();
-    if (std::ranges::any_of(available_exts, [](const auto& ext) {
-            return strcmp(ext.extensionName, "VK_KHR_portability_subset") == 0;
-        })) {
+    if (is_supported("VK_KHR_portability_subset")) {
         device_extensions.push_back("VK_KHR_portability_subset");
     }
 
@@ -697,8 +702,38 @@ bool VKDevice::create_logical_device(vk::Instance /*instance*/, const GraphicsBa
     feature_chain.get<vk::PhysicalDeviceVulkan13Features>().synchronization2 = VK_TRUE;
     feature_chain.get<vk::PhysicalDeviceVulkan12Features>().bufferDeviceAddress = VK_TRUE;
 
+    std::vector<std::string> missing_required;
+
     for (const auto& ext : backend_info.required_extensions) {
-        device_extensions.push_back(ext.c_str());
+        if (is_supported(ext)) {
+            device_extensions.push_back(ext.c_str());
+        } else {
+            missing_required.push_back(ext);
+        }
+    }
+
+    if (!missing_required.empty()) {
+        std::string names;
+        for (const auto& ext : missing_required) {
+            if (!names.empty())
+                names += ", ";
+            names += ext;
+        }
+
+        error<std::runtime_error>(Journal::Component::Core, Journal::Context::GraphicsBackend,
+            std::source_location::current(),
+            "Device '{}' does not support required extension(s): {}",
+            m_device_name, names);
+    }
+
+    for (const auto& ext : backend_info.optional_extensions) {
+        if (is_supported(ext)) {
+            device_extensions.push_back(ext.c_str());
+        } else {
+            MF_WARN(Journal::Component::Core, Journal::Context::GraphicsBackend,
+                "Device '{}' does not support optional extension '{}'; skipping",
+                m_device_name, ext);
+        }
     }
 
     vk::DeviceCreateInfo create_info {};

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKDevice.hpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKDevice.hpp
@@ -40,13 +40,12 @@ public:
     VKDevice& operator=(VKDevice&&) noexcept;
 
     /**
-     * @brief Initialize device (pick physical device and create logical device)
+     * @brief Select a physical device and create the logical device
      * @param instance Vulkan instance
-     * @param backend_info Graphics surface configuration
-     * @param temp_surface Temporary surface for presentation support checks (real surface created with windows and swapchain later)
+     * @param backend_info Graphics backend configuration, including device selection
      * @return true if initialization succeeded
      */
-    bool initialize(vk::Instance instance, vk::SurfaceKHR temp_surface, const GraphicsBackendInfo& backend_info);
+    bool initialize(vk::Instance instance, const GraphicsBackendInfo& backend_info);
 
     /**
      * @brief Cleanup device resources
@@ -82,6 +81,12 @@ public:
      * @brief Get queue family indices
      */
     [[nodiscard]] const QueueFamilyIndices& get_queue_families() const { return m_queue_families; }
+
+    /** @brief Name of the selected physical device */
+    [[nodiscard]] const std::string& get_device_name() const { return m_device_name; }
+
+    /** @brief Whether the graphics queue family passed the surfaceless presentation probe */
+    [[nodiscard]] bool graphics_family_presents() const { return m_graphics_presents; }
 
     /**
      * @brief Update presentation queue family for a specific surface
@@ -122,20 +127,19 @@ private:
     QueueFamilyIndices m_queue_families; ///< Indices of required queue families
 
     /**
-     * @brief Pick a suitable physical device (GPU)
+     * @brief Select a physical device by config selector or score
      * @param instance Vulkan instance
-     * @param temp_surface Temporary surface for presentation support checks
+     * @param backend_info Graphics backend configuration
      * @return true if a suitable device was found
      */
-    bool pick_physical_device(vk::Instance instance, vk::SurfaceKHR temp_surface);
+    bool pick_physical_device(vk::Instance instance, const GraphicsBackendInfo& backend_info);
 
     /**
      * @brief Find queue families on the given physical device
      * @param device Physical device to query
-     * @param surface Optional surface to check for presentation support
      * @return QueueFamilyIndices with found queue family indices
      */
-    QueueFamilyIndices find_queue_families(vk::PhysicalDevice device, vk::SurfaceKHR surface = nullptr);
+    static QueueFamilyIndices find_queue_families(vk::PhysicalDevice device);
 
     /**
      * @brief Create the logical device and retrieve queue handles
@@ -147,7 +151,9 @@ private:
     bool create_logical_device(vk::Instance instance, const GraphicsBackendInfo& backend_info);
 
     bool m_presentation_initialized {}; ///< Whether presentation support has been initialized
-
     bool m_supports_mesh_shaders {}; ///< Whether the device supports mesh shaders
+    bool m_graphics_presents {}; ///< Graphics family passed the surfaceless presentation probe
+    std::string m_device_name; ///< Selected device name, cached for logging
+    std::array<uint8_t, VK_UUID_SIZE> m_device_uuid {}; ///< Selected device UUID
 };
 }

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKDevice.hpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKDevice.hpp
@@ -9,16 +9,47 @@ struct GraphicsBackendInfo;
 /**
  * @struct QueueFamilyIndices
  * @brief Stores indices of queue families we need
+ *
+ * Immutable after VKDevice::create_logical_device. Presentation is a property
+ * of the device, the family, and the platform, resolved once at device
+ * selection, so present_family_mask is never renegotiated per surface.
  */
 struct QueueFamilyIndices {
+    static constexpr uint32_t MAX_TRACKED_FAMILIES = 32; ///< Width of present_family_mask
+
     std::optional<uint32_t> graphics_family;
     std::optional<uint32_t> compute_family;
     std::optional<uint32_t> transfer_family;
-    std::optional<uint32_t> present_family;
+
+    /** @brief Bit i set when family i passed the surfaceless presentation probe. */
+    uint32_t present_family_mask {};
 
     [[nodiscard]] bool is_complete() const
     {
         return graphics_family.has_value();
+    }
+
+    /** @brief Whether family @p index can present. */
+    [[nodiscard]] bool can_present(uint32_t index) const
+    {
+        return index < MAX_TRACKED_FAMILIES && (present_family_mask & (1U << index)) != 0;
+    }
+
+    /**
+     * @brief Family the engine presents on by default.
+     * @return The graphics family when it can present, otherwise the lowest
+     *         presentation-capable family, otherwise empty.
+     */
+    [[nodiscard]] std::optional<uint32_t> preferred_present_family() const
+    {
+        if (graphics_family.has_value() && can_present(graphics_family.value()))
+            return graphics_family;
+
+        for (uint32_t i = 0; i < MAX_TRACKED_FAMILIES; ++i) {
+            if (can_present(i))
+                return i;
+        }
+        return std::nullopt;
     }
 };
 
@@ -89,11 +120,32 @@ public:
     [[nodiscard]] bool graphics_family_presents() const { return m_graphics_presents; }
 
     /**
-     * @brief Update presentation queue family for a specific surface
-     * @param surface Surface to check presentation support for
-     * @return true if presentation support found
+     * @brief Confirm the graphics family presents to a concrete surface
+     * @param surface Surface to check
+     * @return true if presentation is supported
+     *
+     * Device selection already guarantees this when require_presentation is
+     * set; this confirms the surfaceless probe against a real surface. Const
+     * and non-mutating, so it is safe from any thread.
      */
-    bool update_presentation_queue(vk::SurfaceKHR surface);
+    [[nodiscard]] bool graphics_family_can_present(vk::SurfaceKHR surface) const;
+
+    /**
+     * @brief Queue for a presentation-capable family
+     * @param family_index Family index, must be set in present_family_mask
+     * @return Queue handle, or null if the family has no presentation support
+     *
+     * A queue is created for every family in the mask, not only the one the
+     * engine's default present path uses, so a caller driving its own
+     * presentation has a queue available without recreating the device.
+     */
+    [[nodiscard]] vk::Queue get_present_queue(uint32_t family_index) const;
+
+    /**
+     * @brief Queue for the preferred presentation family
+     * @return Queue handle, or null when no family can present
+     */
+    [[nodiscard]] vk::Queue get_preferred_present_queue() const;
 
     /**
      * @brief Wait for the device to become idle
@@ -150,10 +202,10 @@ private:
      */
     bool create_logical_device(vk::Instance instance, const GraphicsBackendInfo& backend_info);
 
-    bool m_presentation_initialized {}; ///< Whether presentation support has been initialized
-    bool m_supports_mesh_shaders {}; ///< Whether the device supports mesh shaders
     bool m_graphics_presents {}; ///< Graphics family passed the surfaceless presentation probe
+    std::unordered_map<uint32_t, vk::Queue> m_present_queues; ///< One queue per presentation-capable family
     std::string m_device_name; ///< Selected device name, cached for logging
     std::array<uint8_t, VK_UUID_SIZE> m_device_uuid {}; ///< Selected device UUID
+    bool m_supports_mesh_shaders {}; ///< Whether the device supports mesh shaders
 };
 }

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKSwapchain.cpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKSwapchain.cpp
@@ -12,7 +12,7 @@ VKSwapchain::~VKSwapchain()
 
 bool VKSwapchain::create(VKContext& context,
     vk::SurfaceKHR surface,
-    const WindowCreateInfo& window_config)
+    const WindowCreateInfo& window_config, const std::vector<uint32_t>& sharing_families)
 {
     m_context = &context;
     m_surface = surface;
@@ -91,17 +91,18 @@ bool VKSwapchain::create(VKContext& context,
             "Surface does not support eTransferSrc; frame capture will be unavailable");
     }
 
-    const auto& queue_families = m_context->get_queue_families();
+    m_sharing_families = sharing_families;
 
-    std::vector<uint32_t> queue_family_indices;
-    uint32_t graphics_family = queue_families.graphics_family.value();
-    uint32_t present_family = queue_families.present_family.value();
+    std::vector<uint32_t> unique_families;
+    for (uint32_t f : sharing_families) {
+        if (std::ranges::find(unique_families, f) == unique_families.end())
+            unique_families.push_back(f);
+    }
 
-    if (graphics_family != present_family) {
-        queue_family_indices = { graphics_family, present_family };
+    if (unique_families.size() > 1) {
         create_info.imageSharingMode = vk::SharingMode::eConcurrent;
-        create_info.queueFamilyIndexCount = static_cast<uint32_t>(queue_family_indices.size());
-        create_info.pQueueFamilyIndices = queue_family_indices.data();
+        create_info.queueFamilyIndexCount = static_cast<uint32_t>(unique_families.size());
+        create_info.pQueueFamilyIndices = unique_families.data();
     } else {
         create_info.imageSharingMode = vk::SharingMode::eExclusive;
         create_info.queueFamilyIndexCount = 0;
@@ -154,7 +155,7 @@ bool VKSwapchain::recreate(uint32_t width, uint32_t height)
 
     cleanup_swapchain();
 
-    return create(*m_context, m_surface, *m_window_config);
+    return create(*m_context, m_surface, *m_window_config, m_sharing_families);
 }
 
 void VKSwapchain::cleanup()

--- a/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKSwapchain.hpp
+++ b/src/MayaFlux/Core/Backends/Graphics/Vulkan/VKSwapchain.hpp
@@ -38,9 +38,15 @@ public:
      * @param context Vulkan context (provides device and configuration)
      * @param surface Window surface
      * @param window_config per-window configuration overrides
+     * @param sharing_families Queue families that will access the swapchain
+     *        images. Empty or single-entry yields eExclusive; two or more
+     *        distinct families yields eConcurrent. Supply both graphics and
+     *        present families when driving presentation on a separate queue.
      * @return True if creation succeeded
      */
-    bool create(VKContext& context, vk::SurfaceKHR surface, const WindowCreateInfo& window_config);
+    bool create(VKContext& context, vk::SurfaceKHR surface,
+        const WindowCreateInfo& window_config,
+        const std::vector<uint32_t>& sharing_families = {});
 
     /**
      * @brief Recreate swapchain (for window resize)
@@ -95,6 +101,7 @@ private:
     VKContext* m_context = nullptr; // Non-owning pointer to context
     vk::SurfaceKHR m_surface;
     const WindowCreateInfo* m_window_config = nullptr; // Store for recreation
+    std::vector<uint32_t> m_sharing_families;
 
     vk::SwapchainKHR m_swapchain;
     std::vector<vk::Image> m_images;

--- a/src/MayaFlux/Core/GlobalGraphicsInfo.hpp
+++ b/src/MayaFlux/Core/GlobalGraphicsInfo.hpp
@@ -32,6 +32,44 @@ struct MAYAFLUX_API GraphicsBackendInfo {
         bool fill_mode_non_solid = false;
     } required_features;
 
+    /**
+     * @brief Preferred physical device class when no explicit selector matches.
+     *
+     * AUTO scores discrete above integrated above virtual above everything
+     * else. The other values pin the class; if no device of that class
+     * survives the presentation and extension filters, selection falls back
+     * to AUTO ordering unless strict_device_selection is set.
+     *
+     * EXTERNAL is a heuristic, not a device type. Vulkan reports an external GPU
+     * as DISCRETE GPU, indistinguishable from a built-in one. EXTERNAL therefore
+     * means DISCRETE plus a preference for the highest PCI bus number, since
+     * a Thunderbolt-attached device sits behind a PCIe switch well above the
+     * root complex. It requires VK_EXT_pci_bus_info; without that extension
+     * EXTERNAL behaves as DISCRETE and says so in the log.
+     */
+    enum class DevicePreference : uint8_t {
+        AUTO,
+        DISCRETE,
+        INTEGRATED,
+        VIRTUAL,
+        EXTERNAL
+    } device_preference = DevicePreference::AUTO;
+
+    /** @brief Index into enumeration order; negative disables. Debugging escape hatch, prefer device_uuid. */
+    int32_t device_index = -1;
+
+    /** @brief Device UUID as 32 lowercase hex chars, no separators; empty disables. Read it from the startup candidate table. */
+    std::string device_uuid;
+
+    /** @brief Case-insensitive substring of the device name; empty disables. Ambiguous matches take the highest scoring one. */
+    std::string device_name;
+
+    /** @brief Require the graphics queue family to support presentation. Set false for headless or compute-only. */
+    bool require_presentation = true;
+
+    /** @brief Treat an unmatched selector as fatal rather than falling back to scoring. */
+    bool strict_device_selection = false;
+
     /** @brief Memory allocation strategy */
     enum class MemoryStrategy : uint8_t {
         CONSERVATIVE, ///< Minimize allocations
@@ -74,6 +112,12 @@ struct MAYAFLUX_API GraphicsBackendInfo {
         return std::make_tuple(
             Reflect::member("enable_validation", &GraphicsBackendInfo::enable_validation),
             Reflect::member("enable_debug_markers", &GraphicsBackendInfo::enable_debug_markers),
+            Reflect::member("device_preference", &GraphicsBackendInfo::device_preference),
+            Reflect::member("device_index", &GraphicsBackendInfo::device_index),
+            Reflect::member("device_uuid", &GraphicsBackendInfo::device_uuid),
+            Reflect::member("device_name", &GraphicsBackendInfo::device_name),
+            Reflect::member("require_presentation", &GraphicsBackendInfo::require_presentation),
+            Reflect::member("strict_device_selection", &GraphicsBackendInfo::strict_device_selection),
             // Reflect::member("required_features", &GraphicsBackendInfo::required_features),
             Reflect::member("memory_strategy", &GraphicsBackendInfo::memory_strategy),
             Reflect::member("command_pooling", &GraphicsBackendInfo::command_pooling),


### PR DESCRIPTION
On a machine with more than one GPU, MayaFlux picked whichever one the loader
happened to enumerate first. There was no way to say otherwise, and no way to
find out what it had picked or what else was available. This adds both.

## Choosing a GPU

```cpp
void settings() {
    auto& gfx = MayaFlux::Config::get_global_graphics_config();

    gfx.backend_info.device_preference =
        Core::GraphicsBackendInfo::DevicePreference::DISCRETE;
}
```

Or pin one exactly, using the uuid printed at startup:

```cpp
gfx.backend_info.device_uuid = "00000000030000000000000000000000";
```

Or by name substring, case-insensitive:

```cpp
gfx.backend_info.device_name = "7900";
```

The same fields work from JSON under `graphics.backend_info`, and
`MAYAFLUX_GPU` overrides all of it at runtime without a rebuild:

```sh
MAYAFLUX_GPU=1 ./my_piece
MAYAFLUX_GPU=intel ./my_piece
```

Selectors apply in precedence order: index, uuid, name, then preference as a
scoring bias. `strict_device_selection` turns an unmatched selector into a
startup failure instead of a fallback. `require_presentation` set false is the
headless and compute-only path.

## Seeing what is there

Every enumerated device is logged at startup, including the ones that were
rejected and why:

```log
GPU [0] AMD Radeon RX 7900 XTX (RADV NAVI31) | type=DiscreteGpu driver=MesaRadv (radv)
api=1.4.354 | uuid=00000000030000000000000000000000 | gfx=0 compute=1 transfer=0 |
present=gfx:yes mask:0x7 mesh=yes vram=24560MB pci_bus=3 | score=4623
```

The uuid in that line is what goes in the config. The driver id column names
the actual driver, which is the field that distinguishes a proprietary stack
from a Mesa one when behaviour differs between them.

Selection composes below driver-level filtering rather than overriding it.
`VK_DRIVER_FILES`, `MESA_VK_DEVICE_SELECT`, and the PRIME variables all act
before the engine sees the list, so a GPU missing from the log entirely was
filtered upstream.

## Presentation is now checked before the device is created

Previously a device could be selected that could not present at all, failing
later at swapchain creation. Checking earlier is awkward because
`vkGetPhysicalDeviceSurfaceSupportKHR` needs a surface, a surface needs a
window, and device selection runs from `GraphicsSubsystem` before any window
exists. The platform presentation entry points answer the same question from a
native display connection instead. On Wayland no connection exists at that
point either, since each window opens its own, so the probe opens one scratch
connection for the selection pass and closes it after.

Presentation support is resolved once, into an immutable mask, and never
renegotiated. Previously it was recomputed and written to shared device state
on every window registration, and its fallback branch could name a queue family
that the engine then did not present on. That path was unreachable on hardware
where the graphics family presents, which is every consumer GPU I know of, so
this is a correctness fix rather than a fix for observed breakage.

A side effect worth naming: `create_logical_device` now creates a queue for
every presentation-capable family, not just the one the default path uses.
Anyone wanting a dedicated present queue can now have one. Previously asking
for it was undefined behaviour, so the door was shut by omission rather than
by decision.

## Device extensions

`required_extensions` was passed to `createDevice` unchecked, so an
unsupported entry produced a driver-worded failure naming nothing.
`optional_extensions` was declared and never read. Both are now validated:
required ones fail at startup with the names, optional ones are skipped with a
warning.

```cpp
gfx.backend_info.optional_extensions = { "VK_EXT_memory_budget" };
```

## On a single-GPU machine

Nothing changes except the new startup log lines.

## Not included

Cross-device sharing. That needs external memory and semaphore extensions and,
more to the point, an answer to whether `VKContext` holds one device or
several, which reaches every device-scoped resource in the tree.