### PR TITLE
Deferred vision steps

### DIFF
--- a/data/shaders/cc_colorize.comp
+++ b/data/shaders/cc_colorize.comp
@@ -8,7 +8,7 @@ layout(local_size_x = 8, local_size_y = 8) in;
 layout(set = 0, binding = 0, rgba32f) uniform writeonly image2D out_image;
 layout(set = 0, binding = 1, rgba32f) uniform readonly image2D in_image;
 
-layout(set = 0, binding = 2, std430) buffer ParentBuf {
+layout(set = 0, binding = 2, std430) coherent volatile buffer ParentBuf {
     uint parent[];
 };
 

--- a/data/shaders/cc_compress.comp
+++ b/data/shaders/cc_compress.comp
@@ -5,7 +5,7 @@
 
 layout(local_size_x = 8, local_size_y = 8) in;
 
-layout(set = 0, binding = 2, std430) buffer BlockLabelBuf {
+layout(set = 0, binding = 2, std430) coherent volatile buffer BlockLabelBuf {
     uint block_label[];
 };
 

--- a/data/shaders/cc_final_label.comp
+++ b/data/shaders/cc_final_label.comp
@@ -12,7 +12,7 @@ layout(set = 0, binding = 2, std430) buffer BlockLabelBuf {
     uint block_label[];
 };
 
-layout(set = 0, binding = 4, std430) buffer LabelLutBuf {
+layout(set = 0, binding = 4, std430) coherent volatile buffer LabelLutBuf {
     uint label_lut[];
 };
 

--- a/data/shaders/cc_merge.comp
+++ b/data/shaders/cc_merge.comp
@@ -6,7 +6,7 @@ layout(local_size_x = 8, local_size_y = 8) in;
 
 layout(set = 0, binding = 1, rgba32f) uniform readonly image2D in_image;
 
-layout(set = 0, binding = 2, std430) buffer BlockLabelBuf {
+layout(set = 0, binding = 2, std430) coherent volatile buffer BlockLabelBuf {
     uint block_label[];
 };
 

--- a/data/shaders/harris_response.comp
+++ b/data/shaders/harris_response.comp
@@ -6,7 +6,7 @@ layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
 layout(set = 0, binding = 0, rgba32f) uniform image2D out_image;
 layout(set = 0, binding = 1, rgba32f) readonly uniform image2D in_image;
 
-layout(set = 0, binding = 2) coherent buffer PeakBuf {
+layout(set = 0, binding = 2, std430) coherent buffer PeakBuf {
     uint peak_bits;
 } peak_buf;
 

--- a/data/shaders/probe_image_read.comp
+++ b/data/shaders/probe_image_read.comp
@@ -3,7 +3,7 @@
 layout(local_size_x = 8, local_size_y = 8) in;
 
 layout(set = 0, binding = 0, rgba32f) uniform image2D in_image;
-layout(set = 0, binding = 1) buffer ProbeBuf {
+layout(set = 0, binding = 1, std430) buffer ProbeBuf {
     uint probe_bits;
     uint sentinel_bits;
 } probe;

--- a/data/shaders/vision_ingest.comp
+++ b/data/shaders/vision_ingest.comp
@@ -1,0 +1,32 @@
+#version 460
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+layout(set = 0, binding = 0, rgba32f) uniform writeonly image2D out_image;
+layout(set = 0, binding = 1) uniform sampler2D in_tex;
+
+layout(push_constant) uniform PC {
+    uint width;
+    uint height;
+} pc;
+
+/**
+ * @brief Ingest prelude for the GPU vision pipeline.
+ *
+ * The vision compute shaders bind their input as an rgba32f storage image.
+ * A source frame from the normal texture path is an 8-bit sampled texture,
+ * which cannot legally be bound to an rgba32f storage descriptor. This pass
+ * runs once per run() before any rgba32f processing: it reads the source as
+ * a sampled texture — the sampler unit performs the unorm/sRGB decode to
+ * float — and writes the result into a dedicated rgba32f storage image the
+ * rest of the pipeline then consumes. An already-rgba32f source is copied
+ * unchanged.
+ */
+void main()
+{
+    const ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+    if (coord.x >= int(pc.width) || coord.y >= int(pc.height))
+        return;
+
+    imageStore(out_image, coord, texelFetch(in_tex, coord, 0));
+}

--- a/src/MayaFlux/Buffers/Textures/ImageCVProcessor.hpp
+++ b/src/MayaFlux/Buffers/Textures/ImageCVProcessor.hpp
@@ -8,6 +8,7 @@
 
 #include "MayaFlux/Vruta/BroadcastSource.hpp"
 
+#include "MayaFlux/Kinesis/Vision/VisionExecutor.hpp"
 #include "MayaFlux/Yantra/Executors/VisionGpuDispatch.hpp"
 
 namespace MayaFlux::Buffers {

--- a/src/MayaFlux/Buffers/Textures/ImageCVProcessor.hpp
+++ b/src/MayaFlux/Buffers/Textures/ImageCVProcessor.hpp
@@ -131,9 +131,16 @@ public:
                     image->get_width(), image->get_height());
             }
         } else {
-            m_result = m_executor->run(
+            auto pass = m_executor->run(
                 m_sequence, image,
                 image->get_width(), image->get_height());
+
+            if (!pass.is_ready()) {
+                m_is_processing.store(false, std::memory_order_release);
+                return;
+            }
+
+            m_result = std::move(pass);
         }
 
         if (m_result_source)

--- a/src/MayaFlux/Kakshya/Processors/VisionProcessor.cpp
+++ b/src/MayaFlux/Kakshya/Processors/VisionProcessor.cpp
@@ -90,14 +90,27 @@ void VisionProcessor::process(const std::shared_ptr<SignalSourceContainer>& cont
         } else if (auto tc = std::dynamic_pointer_cast<TextureContainer>(container)) {
             frame = tc->as_normalised_float(0);
         }
+
         if (!frame.empty())
             m_result = m_cpu_executor.run(m_sequence, frame, m_width, m_height);
     } else if (m_gpu_frame) {
-        const void* raw = container->get_raw_data();
-        if (raw) {
+        if (m_executor->is_suspended()) {
+            auto poll = m_executor->run(m_sequence, m_gpu_frame, m_width, m_height);
+            if (!poll.is_ready()) {
+                m_is_processing.store(false, std::memory_order_release);
+                return;
+            }
+            m_result = std::move(poll);
+        } else if (const void* raw = container->get_raw_data()) {
             auto& loom = Portal::Graphics::TextureLoom::instance();
             loom.upload_data(m_gpu_frame, raw, m_gpu_frame->get_size_bytes(), m_upload_staging);
-            m_result = m_executor->run(m_sequence, m_gpu_frame, m_width, m_height);
+
+            auto pass = m_executor->run(m_sequence, m_gpu_frame, m_width, m_height);
+            if (!pass.is_ready()) {
+                m_is_processing.store(false, std::memory_order_release);
+                return;
+            }
+            m_result = std::move(pass);
         }
     }
 

--- a/src/MayaFlux/Kakshya/Processors/VisionProcessor.hpp
+++ b/src/MayaFlux/Kakshya/Processors/VisionProcessor.hpp
@@ -2,6 +2,7 @@
 
 #include "MayaFlux/Kakshya/DataProcessor.hpp"
 
+#include "MayaFlux/Kinesis/Vision/VisionExecutor.hpp"
 #include "MayaFlux/Yantra/Executors/VisionGpuDispatch.hpp"
 
 namespace MayaFlux::Vruta {

--- a/src/MayaFlux/Kinesis/Vision/VisionContext.hpp
+++ b/src/MayaFlux/Kinesis/Vision/VisionContext.hpp
@@ -1,0 +1,211 @@
+#pragma once
+
+#include "ConnectedComponents.hpp"
+#include "Features.hpp"
+#include "Gradient.hpp"
+#include "OpticalFlow.hpp"
+#include "VisionOp.hpp"
+
+#include "MayaFlux/Kakshya/NDData/NDData.hpp"
+
+namespace MayaFlux::Core {
+class VKImage;
+}
+
+namespace MayaFlux::Kinesis::Vision {
+
+using StructuredOutput = std::variant<
+    std::monostate,
+    GradientResult,
+    ComponentResult,
+    std::vector<Contour>,
+    std::vector<Keypoint>,
+    std::vector<TrackResult>>;
+
+/**
+ * @brief Whether a run carried the sequence to its end.
+ *
+ * SUSPENDED means a deferred step has work outstanding. The result carries
+ * nothing and must not be consumed. Call run again with the same arguments
+ * to poll; the executor resumes where it left off and ignores the image
+ * argument until the sequence completes.
+ */
+enum class VisionStatus : uint8_t {
+    COMPLETE,
+    SUSPENDED,
+};
+
+/**
+ * @brief Result of executing a VisionSequence on one frame.
+ *
+ * pixel_image holds the final normalised float pixel buffer as a DataVariant
+ * (active alternative: vector<float>). Empty when the terminal step produces
+ * only structured output.
+ *
+ * Callers access pixel data via:
+ *   EigenAccess(result.pixel_image).view<Eigen::VectorXf>()  -- zero-copy Eigen map
+ *   std::get<std::vector<float>>(result.pixel_image)          -- direct vector access
+ *
+ * w and h are the dimensions of pixel_image. Both are 0 when pixel_image is empty.
+ */
+struct VisionResult {
+    Kakshya::DataVariant pixel_image { std::vector<float> {} };
+    StructuredOutput structured { std::monostate {} };
+    std::vector<SnapshotEntry> snapshots;
+    std::shared_ptr<Core::VKImage> debug_labels;
+    std::shared_ptr<Core::VKImage> debug_contours;
+    uint32_t w { 0 };
+    uint32_t h { 0 };
+    VisionStatus status { VisionStatus::COMPLETE };
+    size_t suspended_at { 0 };
+
+    /**
+     * @brief True when the sequence reached its end and this result may be
+     *        consumed, cached, or broadcast.
+     */
+    [[nodiscard]] bool is_ready() const noexcept
+    {
+        return status == VisionStatus::COMPLETE;
+    }
+
+    /**
+     * @brief Zero-copy float span into pixel_image storage.
+     * @return Empty span if pixel_image is not vector<float> or is empty.
+     */
+    [[nodiscard]] std::span<const float> as_span() const noexcept
+    {
+        const auto* v = std::get_if<std::vector<float>>(&pixel_image);
+        if (!v || v->empty())
+            return {};
+        return { v->data(), v->size() };
+    }
+};
+
+/**
+ * @brief State threaded through one execution of a VisionSequence.
+ *
+ * Shared by the CPU and GPU executors so op functions have one signature on
+ * both paths. Three bands: the walk, working storage, and redundancy caches.
+ *
+ * Cross-run retained state is not here. It is owned vectors on the CPU path
+ * and owned images on the GPU path, neither of which is a working storage
+ * handle, so each executor holds its own in its own types.
+ *
+ * @tparam Handle Working storage handle. Slot index on the CPU path,
+ *                shared_ptr<VKImage> on the GPU path.
+ *
+ * sequence is non-owning and valid only for the run that constructed the
+ * pass. Storage and caches outlive a single run once the pass is held by
+ * the executor; the walk band is reset per run by begin().
+ */
+template <typename Handle>
+struct VisionPass {
+    // -------------------------------------------------------------------------
+    // Walk
+    // -------------------------------------------------------------------------
+
+    const VisionSequence* sequence { nullptr };
+    size_t index { 0 };
+    uint32_t w { 0 };
+    uint32_t h { 0 };
+    uint32_t channels { 4 };
+    VisionResult result;
+
+    // -------------------------------------------------------------------------
+    // Working storage
+    // -------------------------------------------------------------------------
+
+    Handle current {};
+    uint32_t storage_w { 0 };
+    uint32_t storage_h { 0 };
+
+    // -------------------------------------------------------------------------
+    // Retained across runs
+    // -------------------------------------------------------------------------
+
+    Handle prev {};
+    Handle prev_cache {};
+    std::vector<Keypoint> prev_keypoints;
+
+    // -------------------------------------------------------------------------
+    // Redundancy caches
+    // -------------------------------------------------------------------------
+
+    struct Completed {
+        Handle output {};
+        Handle input {};
+    };
+
+    std::unordered_map<size_t, Completed> completed;
+
+    /**
+     * @brief Reset the walk band for a fresh run, leaving storage, retained
+     *        state, and caches intact.
+     */
+    void begin(const VisionSequence& seq, uint32_t width, uint32_t height)
+    {
+        sequence = &seq;
+        index = 0;
+        channels = 4;
+        result = VisionResult {};
+        set_geometry(width, height);
+    }
+
+    /**
+     * @brief Discard retained cross-run state. Storage and caches are kept.
+     */
+    void forget()
+    {
+        prev = Handle {};
+        prev_cache = Handle {};
+        prev_keypoints.clear();
+    }
+
+    [[nodiscard]] const VisionStep& step() const noexcept
+    {
+        return sequence->steps[index];
+    }
+
+    [[nodiscard]] size_t plane_size() const noexcept
+    {
+        return static_cast<size_t>(w) * h;
+    }
+
+    /**
+     * @brief Op at @p offset steps ahead, or nullptr past the end.
+     *
+     * Replaces the adjacency booleans derived by VisionSequence::Builder.
+     * Correct under any mutation of steps because it is evaluated at the
+     * point of use.
+     */
+    [[nodiscard]] const VisionStep* ahead(size_t offset = 1) const noexcept
+    {
+        const auto& steps = sequence->steps;
+        const size_t at = index + offset;
+        return at < steps.size() ? &steps[at] : nullptr;
+    }
+
+    void set_geometry(uint32_t width, uint32_t height) noexcept
+    {
+        w = width;
+        h = height;
+        result.w = width;
+        result.h = height;
+    }
+
+    /**
+     * @brief Memoised output for @p key when it was produced from @p input.
+     */
+    [[nodiscard]] const Handle* memo(size_t key, const Handle& input) const
+    {
+        auto it = completed.find(key);
+        if (it == completed.end() || !(it->second.input == input))
+            return nullptr;
+        return &it->second.output;
+    }
+};
+
+using CpuVisionPass = VisionPass<size_t>;
+using GpuVisionPass = VisionPass<std::shared_ptr<Core::VKImage>>;
+
+} // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Kinesis/Vision/VisionContext.hpp
+++ b/src/MayaFlux/Kinesis/Vision/VisionContext.hpp
@@ -139,11 +139,23 @@ struct VisionPass {
     std::unordered_map<size_t, Completed> completed;
 
     /**
-     * @brief Reset the walk band for a fresh run, leaving storage, retained
-     *        state, and caches intact.
+     * @brief Reset the walk band for a fresh run.
+     *
+     * Clears the memo unconditionally: its keys compare image handles, which
+     * proxy for content only within one walk. Across runs the caller's input
+     * and the contexts' output images are reused in place, so an equal handle
+     * does not mean equal pixels.
+     *
+     * Retained cross-run state is dropped only when the geometry changes,
+     * since surviving between runs is what it is for.
      */
     void begin(const VisionSequence& seq, uint32_t width, uint32_t height)
     {
+        completed.clear();
+
+        if (width != w || height != h)
+            forget();
+
         sequence = &seq;
         index = 0;
         channels = 4;

--- a/src/MayaFlux/Kinesis/Vision/VisionContext.hpp
+++ b/src/MayaFlux/Kinesis/Vision/VisionContext.hpp
@@ -197,6 +197,18 @@ struct VisionPass {
         return at < steps.size() ? &steps[at] : nullptr;
     }
 
+    /**
+     * @brief Op at @p offset steps back, or nullptr before the start.
+     *
+     * Counterpart to ahead(), for ops validating what produced their input.
+     */
+    [[nodiscard]] const VisionStep* behind(size_t offset = 1) const noexcept
+    {
+        if (offset > index)
+            return nullptr;
+        return &sequence->steps[index - offset];
+    }
+
     void set_geometry(uint32_t width, uint32_t height) noexcept
     {
         w = width;

--- a/src/MayaFlux/Kinesis/Vision/VisionExecutor.cpp
+++ b/src/MayaFlux/Kinesis/Vision/VisionExecutor.cpp
@@ -106,127 +106,123 @@ VisionResult VisionExecutor::run(
     if (slot_vec(k_slot_cur).capacity() < slot_min)
         slot_vec(k_slot_cur).reserve(slot_min);
 
-    uint32_t channels = 4;
-
     auto& cur_vec = slot_vec(k_slot_cur);
     cur_vec.assign(frame.begin(), frame.end());
 
-    size_t cur = k_slot_cur;
+    m_pass.begin(sequence, w, h);
+    m_pass.current = k_slot_cur;
+
     size_t nxt = k_slot_nxt;
-    auto en = static_cast<Eigen::Index>(static_cast<size_t>(w) * h);
+    auto en = static_cast<Eigen::Index>(m_pass.plane_size());
 
-    VisionResult result;
-    result.w = w;
-    result.h = h;
+    for (m_pass.index = 0; m_pass.index < sequence.steps.size(); ++m_pass.index) {
+        const auto& step = m_pass.step();
 
-    for (const auto& step : sequence.steps) {
         switch (step.op) {
-
         case VisionOp::Downsample2x: {
             uint32_t new_w = 0, new_h = 0;
-            downsample_2x(slot_vec(cur), slot_vec(nxt), w, h, channels, new_w, new_h);
+            downsample_2x(slot_vec(m_pass.current), slot_vec(nxt), w, h, m_pass.channels, new_w, new_h);
             w = new_w;
             h = new_h;
-            result.w = w;
-            result.h = h;
-            en = static_cast<Eigen::Index>(static_cast<size_t>(w) * h);
-            std::swap(cur, nxt);
-            result.structured = std::monostate {};
+            m_pass.set_geometry(w, h);
+            en = static_cast<Eigen::Index>(m_pass.plane_size());
+            std::swap(m_pass.current, nxt);
+            m_pass.result.structured = std::monostate {};
             break;
         }
 
         case VisionOp::RgbaToGray: {
-            rgba_to_gray(slot_vec(cur), slot_vec(nxt), w, h);
-            channels = 1;
-            std::swap(cur, nxt);
+            rgba_to_gray(slot_vec(m_pass.current), slot_vec(nxt), w, h);
+            m_pass.channels = 1;
+            std::swap(m_pass.current, nxt);
 
             if (sequence.tracks_keypoints && !sequence.track_follows_peaks) {
-                m_curr_gray_cache.assign(slot_vec(cur).begin(),
-                    slot_vec(cur).begin() + static_cast<size_t>(w) * h);
+                m_curr_gray_cache.assign(slot_vec(m_pass.current).begin(),
+                    slot_vec(m_pass.current).begin() + m_pass.plane_size());
             }
 
-            result.structured = std::monostate {};
+            m_pass.result.structured = std::monostate {};
             break;
         }
 
         case VisionOp::RgbaToHsv: {
-            rgba_to_hsv(slot_vec(cur), slot_vec(nxt), w, h);
-            channels = 3;
-            std::swap(cur, nxt);
-            result.structured = std::monostate {};
+            rgba_to_hsv(slot_vec(m_pass.current), slot_vec(nxt), w, h);
+            m_pass.channels = 3;
+            std::swap(m_pass.current, nxt);
+            m_pass.result.structured = std::monostate {};
             break;
         }
 
         case VisionOp::GrayToRgba: {
-            gray_to_rgba(slot_vec(cur), slot_vec(nxt), w, h);
-            channels = 4;
-            std::swap(cur, nxt);
-            result.structured = std::monostate {};
+            gray_to_rgba(slot_vec(m_pass.current), slot_vec(nxt), w, h);
+            m_pass.channels = 4;
+            std::swap(m_pass.current, nxt);
+            m_pass.result.structured = std::monostate {};
             break;
         }
 
         case VisionOp::Threshold: {
             const auto& p = get_params<ThresholdParams>(step.params, step.op);
-            slot_map_mut(cur, en) = (slot_map(cur, en) >= p.value).cast<float>();
-            result.structured = std::monostate {};
+            slot_map_mut(m_pass.current, en) = (slot_map(m_pass.current, en) >= p.value).cast<float>();
+            m_pass.result.structured = std::monostate {};
             break;
         }
 
         case VisionOp::ThresholdAdaptive: {
             const auto& p = get_params<ThresholdAdaptiveParams>(step.params, step.op);
-            threshold_adaptive(slot_vec(cur), slot_vec(nxt), w, h, p.block_size, p.offset);
-            std::swap(cur, nxt);
-            result.structured = std::monostate {};
+            threshold_adaptive(slot_vec(m_pass.current), slot_vec(nxt), w, h, p.block_size, p.offset);
+            std::swap(m_pass.current, nxt);
+            m_pass.result.structured = std::monostate {};
             break;
         }
 
         case VisionOp::ThresholdOtsu: {
-            threshold_otsu(slot_vec(cur), slot_vec(nxt));
-            std::swap(cur, nxt);
-            result.structured = std::monostate {};
+            threshold_otsu(slot_vec(m_pass.current), slot_vec(nxt));
+            std::swap(m_pass.current, nxt);
+            m_pass.result.structured = std::monostate {};
             break;
         }
 
         case VisionOp::NormalizeInplace: {
-            auto m = slot_map_mut(cur, en);
+            auto m = slot_map_mut(m_pass.current, en);
             const float mn = m.minCoeff();
             const float mx = m.maxCoeff();
             if (mx > mn)
                 m = (m - mn) / (mx - mn);
-            result.structured = std::monostate {};
+            m_pass.result.structured = std::monostate {};
             break;
         }
 
         case VisionOp::NormalizeRange: {
             const auto& p = get_params<NormalizeRangeParams>(step.params, step.op);
             if (p.hi > p.lo) {
-                auto m = slot_map_mut(cur, en);
+                auto m = slot_map_mut(m_pass.current, en);
                 m = ((m - p.lo) / (p.hi - p.lo)).max(0.0F).min(1.0F);
             }
-            result.structured = std::monostate {};
+            m_pass.result.structured = std::monostate {};
             break;
         }
 
         case VisionOp::GaussianBlur: {
             const auto& p = get_params<GaussianBlurParams>(step.params, step.op);
             const auto& kern = gaussian_kernel(p.sigma);
-            filter_separable(slot_vec(cur), slot_vec(k_slot_tmp), slot_vec(nxt), w, h, kern, kern);
-            std::swap(cur, nxt);
-            result.structured = std::monostate {};
+            filter_separable(slot_vec(m_pass.current), slot_vec(k_slot_tmp), slot_vec(nxt), w, h, kern, kern);
+            std::swap(m_pass.current, nxt);
+            m_pass.result.structured = std::monostate {};
             break;
         }
 
         case VisionOp::FilterSeparable: {
             const auto& p = get_params<FilterSeparableParams>(step.params, step.op);
-            filter_separable(slot_vec(cur), slot_vec(k_slot_tmp), slot_vec(nxt), w, h, p.kernel_x, p.kernel_y);
-            std::swap(cur, nxt);
-            result.structured = std::monostate {};
+            filter_separable(slot_vec(m_pass.current), slot_vec(k_slot_tmp), slot_vec(nxt), w, h, p.kernel_x, p.kernel_y);
+            std::swap(m_pass.current, nxt);
+            m_pass.result.structured = std::monostate {};
             break;
         }
 
         case VisionOp::Sobel: {
             GradientResult grad;
-            sobel(slot_vec(cur), slot_vec(k_slot_dx), slot_vec(k_slot_dy),
+            sobel(slot_vec(m_pass.current), slot_vec(k_slot_dx), slot_vec(k_slot_dy),
                 slot_vec(k_slot_tmp), w, h);
 
             auto dx = slot_map(k_slot_dx, en);
@@ -247,14 +243,14 @@ VisionResult VisionExecutor::run(
                 slot_vec(k_slot_dy).begin(), grad.angle.begin(),
                 [](float gx, float gy) { return std::atan2(gy, gx); });
 
-            result.structured = std::move(grad);
-            std::swap(cur, nxt);
+            m_pass.result.structured = std::move(grad);
+            std::swap(m_pass.current, nxt);
             break;
         }
 
         case VisionOp::Scharr: {
             GradientResult grad;
-            scharr(slot_vec(cur), slot_vec(k_slot_dx), slot_vec(k_slot_dy),
+            scharr(slot_vec(m_pass.current), slot_vec(k_slot_dx), slot_vec(k_slot_dy),
                 slot_vec(k_slot_tmp), w, h);
 
             auto dx = slot_map(k_slot_dx, en);
@@ -275,109 +271,109 @@ VisionResult VisionExecutor::run(
                 slot_vec(k_slot_dy).begin(), grad.angle.begin(),
                 [](float gx, float gy) { return std::atan2(gy, gx); });
 
-            result.structured = std::move(grad);
-            std::swap(cur, nxt);
+            m_pass.result.structured = std::move(grad);
+            std::swap(m_pass.current, nxt);
             break;
         }
 
         case VisionOp::Canny: {
             const auto& p = get_params<CannyParams>(step.params, step.op);
-            canny(slot_vec(cur), slot_vec(nxt), w, h, p.sigma, p.low_threshold, p.high_threshold);
-            std::swap(cur, nxt);
-            result.structured = std::monostate {};
+            canny(slot_vec(m_pass.current), slot_vec(nxt), w, h, p.sigma, p.low_threshold, p.high_threshold);
+            std::swap(m_pass.current, nxt);
+            m_pass.result.structured = std::monostate {};
             break;
         }
 
         case VisionOp::Erode: {
             const auto& p = get_params<MorphParams>(step.params, step.op);
-            erode(slot_vec(cur), slot_vec(nxt), w, h, p.radius);
-            std::swap(cur, nxt);
-            result.structured = std::monostate {};
+            erode(slot_vec(m_pass.current), slot_vec(nxt), w, h, p.radius);
+            std::swap(m_pass.current, nxt);
+            m_pass.result.structured = std::monostate {};
             break;
         }
 
         case VisionOp::Dilate: {
             const auto& p = get_params<MorphParams>(step.params, step.op);
-            dilate(slot_vec(cur), slot_vec(nxt), w, h, p.radius);
-            std::swap(cur, nxt);
-            result.structured = std::monostate {};
+            dilate(slot_vec(m_pass.current), slot_vec(nxt), w, h, p.radius);
+            std::swap(m_pass.current, nxt);
+            m_pass.result.structured = std::monostate {};
             break;
         }
 
         case VisionOp::Open: {
             const auto& p = get_params<MorphParams>(step.params, step.op);
-            open(slot_vec(cur), slot_vec(k_slot_tmp), slot_vec(nxt), w, h, p.radius);
-            std::swap(cur, nxt);
-            result.structured = std::monostate {};
+            open(slot_vec(m_pass.current), slot_vec(k_slot_tmp), slot_vec(nxt), w, h, p.radius);
+            std::swap(m_pass.current, nxt);
+            m_pass.result.structured = std::monostate {};
             break;
         }
 
         case VisionOp::Close: {
             const auto& p = get_params<MorphParams>(step.params, step.op);
-            close(slot_vec(cur), slot_vec(k_slot_tmp), slot_vec(nxt), w, h, p.radius);
-            std::swap(cur, nxt);
-            result.structured = std::monostate {};
+            close(slot_vec(m_pass.current), slot_vec(k_slot_tmp), slot_vec(nxt), w, h, p.radius);
+            std::swap(m_pass.current, nxt);
+            m_pass.result.structured = std::monostate {};
             break;
         }
 
         case VisionOp::MorphGradient: {
             const auto& p = get_params<MorphParams>(step.params, step.op);
-            morph_gradient(slot_vec(cur), slot_vec(k_slot_tmp), slot_vec(nxt), w, h, p.radius);
-            std::swap(cur, nxt);
-            result.structured = std::monostate {};
+            morph_gradient(slot_vec(m_pass.current), slot_vec(k_slot_tmp), slot_vec(nxt), w, h, p.radius);
+            std::swap(m_pass.current, nxt);
+            m_pass.result.structured = std::monostate {};
             break;
         }
 
         case VisionOp::ConnectedComponents: {
-            const size_t n = static_cast<size_t>(w) * h;
-            result.structured = connected_components(
-                std::span<const float>(slot_vec(cur)).subspan(0, n),
+            const size_t n = m_pass.plane_size();
+            m_pass.result.structured = connected_components(
+                std::span<const float>(slot_vec(m_pass.current)).subspan(0, n),
                 w, h);
-            slot_vec(cur).clear();
-            result.w = 0;
-            result.h = 0;
+            slot_vec(m_pass.current).clear();
+            m_pass.result.w = 0;
+            m_pass.result.h = 0;
             break;
         }
 
         case VisionOp::FindContours: {
             const auto& p = get_params<FindContoursParams>(step.params, step.op);
-            const size_t n = static_cast<size_t>(w) * h;
-            result.structured = find_contours(
-                std::span<const float>(slot_vec(cur)).subspan(0, n),
+            const size_t n = m_pass.plane_size();
+            m_pass.result.structured = find_contours(
+                std::span<const float>(slot_vec(m_pass.current)).subspan(0, n),
                 w, h, p.min_area, p.max_contours);
-            slot_vec(cur).clear();
-            result.w = 0;
-            result.h = 0;
+            slot_vec(m_pass.current).clear();
+            m_pass.result.w = 0;
+            m_pass.result.h = 0;
             break;
         }
 
         case VisionOp::HarrisResponse: {
             const auto& p = get_params<HarrisParams>(step.params, step.op);
             harris_response(
-                slot_vec(cur),
+                slot_vec(m_pass.current),
                 slot_vec(k_slot_dx), slot_vec(k_slot_dy), slot_vec(k_slot_tmp),
                 slot_vec(k_slot_ixx), slot_vec(k_slot_iyy), slot_vec(k_slot_ixy),
                 slot_vec(k_slot_sxx), slot_vec(k_slot_syy), slot_vec(k_slot_sxy),
                 slot_vec(nxt),
                 w, h, p.k, gaussian_kernel(p.sigma));
-            std::swap(cur, nxt);
-            result.structured = std::monostate {};
+            std::swap(m_pass.current, nxt);
+            m_pass.result.structured = std::monostate {};
             break;
         }
 
         case VisionOp::ExtractPeaks: {
             const auto& p = get_params<ExtractPeaksParams>(step.params, step.op);
-            auto kpts = extract_peaks(slot_vec(cur), w, h, p.threshold, p.nms_radius);
+            auto kpts = extract_peaks(slot_vec(m_pass.current), w, h, p.threshold, p.nms_radius);
             m_prev_keypoints = kpts;
 
             if (sequence.tracks_keypoints && !sequence.track_follows_peaks)
                 std::swap(std::get<std::vector<float>>(m_prev_gray), m_curr_gray_cache);
 
-            result.structured = std::move(kpts);
+            m_pass.result.structured = std::move(kpts);
             if (!sequence.track_follows_peaks) {
-                slot_vec(cur).clear();
-                result.w = 0;
-                result.h = 0;
+                slot_vec(m_pass.current).clear();
+                m_pass.result.w = 0;
+                m_pass.result.h = 0;
             }
             break;
         }
@@ -387,11 +383,11 @@ VisionResult VisionExecutor::run(
 
             auto& prev_vec = std::get<std::vector<float>>(m_prev_gray);
             if (prev_vec.empty() || m_prev_keypoints.empty()) {
-                std::swap(prev_vec, slot_vec(cur));
-                result.structured = std::vector<TrackResult> {};
-                slot_vec(cur).clear();
-                result.w = 0;
-                result.h = 0;
+                std::swap(prev_vec, slot_vec(m_pass.current));
+                m_pass.result.structured = std::vector<TrackResult> {};
+                slot_vec(m_pass.current).clear();
+                m_pass.result.w = 0;
+                m_pass.result.h = 0;
                 break;
             }
 
@@ -401,37 +397,40 @@ VisionResult VisionExecutor::run(
                 prev_pos.push_back(kp.position);
 
             auto tracked = track_keypoints(
-                prev_vec, slot_vec(cur),
+                prev_vec, slot_vec(m_pass.current),
                 w, h, prev_pos,
                 p.window_radius, p.max_iterations,
                 p.eigen_threshold, p.error_threshold);
 
-            std::swap(prev_vec, slot_vec(cur));
-            result.structured = std::move(tracked);
-            slot_vec(cur).clear();
-            result.w = 0;
-            result.h = 0;
+            std::swap(prev_vec, slot_vec(m_pass.current));
+            m_pass.result.structured = std::move(tracked);
+            slot_vec(m_pass.current).clear();
+            m_pass.result.w = 0;
+            m_pass.result.h = 0;
             break;
         }
 
         case VisionOp::Snapshot: {
-            if (slot_vec(cur).empty())
+            if (slot_vec(m_pass.current).empty())
                 break;
-            const size_t n = static_cast<size_t>(w) * h * channels;
+            const size_t n = m_pass.plane_size() * m_pass.channels;
             SnapshotEntry entry;
-            entry.pixels.assign(slot_vec(cur).begin(), slot_vec(cur).begin() + n);
+            entry.pixels.assign(slot_vec(m_pass.current).begin(), slot_vec(m_pass.current).begin() + n);
             entry.w = w;
             entry.h = h;
-            entry.channels = channels;
-            result.snapshots.push_back(std::move(entry));
+            entry.channels = m_pass.channels;
+            m_pass.result.snapshots.push_back(std::move(entry));
             break;
         }
-        } // switch
+        }
     }
 
-    result.pixel_image = std::move(m_slots[cur]);
-    slot_vec(cur).reserve(static_cast<size_t>(m_slot_w) * m_slot_h * 4);
-    return result;
+    m_pass.result.pixel_image = std::move(m_slots[m_pass.current]);
+    slot_vec(m_pass.current).reserve(static_cast<size_t>(m_slot_w) * m_slot_h * 4);
+
+    VisionResult out = std::move(m_pass.result);
+    m_pass.result = VisionResult {};
+    return out;
 }
 
 } // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Kinesis/Vision/VisionExecutor.cpp
+++ b/src/MayaFlux/Kinesis/Vision/VisionExecutor.cpp
@@ -114,6 +114,8 @@ VisionResult VisionExecutor::run(
 
     size_t nxt = k_slot_nxt;
     auto en = static_cast<Eigen::Index>(m_pass.plane_size());
+    const bool wants_tracking = tracks_keypoints(sequence);
+    const bool peaks_feed_track = track_follows_peaks(sequence);
 
     for (m_pass.index = 0; m_pass.index < sequence.steps.size(); ++m_pass.index) {
         const auto& step = m_pass.step();
@@ -136,7 +138,7 @@ VisionResult VisionExecutor::run(
             m_pass.channels = 1;
             std::swap(m_pass.current, nxt);
 
-            if (sequence.tracks_keypoints && !sequence.track_follows_peaks) {
+            if (wants_tracking && !peaks_feed_track) {
                 m_curr_gray_cache.assign(slot_vec(m_pass.current).begin(),
                     slot_vec(m_pass.current).begin() + m_pass.plane_size());
             }
@@ -366,11 +368,11 @@ VisionResult VisionExecutor::run(
             auto kpts = extract_peaks(slot_vec(m_pass.current), w, h, p.threshold, p.nms_radius);
             m_prev_keypoints = kpts;
 
-            if (sequence.tracks_keypoints && !sequence.track_follows_peaks)
+            if (wants_tracking && !peaks_feed_track)
                 std::swap(std::get<std::vector<float>>(m_prev_gray), m_curr_gray_cache);
 
             m_pass.result.structured = std::move(kpts);
-            if (!sequence.track_follows_peaks) {
+            if (!peaks_feed_track) {
                 slot_vec(m_pass.current).clear();
                 m_pass.result.w = 0;
                 m_pass.result.h = 0;

--- a/src/MayaFlux/Kinesis/Vision/VisionExecutor.hpp
+++ b/src/MayaFlux/Kinesis/Vision/VisionExecutor.hpp
@@ -43,6 +43,19 @@ using StructuredOutput = std::variant<
     std::vector<TrackResult>>;
 
 /**
+ * @brief Whether a run carried the sequence to its end.
+ *
+ * SUSPENDED means a deferred step has work outstanding. The result carries
+ * nothing and must not be consumed. Call run again with the same arguments
+ * to poll; the executor resumes where it left off and ignores the image
+ * argument until the sequence completes.
+ */
+enum class VisionStatus : uint8_t {
+    COMPLETE,
+    SUSPENDED,
+};
+
+/**
  * @brief Result of executing a VisionSequence on one frame.
  *
  * pixel_image holds the final normalised float pixel buffer as a DataVariant
@@ -63,6 +76,17 @@ struct VisionResult {
     std::shared_ptr<Core::VKImage> debug_contours;
     uint32_t w { 0 };
     uint32_t h { 0 };
+    VisionStatus status { VisionStatus::COMPLETE };
+    size_t suspended_at { 0 };
+
+    /**
+     * @brief True when the sequence reached its end and this result may be
+     *        consumed, cached, or broadcast.
+     */
+    [[nodiscard]] bool is_ready() const noexcept
+    {
+        return status == VisionStatus::COMPLETE;
+    }
 
     /**
      * @brief Zero-copy float span into pixel_image storage.

--- a/src/MayaFlux/Kinesis/Vision/VisionExecutor.hpp
+++ b/src/MayaFlux/Kinesis/Vision/VisionExecutor.hpp
@@ -1,17 +1,8 @@
 #pragma once
 
-#include "ConnectedComponents.hpp"
-#include "Features.hpp"
-#include "Gradient.hpp"
-#include "OpticalFlow.hpp"
-#include "VisionOp.hpp"
+#include "VisionContext.hpp"
 
 #include "MayaFlux/Kakshya/NDData/EigenAccess.hpp"
-#include "MayaFlux/Kakshya/NDData/NDData.hpp"
-
-namespace MayaFlux::Core {
-class VKImage;
-}
 
 /**
  * @file VisionExecutor.hpp
@@ -33,73 +24,6 @@ class VKImage;
  */
 
 namespace MayaFlux::Kinesis::Vision {
-
-using StructuredOutput = std::variant<
-    std::monostate,
-    GradientResult,
-    ComponentResult,
-    std::vector<Contour>,
-    std::vector<Keypoint>,
-    std::vector<TrackResult>>;
-
-/**
- * @brief Whether a run carried the sequence to its end.
- *
- * SUSPENDED means a deferred step has work outstanding. The result carries
- * nothing and must not be consumed. Call run again with the same arguments
- * to poll; the executor resumes where it left off and ignores the image
- * argument until the sequence completes.
- */
-enum class VisionStatus : uint8_t {
-    COMPLETE,
-    SUSPENDED,
-};
-
-/**
- * @brief Result of executing a VisionSequence on one frame.
- *
- * pixel_image holds the final normalised float pixel buffer as a DataVariant
- * (active alternative: vector<float>). Empty when the terminal step produces
- * only structured output.
- *
- * Callers access pixel data via:
- *   EigenAccess(result.pixel_image).view<Eigen::VectorXf>()  -- zero-copy Eigen map
- *   std::get<std::vector<float>>(result.pixel_image)          -- direct vector access
- *
- * w and h are the dimensions of pixel_image. Both are 0 when pixel_image is empty.
- */
-struct VisionResult {
-    Kakshya::DataVariant pixel_image { std::vector<float> {} };
-    StructuredOutput structured { std::monostate {} };
-    std::vector<SnapshotEntry> snapshots;
-    std::shared_ptr<Core::VKImage> debug_labels;
-    std::shared_ptr<Core::VKImage> debug_contours;
-    uint32_t w { 0 };
-    uint32_t h { 0 };
-    VisionStatus status { VisionStatus::COMPLETE };
-    size_t suspended_at { 0 };
-
-    /**
-     * @brief True when the sequence reached its end and this result may be
-     *        consumed, cached, or broadcast.
-     */
-    [[nodiscard]] bool is_ready() const noexcept
-    {
-        return status == VisionStatus::COMPLETE;
-    }
-
-    /**
-     * @brief Zero-copy float span into pixel_image storage.
-     * @return Empty span if pixel_image is not vector<float> or is empty.
-     */
-    [[nodiscard]] std::span<const float> as_span() const noexcept
-    {
-        const auto* v = std::get_if<std::vector<float>>(&pixel_image);
-        if (!v || v->empty())
-            return {};
-        return { v->data(), v->size() };
-    }
-};
 
 /**
  * @class VisionExecutor

--- a/src/MayaFlux/Kinesis/Vision/VisionExecutor.hpp
+++ b/src/MayaFlux/Kinesis/Vision/VisionExecutor.hpp
@@ -68,6 +68,15 @@ public:
     void reset();
 
 private:
+    /**
+     * @brief Walk state for the current run: sequence position, geometry,
+     *        working slot index, and the result under construction.
+     *
+     * Reset by begin() at the top of each run. Inter-frame state is separate,
+     * below.
+     */
+    CpuVisionPass m_pass;
+
     // =========================================================================
     // Scratch pool
     //

--- a/src/MayaFlux/Kinesis/Vision/VisionOp.hpp
+++ b/src/MayaFlux/Kinesis/Vision/VisionOp.hpp
@@ -149,10 +149,16 @@ using VisionParams = std::variant<
 
 /**
  * @brief One step in a VisionSequence: an op and its parameters.
+ *
+ * A deferred step submits its GPU work without waiting on the fence. The
+ * run that submits it returns SUSPENDED at that step index; a subsequent
+ * run polls the fence, and once signalled resumes the sequence from the
+ * following step. How many calls that takes is not the executor's concern.
  */
 struct VisionStep {
     VisionOp op;
     VisionParams params { std::monostate {} };
+    bool deferred { false };
 };
 
 /**
@@ -338,6 +344,16 @@ struct VisionSequence {
                 }
             }
             return seq;
+        }
+
+        /**
+         * @brief Mark the most recently pushed step deferred.
+         */
+        Builder& defer()
+        {
+            if (!m_steps.empty())
+                m_steps.back().deferred = true;
+            return *this;
         }
 
     private:

--- a/src/MayaFlux/Kinesis/Vision/VisionOp.hpp
+++ b/src/MayaFlux/Kinesis/Vision/VisionOp.hpp
@@ -378,9 +378,9 @@ inline void hash_combine(size_t& seed, size_t value)
 /**
  * @brief Hash a VisionStep's op and parameters together.
  *
- * Used to key GPU dispatch memoization within a single VisionGpuExecutor::run()
- * call, so an op run earlier in a sequence with identical parameters can be
- * reused rather than redispatched (e.g. Canny reusing an earlier Sobel step).
+ * Keys GPU dispatch memoization on VisionPass::completed, which spans one
+ * walk including any suspensions. Two steps hashing equal are treated as
+ * interchangeable, so every field that changes the output must be hashed.
  */
 inline size_t hash_vision_step(VisionOp op, const VisionParams& params)
 {
@@ -424,6 +424,11 @@ inline size_t hash_vision_step(VisionOp op, const VisionParams& params)
         } else if constexpr (std::is_same_v<T, FindContoursParams>) {
             hash_combine(seed, std::hash<float> {}(p.min_area));
             hash_combine(seed, std::hash<uint32_t> {}(p.max_contours));
+            hash_combine(seed, std::hash<uint32_t> {}(p.max_points_per_contour));
+            hash_combine(seed, std::hash<bool> {}(p.as_image));
+        } else if constexpr (std::is_same_v<T, ConnectedComponentsParams>) {
+            hash_combine(seed, std::hash<bool> {}(p.export_labels));
+            hash_combine(seed, std::hash<bool> {}(p.with_colors));
         }
     },
         params);

--- a/src/MayaFlux/Kinesis/Vision/VisionOp.hpp
+++ b/src/MayaFlux/Kinesis/Vision/VisionOp.hpp
@@ -168,9 +168,6 @@ struct VisionStep {
  */
 struct VisionSequence {
     std::vector<VisionStep> steps;
-    bool tracks_keypoints { false };
-    bool track_follows_peaks { false };
-    bool contours_follow_cc { false };
 
     /**
      * @brief Fluent builder for VisionSequence.
@@ -328,22 +325,7 @@ struct VisionSequence {
 
         [[nodiscard]] VisionSequence build()
         {
-            VisionSequence seq { .steps = std::move(m_steps) };
-            for (size_t i = 0; i < seq.steps.size(); ++i) {
-                if (seq.steps[i].op == VisionOp::TrackKeypoints)
-                    seq.tracks_keypoints = true;
-                if (i + 1 < seq.steps.size()
-                    && seq.steps[i].op == VisionOp::ExtractPeaks
-                    && seq.steps[i + 1].op == VisionOp::TrackKeypoints)
-                    seq.track_follows_peaks = true;
-                if (i + 1 < seq.steps.size()
-                    && seq.steps[i].op == VisionOp::ConnectedComponents
-                    && seq.steps[i + 1].op == VisionOp::FindContours) {
-                    seq.contours_follow_cc = true;
-                    std::get<ConnectedComponentsParams>(seq.steps[i].params).export_labels = true;
-                }
-            }
-            return seq;
+            return VisionSequence { .steps = std::move(m_steps) };
         }
 
         /**
@@ -434,6 +416,36 @@ inline size_t hash_vision_step(VisionOp op, const VisionParams& params)
         params);
 
     return seed;
+}
+
+/**
+ * @brief True when any step tracks keypoints.
+ *
+ * Whole-sequence, not index-local: the gray-frame capture this gates happens
+ * at RgbaToGray, arbitrarily far ahead of the TrackKeypoints step that needs
+ * it. Evaluate once per run; sequences are short.
+ */
+[[nodiscard]] inline bool tracks_keypoints(const VisionSequence& seq)
+{
+    return std::ranges::any_of(seq.steps,
+        [](const VisionStep& s) { return s.op == VisionOp::TrackKeypoints; });
+}
+
+/**
+ * @brief True when an ExtractPeaks step is immediately followed by TrackKeypoints.
+ *
+ * Whole-sequence for the same reason: the capture gate at RgbaToGray needs the
+ * answer before either step is reached. Ops sitting at the pair itself should
+ * use VisionPass::ahead() instead.
+ */
+[[nodiscard]] inline bool track_follows_peaks(const VisionSequence& seq)
+{
+    for (size_t i = 0; i + 1 < seq.steps.size(); ++i) {
+        if (seq.steps[i].op == VisionOp::ExtractPeaks
+            && seq.steps[i + 1].op == VisionOp::TrackKeypoints)
+            return true;
+    }
+    return false;
 }
 
 } // namespace MayaFlux::Kinesis::Vision

--- a/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
+++ b/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
@@ -448,12 +448,7 @@ VisionResult VisionGpuExecutor::run(
     auto& label_ctx = contexts.labels;
     auto& cc_pipeline = contexts.cc_pipeline;
 
-    VisionResult result;
-    result.w = w;
-    result.h = h;
-
     auto& foundry = Portal::Graphics::get_shader_foundry();
-    std::shared_ptr<Core::VKImage> current = image;
 
     Portal::Graphics::ShaderID last_shader_id = Portal::Graphics::INVALID_SHADER;
     std::string last_shader_path;
@@ -471,23 +466,25 @@ VisionResult VisionGpuExecutor::run(
         if (!foundry.is_fence_signaled(contexts.suspended.fence)) {
             VisionResult pending;
             pending.status = VisionStatus::SUSPENDED;
-            pending.suspended_at = contexts.suspended.step_index;
+            pending.suspended_at = contexts.pass.index;
             return pending;
         }
 
         foundry.release_fence(contexts.suspended.fence);
         contexts.suspended.fence = Portal::Graphics::INVALID_FENCE;
 
-        begin = contexts.suspended.step_index;
-        current = contexts.suspended.working;
-        w = contexts.suspended.w;
-        h = contexts.suspended.h;
-        result = std::move(contexts.suspended.partial);
-        contexts.suspended.working.reset();
+        begin = contexts.pass.index;
+    } else {
+        contexts.pass.begin(sequence, w, h);
+        contexts.pass.current = image;
     }
 
-    for (size_t i = begin; i < sequence.steps.size(); ++i) {
-        const auto& step = sequence.steps[i];
+    for (contexts.pass.index = begin; contexts.pass.index < sequence.steps.size(); ++contexts.pass.index) {
+        const auto& step = sequence.steps[contexts.pass.index];
+
+        const uint32_t w = contexts.pass.w;
+        const uint32_t h = contexts.pass.h;
+
         const auto cfg = config(step.op, step.params);
 
         if (cfg.shader_id == Portal::Graphics::INVALID_SHADER && cfg.shader_path.empty()) {
@@ -502,9 +499,9 @@ VisionResult VisionGpuExecutor::run(
             last_shader_id = cfg.shader_id;
             last_shader_path = cfg.shader_path;
         }
-        if (current != last_staged) {
-            pixel_ctx.stage_image(current);
-            last_staged = current;
+        if (contexts.pass.current != last_staged) {
+            pixel_ctx.stage_image(contexts.pass.current);
+            last_staged = contexts.pass.current;
         }
         if (w != last_w || h != last_h) {
             pixel_ctx.prepare_output_image(w, h);
@@ -528,16 +525,13 @@ VisionResult VisionGpuExecutor::run(
             pixel_ctx.clear_output_dimensions();
 
             auto downsampled = pixel_ctx.get_output_image(0);
-            completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = { .output = downsampled, .input = current };
-            current = downsampled;
-            last_staged = current;
+            completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = { .output = downsampled, .input = contexts.pass.current };
+            contexts.pass.current = downsampled;
+            last_staged = contexts.pass.current;
 
-            w = new_w;
-            h = new_h;
-            result.w = w;
-            result.h = h;
-            last_w = w;
-            last_h = h;
+            contexts.pass.set_geometry(new_w, new_h);
+            last_w = new_w;
+            last_h = new_h;
 
             continue;
         }
@@ -583,7 +577,7 @@ VisionResult VisionGpuExecutor::run(
             });
             std::vector<uint32_t> zeros(256, 0);
             structured_ctx.set_binding_data(3, std::span<const uint32_t>(zeros));
-            structured_ctx.stage_image(current);
+            structured_ctx.stage_image(contexts.pass.current);
             structured_ctx.set_push_constants(OtsuHistPC { .width = w, .height = h });
             structured_ctx.set_output_dimensions(w, h);
             {
@@ -627,7 +621,7 @@ VisionResult VisionGpuExecutor::run(
                     .workgroup(k_wg2d[0], k_wg2d[1])
                     .build());
             pixel_ctx.swap_shader(apply_cfg);
-            pixel_ctx.stage_image(current);
+            pixel_ctx.stage_image(contexts.pass.current);
             pixel_ctx.set_push_constants(ThresholdPC { .value = t_norm });
             pixel_ctx.prepare_output_image(w, h);
             {
@@ -637,11 +631,11 @@ VisionResult VisionGpuExecutor::run(
             }
             auto thresholded = pixel_ctx.get_output_image(0);
 
-            completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = { .output = thresholded, .input = current };
-            result.debug_labels = thresholded;
-            current = thresholded;
-            last_staged = current;
-            result.structured = std::monostate {};
+            completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = { .output = thresholded, .input = contexts.pass.current };
+            contexts.pass.result.debug_labels = thresholded;
+            contexts.pass.current = thresholded;
+            last_staged = contexts.pass.current;
+            contexts.pass.result.structured = std::monostate {};
             continue;
         }
         case VisionOp::Open:
@@ -655,7 +649,7 @@ VisionResult VisionGpuExecutor::run(
                 .push_constant_size = sizeof(MorphPC),
             };
             pixel_ctx.swap_shader(first_cfg);
-            pixel_ctx.stage_image(current);
+            pixel_ctx.stage_image(contexts.pass.current);
             pixel_ctx.set_push_constants(MorphPC { .radius = radius });
             pixel_ctx.prepare_output_image(w, h);
             pixel_ctx.set_output_dimensions(w, h);
@@ -683,15 +677,15 @@ VisionResult VisionGpuExecutor::run(
             }
 
             auto opened_closed = pixel_ctx.get_output_image(0);
-            completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = { .output = opened_closed, .input = current };
-            current = opened_closed;
-            last_staged = current;
-            result.structured = std::monostate {};
+            completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = { .output = opened_closed, .input = contexts.pass.current };
+            contexts.pass.current = opened_closed;
+            last_staged = contexts.pass.current;
+            contexts.pass.result.structured = std::monostate {};
             continue;
         }
         case VisionOp::Canny: {
             const auto& p = std::get<CannyParams>(step.params);
-            auto canny_input = current;
+            auto canny_input = contexts.pass.current;
 
             const auto blur_key = Kinesis::Vision::hash_vision_step(
                 VisionOp::GaussianBlur, GaussianBlurParams { .sigma = p.sigma });
@@ -819,10 +813,10 @@ VisionResult VisionGpuExecutor::run(
 
             completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = { .output = finalized, .input = canny_input };
 
-            result.debug_labels = finalized;
-            current = finalized;
-            last_staged = current;
-            result.structured = std::monostate {};
+            contexts.pass.result.debug_labels = finalized;
+            contexts.pass.current = finalized;
+            last_staged = contexts.pass.current;
+            contexts.pass.result.structured = std::monostate {};
             continue;
         }
         case VisionOp::HarrisResponse: {
@@ -830,9 +824,9 @@ VisionResult VisionGpuExecutor::run(
             const auto radius = static_cast<uint32_t>(std::ceil(p.sigma * 3.0F));
             const auto& weights = gaussian_kernel_1d(radius, p.sigma);
 
-            auto harris_input = current;
+            auto harris_input = contexts.pass.current;
             pixel_ctx.swap_shader({ .shader_path = "harris_grad_pack.comp.spv", .workgroup_size = k_wg2d });
-            pixel_ctx.stage_image(current);
+            pixel_ctx.stage_image(contexts.pass.current);
             pixel_ctx.prepare_output_image(w, h);
             {
                 const auto f = pixel_ctx.dispatch_async({});
@@ -875,10 +869,10 @@ VisionResult VisionGpuExecutor::run(
                 foundry.wait_for_fence(f);
                 foundry.release_fence(f);
             }
-            current = pixel_ctx.get_output_image(0);
-            completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = { .output = current, .input = harris_input };
+            contexts.pass.current = pixel_ctx.get_output_image(0);
+            completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = { .output = contexts.pass.current, .input = harris_input };
 
-            result.structured = std::monostate {};
+            contexts.pass.result.structured = std::monostate {};
             continue;
         }
         case VisionOp::ExtractPeaks: {
@@ -894,7 +888,7 @@ VisionResult VisionGpuExecutor::run(
             structured_ctx.set_output_size(1, sizeof(uint32_t));
             structured_ctx.set_output_size(2, static_cast<size_t>(k_max_kp) * 4 * sizeof(float));
 
-            structured_ctx.stage_image(current);
+            structured_ctx.stage_image(contexts.pass.current);
             structured_ctx.set_push_constants(ExtractPeaksPC {
                 .threshold = p.threshold,
                 .nms_radius = p.nms_radius,
@@ -910,9 +904,9 @@ VisionResult VisionGpuExecutor::run(
             foundry.release_fence(fence);
 
             if (sequence.track_follows_peaks) {
-                result.structured = std::monostate {};
-                result.w = w;
-                result.h = h;
+                contexts.pass.result.structured = std::monostate {};
+                contexts.pass.result.w = w;
+                contexts.pass.result.h = h;
                 continue;
             }
 
@@ -942,19 +936,19 @@ VisionResult VisionGpuExecutor::run(
             }
             std::ranges::sort(kpts, [](const auto& a, const auto& b) { return a.response > b.response; });
 
-            result.structured = std::move(kpts);
-            result.w = 0;
-            result.h = 0;
+            contexts.pass.result.structured = std::move(kpts);
+            contexts.pass.result.w = 0;
+            contexts.pass.result.h = 0;
             continue;
         }
         case VisionOp::ConnectedComponents: {
             const auto& p = std::get<Kinesis::Vision::ConnectedComponentsParams>(step.params);
 
-            if (!current) {
+            if (!contexts.pass.current) {
                 continue;
             }
 
-            const auto seed_input = current;
+            const auto seed_input = contexts.pass.current;
 
             const uint32_t block_width = (w + 1U) / 2U;
             const uint32_t block_height = (h + 1U) / 2U;
@@ -1064,7 +1058,7 @@ VisionResult VisionGpuExecutor::run(
             }
             cc_pipeline.clear_output_dimensions();
 
-            result.debug_labels = p.with_colors ? cc_pipeline.get_output_image(0) : nullptr;
+            contexts.pass.result.debug_labels = p.with_colors ? cc_pipeline.get_output_image(0) : nullptr;
 
             uint32_t compact_count = 0;
             cc_pipeline.download_shared(0, 5, &compact_count, sizeof(uint32_t));
@@ -1096,9 +1090,9 @@ VisionResult VisionGpuExecutor::run(
                 }
             }
 
-            result.structured = std::move(cc_result);
-            result.w = 0;
-            result.h = 0;
+            contexts.pass.result.structured = std::move(cc_result);
+            contexts.pass.result.w = 0;
+            contexts.pass.result.h = 0;
             continue;
         }
         case VisionOp::FindContours: {
@@ -1270,10 +1264,10 @@ VisionResult VisionGpuExecutor::run(
                 }
                 cc_pipeline.clear_output_dimensions();
 
-                result.debug_contours = cc_pipeline.get_output_image(0);
-                result.structured = std::monostate {};
-                result.w = 0;
-                result.h = 0;
+                contexts.pass.result.debug_contours = cc_pipeline.get_output_image(0);
+                contexts.pass.result.structured = std::monostate {};
+                contexts.pass.result.w = 0;
+                contexts.pass.result.h = 0;
                 continue;
             }
 
@@ -1319,30 +1313,25 @@ VisionResult VisionGpuExecutor::run(
                 out_contours.push_back({ .points = std::move(pts), .area = ap.x, .perimeter = ap.y, .parent_label = m.z });
             }
 
-            result.structured = std::move(out_contours);
-            result.w = 0;
-            result.h = 0;
+            contexts.pass.result.structured = std::move(out_contours);
+            contexts.pass.result.w = 0;
+            contexts.pass.result.h = 0;
             continue;
         }
         default:
             break;
         }
 
-        auto dispatch_input = current;
+        auto dispatch_input = contexts.pass.current;
         const auto fence = pixel_ctx.dispatch_async({});
 
         if (step.deferred) {
-            contexts.suspended = {
-                .fence = fence,
-                .step_index = i,
-                .working = pixel_ctx.get_output_image(0),
-                .w = w,
-                .h = h,
-                .partial = std::move(result),
-            };
+            contexts.pass.current = pixel_ctx.get_output_image(0);
+            contexts.suspended.fence = fence;
+
             VisionResult pending;
             pending.status = VisionStatus::SUSPENDED;
-            pending.suspended_at = i;
+            pending.suspended_at = contexts.pass.index;
             return pending;
         }
 
@@ -1350,12 +1339,12 @@ VisionResult VisionGpuExecutor::run(
         foundry.release_fence(fence);
 
         pixel_ctx.clear_output_dimensions();
-        current = pixel_ctx.get_output_image(0);
-        last_staged = current;
-        completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = { .output = current, .input = dispatch_input };
+        contexts.pass.current = pixel_ctx.get_output_image(0);
+        last_staged = contexts.pass.current;
+        completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = { .output = contexts.pass.current, .input = dispatch_input };
     }
 
-    return result;
+    return std::move(contexts.pass.result);
 }
 
 VisionResult VisionGpuExecutor::run(

--- a/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
+++ b/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
@@ -233,7 +233,7 @@ namespace {
         return cache.emplace(key, std::move(k)).first->second;
     }
 
-    CompletedOp op_threshold_otsu(VisionGpuContexts& contexts)
+    GpuVisionPass::Completed op_threshold_otsu(VisionGpuContexts& contexts)
     {
         auto& pixel_ctx = contexts.pixel;
         auto& structured_ctx = contexts.structured;
@@ -314,7 +314,7 @@ namespace {
         return { .output = thresholded, .input = otsu_input };
     }
 
-    CompletedOp op_open_close(
+    GpuVisionPass::Completed op_open_close(
         VisionGpuContexts& contexts,
         VisionOp op,
         const MorphParams& p)
@@ -371,9 +371,8 @@ namespace {
         return { .output = opened_closed, .input = morph_input };
     }
 
-    CompletedOp op_canny(
+    GpuVisionPass::Completed op_canny(
         VisionGpuContexts& contexts,
-        std::unordered_map<size_t, CompletedOp>& completed,
         const VisionParams& params,
         const CannyParams& p)
     {
@@ -388,8 +387,9 @@ namespace {
         const auto blur_key = Kinesis::Vision::hash_vision_step(
             VisionOp::GaussianBlur, GaussianBlurParams { .sigma = p.sigma });
         std::shared_ptr<Core::VKImage> blurred;
-        if (auto it = completed.find(blur_key);
-            it != completed.end() && it->second.input == canny_input) {
+
+        if (auto it = contexts.pass.completed.find(blur_key);
+            it != contexts.pass.completed.end() && it->second.input == canny_input) {
             blurred = it->second.output;
         } else {
             const auto radius = static_cast<uint32_t>(std::ceil(p.sigma * 3.0F));
@@ -406,13 +406,13 @@ namespace {
                 foundry.release_fence(f);
             }
             blurred = pixel_ctx.get_output_image(0);
-            completed[blur_key] = { .output = blurred, .input = canny_input };
+            contexts.pass.completed[blur_key] = { .output = blurred, .input = canny_input };
         }
 
         const auto sobel_key = Kinesis::Vision::hash_vision_step(VisionOp::Sobel, std::monostate {});
         std::shared_ptr<Core::VKImage> grad;
-        if (auto it = completed.find(sobel_key);
-            it != completed.end() && it->second.input == blurred) {
+        if (auto it = contexts.pass.completed.find(sobel_key);
+            it != contexts.pass.completed.end() && it->second.input == blurred) {
             grad = it->second.output;
         } else {
             const auto sobel_cfg = VisionGpuExecutor::config(VisionOp::Sobel, std::monostate {});
@@ -425,7 +425,7 @@ namespace {
                 foundry.release_fence(f);
             }
             grad = pixel_ctx.get_output_image(0);
-            completed[sobel_key] = { .output = grad, .input = blurred };
+            contexts.pass.completed[sobel_key] = { .output = grad, .input = blurred };
         }
 
         const GpuComputeConfig nms_cfg {
@@ -519,7 +519,7 @@ namespace {
         return { .output = finalized, .input = canny_input };
     }
 
-    CompletedOp op_harris_response(
+    GpuVisionPass::Completed op_harris_response(
         VisionGpuContexts& contexts,
         const HarrisParams& p)
     {
@@ -1409,21 +1409,21 @@ VisionResult VisionGpuExecutor::run(
             break;
         }
         case VisionOp::ThresholdOtsu: {
-            completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = op_threshold_otsu(contexts);
+            contexts.pass.completed[Kinesis::Vision::hash_vision_step(step.op, step.params)] = op_threshold_otsu(contexts);
             continue;
         }
         case VisionOp::Open:
         case VisionOp::Close: {
-            completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = op_open_close(contexts, step.op, std::get<MorphParams>(step.params));
+            contexts.pass.completed[Kinesis::Vision::hash_vision_step(step.op, step.params)] = op_open_close(contexts, step.op, std::get<MorphParams>(step.params));
             continue;
         }
         case VisionOp::Canny: {
-            completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = op_canny(contexts, completed_ops, step.params,
-                std::get<CannyParams>(step.params));
+            auto done = op_canny(contexts, step.params, std::get<CannyParams>(step.params));
+            contexts.pass.completed[Kinesis::Vision::hash_vision_step(step.op, step.params)] = done;
             continue;
         }
         case VisionOp::HarrisResponse: {
-            completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = op_harris_response(contexts, std::get<HarrisParams>(step.params));
+            contexts.pass.completed[Kinesis::Vision::hash_vision_step(step.op, step.params)] = op_harris_response(contexts, std::get<HarrisParams>(step.params));
             continue;
         }
         case VisionOp::ExtractPeaks: {
@@ -1454,6 +1454,13 @@ VisionResult VisionGpuExecutor::run(
             pixel_ctx.clear_output_dimensions();
             contexts.pass.current = pixel_ctx.get_output_image(0);
             contexts.bound_staged = contexts.pass.current;
+
+            const Kinesis::Vision::GpuVisionPass::Completed done {
+                .output = contexts.pass.current,
+                .input = dispatch_input
+            };
+            contexts.pass.completed[Kinesis::Vision::hash_vision_step(step.op, step.params)] = done;
+
             contexts.suspended.fence = fence;
 
             VisionResult pending;

--- a/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
+++ b/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
@@ -52,10 +52,6 @@ namespace {
         uint32_t width;
         uint32_t height;
     };
-    struct ExtractPC {
-        float threshold;
-        uint32_t nms_radius;
-    };
     struct CannyPC {
         float sigma;
         float lo;
@@ -563,6 +559,11 @@ namespace {
         };
         pixel_ctx.swap_shader(harris_resp_cfg);
         pixel_ctx.stage_image(smoothed);
+
+        /** Zero PeakBuf (binding 2) before pass 0 so its atomicMax starts clean;
+         *  clear the staged bytes before pass 1 so the accumulated max survives. */
+        const uint32_t peak_reset = 0U;
+        pixel_ctx.set_binding_data(2, std::span<const uint32_t>(&peak_reset, 1));
         pixel_ctx.set_push_constants(HarrisPC { .k = p.k, .pass = 0U, .width = w, .height = h });
         pixel_ctx.prepare_output_image(w, h);
         {
@@ -571,6 +572,7 @@ namespace {
             foundry.release_fence(f);
         }
 
+        pixel_ctx.set_binding_data(2, std::span<const uint32_t>(&peak_reset, 0));
         pixel_ctx.set_push_constants(HarrisPC { .k = p.k, .pass = 1U, .width = w, .height = h });
         {
             const auto f = pixel_ctx.dispatch_async({});
@@ -1236,7 +1238,7 @@ GpuComputeConfig VisionGpuExecutor::config(VisionOp op, const VisionParams& /*pa
     case VisionOp::HarrisResponse:
         return { .shader_path = "harris_response.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(HarrisPC) };
     case VisionOp::ExtractPeaks:
-        return { .shader_path = "extract_peaks.comp.spv", .workgroup_size = { 256, 1, 1 }, .push_constant_size = sizeof(ExtractPC) };
+        return { .shader_path = "extract_peaks.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(ExtractPeaksPC) };
     case VisionOp::ConnectedComponents:
         return { .shader_path = "cc_colorize.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(uint32_t) * 2 };
     case VisionOp::FindContours:

--- a/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
+++ b/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
@@ -465,7 +465,29 @@ VisionResult VisionGpuExecutor::run(
     last_w = w;
     last_h = h;
 
-    for (const auto& step : sequence.steps) {
+    size_t begin = 0;
+
+    if (contexts.suspended.is_active()) {
+        if (!foundry.is_fence_signaled(contexts.suspended.fence)) {
+            VisionResult pending;
+            pending.status = VisionStatus::SUSPENDED;
+            pending.suspended_at = contexts.suspended.step_index;
+            return pending;
+        }
+
+        foundry.release_fence(contexts.suspended.fence);
+        contexts.suspended.fence = Portal::Graphics::INVALID_FENCE;
+
+        begin = contexts.suspended.step_index;
+        current = contexts.suspended.working;
+        w = contexts.suspended.w;
+        h = contexts.suspended.h;
+        result = std::move(contexts.suspended.partial);
+        contexts.suspended.working.reset();
+    }
+
+    for (size_t i = begin; i < sequence.steps.size(); ++i) {
+        const auto& step = sequence.steps[i];
         const auto cfg = config(step.op, step.params);
 
         if (cfg.shader_id == Portal::Graphics::INVALID_SHADER && cfg.shader_path.empty()) {
@@ -1308,6 +1330,22 @@ VisionResult VisionGpuExecutor::run(
 
         auto dispatch_input = current;
         const auto fence = pixel_ctx.dispatch_async({});
+
+        if (step.deferred) {
+            contexts.suspended = {
+                .fence = fence,
+                .step_index = i,
+                .working = pixel_ctx.get_output_image(0),
+                .w = w,
+                .h = h,
+                .partial = std::move(result),
+            };
+            VisionResult pending;
+            pending.status = VisionStatus::SUSPENDED;
+            pending.suspended_at = i;
+            return pending;
+        }
+
         foundry.wait_for_fence(fence);
         foundry.release_fence(fence);
 

--- a/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
+++ b/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
@@ -820,7 +820,6 @@ namespace {
     bool op_find_contours(
         VisionGpuContexts& contexts,
         const VisionSequence& sequence,
-        const std::shared_ptr<Core::VKImage>& image,
         const FindContoursParams& p)
     {
         if (!sequence.contours_follow_cc) {
@@ -859,7 +858,7 @@ namespace {
 
         auto max_points = p.max_points_per_contour > 0 ? std::min<uint32_t>(p.max_points_per_contour, k_max_points_per_contour) : k_max_points_per_contour;
         cc_pipeline.swap_shader({ .shader_path = "contour_march.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(ContourMarchPC) });
-        cc_pipeline.stage_image_at(1, image, GpuBufferBinding::ElementType::IMAGE_SAMPLED);
+        cc_pipeline.stage_image_at(1, contexts.source, GpuBufferBinding::ElementType::IMAGE_SAMPLED);
         cc_pipeline.prepare_output_image(w, h);
         cc_pipeline.set_push_constants(ContourMarchPC {
             .width = w,
@@ -1251,6 +1250,31 @@ GpuComputeConfig VisionGpuExecutor::config(VisionOp op, const VisionParams& /*pa
     }
 }
 
+void VisionGpuExecutor::reset()
+{
+    if (!m_contexts)
+        return;
+
+    auto& contexts = *m_contexts;
+
+    if (contexts.suspended.is_active()) {
+        auto& foundry = Portal::Graphics::get_shader_foundry();
+        foundry.wait_for_fence(contexts.suspended.fence);
+        foundry.release_fence(contexts.suspended.fence);
+        contexts.suspended.fence = Portal::Graphics::INVALID_FENCE;
+    }
+
+    contexts.pass.sequence = nullptr;
+    contexts.pass.index = 0;
+    contexts.pass.result = Kinesis::Vision::VisionResult {};
+    contexts.pass.current.reset();
+    contexts.pass.forget();
+    contexts.pass.completed.clear();
+
+    contexts.source.reset();
+    contexts.bound_staged.reset();
+}
+
 // ============================================================================
 // run_gpu
 // ============================================================================
@@ -1271,6 +1295,12 @@ VisionResult VisionGpuExecutor::run(
     size_t begin = 0;
 
     if (contexts.suspended.is_active()) {
+        if (&sequence != contexts.pass.sequence) {
+            MF_WARN(Journal::Component::Yantra, Journal::Context::ComputeMatrix,
+                "run_gpu: polling a suspension with a different sequence; "
+                "the walk continues on the sequence the run started from");
+        }
+
         if (!foundry.is_fence_signaled(contexts.suspended.fence)) {
             VisionResult pending;
             pending.status = VisionStatus::SUSPENDED;
@@ -1281,10 +1311,11 @@ VisionResult VisionGpuExecutor::run(
         foundry.release_fence(contexts.suspended.fence);
         contexts.suspended.fence = Portal::Graphics::INVALID_FENCE;
 
-        begin = contexts.pass.index;
+        begin = contexts.pass.index + 1;
     } else {
         contexts.pass.begin(sequence, w, h);
         contexts.pass.current = image;
+        contexts.source = image;
     }
 
     for (contexts.pass.index = begin; contexts.pass.index < sequence.steps.size(); ++contexts.pass.index) {
@@ -1407,7 +1438,7 @@ VisionResult VisionGpuExecutor::run(
             continue;
         }
         case VisionOp::FindContours: {
-            if (!op_find_contours(contexts, sequence, image,
+            if (!op_find_contours(contexts, sequence,
                     std::get<Kinesis::Vision::FindContoursParams>(step.params)))
                 return VisionResult {};
             continue;
@@ -1420,7 +1451,9 @@ VisionResult VisionGpuExecutor::run(
         const auto fence = pixel_ctx.dispatch_async({});
 
         if (step.deferred) {
+            pixel_ctx.clear_output_dimensions();
             contexts.pass.current = pixel_ctx.get_output_image(0);
+            contexts.bound_staged = contexts.pass.current;
             contexts.suspended.fence = fence;
 
             VisionResult pending;

--- a/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
+++ b/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
@@ -595,7 +595,6 @@ namespace {
 
     void op_extract_peaks(
         VisionGpuContexts& contexts,
-        const VisionSequence& sequence,
         const ExtractPeaksParams& p)
     {
         auto& structured_ctx = contexts.structured;
@@ -629,7 +628,8 @@ namespace {
         foundry.wait_for_fence(fence);
         foundry.release_fence(fence);
 
-        if (sequence.track_follows_peaks) {
+        const auto* next = contexts.pass.ahead();
+        if (next && next->op == VisionOp::TrackKeypoints) {
             contexts.pass.result.structured = std::monostate {};
             contexts.pass.result.w = w;
             contexts.pass.result.h = h;
@@ -695,7 +695,18 @@ namespace {
 
         const CCBlockInitPC init_pc { .width = w, .height = h, .block_width = block_width, .block_height = block_height };
         const CCMergePC merge_pc { .width = w, .height = h, .block_width = block_width, .block_height = block_height };
-        const CCFinalLabelPC final_pc { .width = w, .height = h, .block_width = block_width, .block_height = block_height, .max_components = k_max_components, .export_labels = 1U };
+        const auto* next = contexts.pass.ahead();
+        const bool contours_follow = next && next->op == VisionOp::FindContours;
+        const uint32_t export_labels = (p.export_labels || contours_follow) ? 1U : 0U;
+
+        const CCFinalLabelPC final_pc {
+            .width = w,
+            .height = h,
+            .block_width = block_width,
+            .block_height = block_height,
+            .max_components = k_max_components,
+            .export_labels = export_labels
+        };
 
         cc_pipeline.swap_shader({ .shader_path = "cc_reset.comp.spv", .workgroup_size = { 256, 1, 1 }, .push_constant_size = sizeof(CCResetPC) });
         cc_pipeline.set_push_constants(CCResetPC {
@@ -825,12 +836,12 @@ namespace {
 
     bool op_find_contours(
         VisionGpuContexts& contexts,
-        const VisionSequence& sequence,
         const FindContoursParams& p)
     {
-        if (!sequence.contours_follow_cc) {
+        const auto* prev = contexts.pass.behind();
+        if (!prev || prev->op != VisionOp::ConnectedComponents) {
             MF_ERROR(Journal::Component::Yantra, Journal::Context::ComputeMatrix,
-                "run_gpu: FindContours requires ConnectedComponents(export_labels=true) as the immediately preceding step");
+                "run_gpu: FindContours requires ConnectedComponents as the immediately preceding step");
             return false;
         }
 
@@ -1511,7 +1522,7 @@ VisionResult VisionGpuExecutor::run(
             continue;
         }
         case VisionOp::ExtractPeaks: {
-            op_extract_peaks(contexts, sequence, std::get<ExtractPeaksParams>(step.params));
+            op_extract_peaks(contexts, std::get<ExtractPeaksParams>(step.params));
             continue;
         }
         case VisionOp::ConnectedComponents: {
@@ -1522,7 +1533,7 @@ VisionResult VisionGpuExecutor::run(
             continue;
         }
         case VisionOp::FindContours: {
-            if (!op_find_contours(contexts, sequence,
+            if (!op_find_contours(contexts,
                     std::get<Kinesis::Vision::FindContoursParams>(step.params)))
                 return VisionResult {};
             continue;

--- a/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
+++ b/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
@@ -365,6 +365,151 @@ namespace {
         return { .output = opened_closed, .input = morph_input };
     }
 
+    CompletedOp op_canny(
+        VisionGpuContexts& contexts,
+        std::unordered_map<size_t, CompletedOp>& completed,
+        const VisionParams& params,
+        const CannyParams& p)
+    {
+        auto& pixel_ctx = contexts.pixel;
+        auto& label_ctx = contexts.labels;
+        auto w = contexts.pass.w;
+        auto h = contexts.pass.h;
+        auto& foundry = Portal::Graphics::get_shader_foundry();
+
+        const auto canny_input = contexts.pass.current;
+
+        const auto blur_key = Kinesis::Vision::hash_vision_step(
+            VisionOp::GaussianBlur, GaussianBlurParams { .sigma = p.sigma });
+        std::shared_ptr<Core::VKImage> blurred;
+        if (auto it = completed.find(blur_key);
+            it != completed.end() && it->second.input == canny_input) {
+            blurred = it->second.output;
+        } else {
+            const auto radius = static_cast<uint32_t>(std::ceil(p.sigma * 3.0F));
+            const auto& weights = gaussian_kernel_1d(radius, p.sigma);
+            const auto blur_cfg = VisionGpuExecutor::config(VisionOp::GaussianBlur, GaussianBlurParams { .sigma = p.sigma });
+            pixel_ctx.swap_shader(blur_cfg);
+            pixel_ctx.stage_image(canny_input);
+            pixel_ctx.set_binding_data(2, std::span<const float>(weights));
+            pixel_ctx.set_push_constants(GaussianPC { .radius = radius, .width = w, .height = h });
+            pixel_ctx.prepare_output_image(w, h);
+            {
+                const auto f = pixel_ctx.dispatch_async({});
+                foundry.wait_for_fence(f);
+                foundry.release_fence(f);
+            }
+            blurred = pixel_ctx.get_output_image(0);
+            completed[blur_key] = { .output = blurred, .input = canny_input };
+        }
+
+        const auto sobel_key = Kinesis::Vision::hash_vision_step(VisionOp::Sobel, std::monostate {});
+        std::shared_ptr<Core::VKImage> grad;
+        if (auto it = completed.find(sobel_key);
+            it != completed.end() && it->second.input == blurred) {
+            grad = it->second.output;
+        } else {
+            const auto sobel_cfg = VisionGpuExecutor::config(VisionOp::Sobel, std::monostate {});
+            pixel_ctx.swap_shader(sobel_cfg);
+            pixel_ctx.stage_image(blurred);
+            pixel_ctx.prepare_output_image(w, h);
+            {
+                const auto f = pixel_ctx.dispatch_async({});
+                foundry.wait_for_fence(f);
+                foundry.release_fence(f);
+            }
+            grad = pixel_ctx.get_output_image(0);
+            completed[sobel_key] = { .output = grad, .input = blurred };
+        }
+
+        const GpuComputeConfig nms_cfg {
+            .shader_path = "canny_nms.comp.spv",
+            .workgroup_size = k_wg2d,
+        };
+        pixel_ctx.swap_shader(nms_cfg);
+        pixel_ctx.stage_image(grad);
+        pixel_ctx.prepare_output_image(w, h);
+        {
+            const auto f = pixel_ctx.dispatch_async({});
+            foundry.wait_for_fence(f);
+            foundry.release_fence(f);
+        }
+        auto suppressed = pixel_ctx.get_output_image(0);
+
+        const auto classify_cfg = VisionGpuExecutor::config(VisionOp::Canny, params);
+        pixel_ctx.swap_shader(classify_cfg);
+        pixel_ctx.stage_image(suppressed);
+        pixel_ctx.set_push_constants(ClassifyPC { .threshold = p.low_threshold, .value = 0.5F });
+        pixel_ctx.prepare_output_image(w, h);
+        {
+            const auto f = pixel_ctx.dispatch_async({});
+            foundry.wait_for_fence(f);
+            foundry.release_fence(f);
+        }
+        auto classified_weak = pixel_ctx.get_output_image(0);
+
+        pixel_ctx.stage_image(classified_weak);
+        pixel_ctx.set_push_constants(ClassifyPC { .threshold = p.high_threshold, .value = 1.0F });
+        pixel_ctx.prepare_output_image(w, h);
+        {
+            const auto f = pixel_ctx.dispatch_async({});
+            foundry.wait_for_fence(f);
+            foundry.release_fence(f);
+        }
+        auto classified = pixel_ctx.get_output_image(0);
+
+        constexpr uint32_t k_max_hysteresis_rounds = 64;
+        label_ctx.set_output_size(2, sizeof(uint32_t));
+        label_ctx.set_output_dimensions(w, h);
+        label_ctx.swap_shader({
+            .shader_path = "canny_hysteresis.comp.spv",
+            .workgroup_size = k_wg2d,
+            .push_constant_size = sizeof(HysteresisPC),
+        });
+        label_ctx.stage_image_at(0, classified, GpuBufferBinding::ElementType::IMAGE_STORAGE);
+        label_ctx.slot_binding(0).direction = GpuBufferBinding::Direction::INPUT_OUTPUT;
+        {
+            uint32_t zero = 0;
+            label_ctx.set_binding_data(2, std::span<const uint32_t>(&zero, 1));
+            const HysteresisPC hpc { .width = w, .height = h };
+            ExecutionContext chained_ctx;
+            chained_ctx.mode = ExecutionMode::CHAINED;
+            chained_ctx.parameters = ChainedParams {
+                .pass_count = k_max_hysteresis_rounds,
+                .pc_updater = [hpc](uint32_t, void* dst) { std::memcpy(dst, &hpc, sizeof(HysteresisPC)); },
+                .passes_per_batch = k_max_hysteresis_rounds,
+            };
+            label_ctx.execute(Datum<> {}, chained_ctx);
+        }
+        label_ctx.slot_binding(0).direction = GpuBufferBinding::Direction::OUTPUT;
+        auto hysteresis_result = classified;
+
+        const auto finalize_cfg = config_from_spec(
+            ShaderSpec::Assemble {}
+                .storage_image("out", BindingDirection::Output)
+                .storage_image("src", BindingDirection::Input)
+                .pc("threshold")
+                .op(KernelOp::CompareGE)
+                .workgroup(k_wg2d[0], k_wg2d[1])
+                .build());
+        pixel_ctx.swap_shader(finalize_cfg);
+        pixel_ctx.stage_image(hysteresis_result);
+        pixel_ctx.set_push_constants(FinalizePC { .threshold = 1.0F });
+        pixel_ctx.prepare_output_image(w, h);
+        {
+            const auto f = pixel_ctx.dispatch_async({});
+            foundry.wait_for_fence(f);
+            foundry.release_fence(f);
+        }
+        auto finalized = pixel_ctx.get_output_image(0);
+
+        contexts.pass.result.debug_labels = finalized;
+        contexts.pass.current = finalized;
+        contexts.pass.result.structured = std::monostate {};
+
+        return { .output = finalized, .input = canny_input };
+    }
+
     CompletedOp op_harris_response(
         VisionGpuContexts& contexts,
         const HarrisParams& p)
@@ -1242,139 +1387,9 @@ VisionResult VisionGpuExecutor::run(
             continue;
         }
         case VisionOp::Canny: {
-            const auto& p = std::get<CannyParams>(step.params);
-            auto canny_input = contexts.pass.current;
-
-            const auto blur_key = Kinesis::Vision::hash_vision_step(
-                VisionOp::GaussianBlur, GaussianBlurParams { .sigma = p.sigma });
-            std::shared_ptr<Core::VKImage> blurred;
-            if (auto it = completed_ops.find(blur_key);
-                it != completed_ops.end() && it->second.input == canny_input) {
-                blurred = it->second.output;
-            } else {
-                const auto radius = static_cast<uint32_t>(std::ceil(p.sigma * 3.0F));
-                const auto& weights = gaussian_kernel_1d(radius, p.sigma);
-                const auto blur_cfg = config(VisionOp::GaussianBlur, GaussianBlurParams { .sigma = p.sigma });
-                pixel_ctx.swap_shader(blur_cfg);
-                pixel_ctx.stage_image(canny_input);
-                pixel_ctx.set_binding_data(2, std::span<const float>(weights));
-                pixel_ctx.set_push_constants(GaussianPC { .radius = radius, .width = w, .height = h });
-                pixel_ctx.prepare_output_image(w, h);
-                {
-                    const auto f = pixel_ctx.dispatch_async({});
-                    foundry.wait_for_fence(f);
-                    foundry.release_fence(f);
-                }
-                blurred = pixel_ctx.get_output_image(0);
-                completed_ops[blur_key] = { .output = blurred, .input = canny_input };
-            }
-
-            const auto sobel_key = Kinesis::Vision::hash_vision_step(VisionOp::Sobel, std::monostate {});
-            std::shared_ptr<Core::VKImage> grad;
-            if (auto it = completed_ops.find(sobel_key);
-                it != completed_ops.end() && it->second.input == blurred) {
-                grad = it->second.output;
-            } else {
-                const auto sobel_cfg = config(VisionOp::Sobel, std::monostate {});
-                pixel_ctx.swap_shader(sobel_cfg);
-                pixel_ctx.stage_image(blurred);
-                pixel_ctx.prepare_output_image(w, h);
-                {
-                    const auto f = pixel_ctx.dispatch_async({});
-                    foundry.wait_for_fence(f);
-                    foundry.release_fence(f);
-                }
-                grad = pixel_ctx.get_output_image(0);
-                completed_ops[sobel_key] = { .output = grad, .input = blurred };
-            }
-
-            const GpuComputeConfig nms_cfg {
-                .shader_path = "canny_nms.comp.spv",
-                .workgroup_size = k_wg2d,
-            };
-            pixel_ctx.swap_shader(nms_cfg);
-            pixel_ctx.stage_image(grad);
-            pixel_ctx.prepare_output_image(w, h);
-            {
-                const auto f = pixel_ctx.dispatch_async({});
-                foundry.wait_for_fence(f);
-                foundry.release_fence(f);
-            }
-            auto suppressed = pixel_ctx.get_output_image(0);
-
-            const auto classify_cfg = config(VisionOp::Canny, step.params);
-            pixel_ctx.swap_shader(classify_cfg);
-            pixel_ctx.stage_image(suppressed);
-            pixel_ctx.set_push_constants(ClassifyPC { .threshold = p.low_threshold, .value = 0.5F });
-            pixel_ctx.prepare_output_image(w, h);
-            {
-                const auto f = pixel_ctx.dispatch_async({});
-                foundry.wait_for_fence(f);
-                foundry.release_fence(f);
-            }
-            auto classified_weak = pixel_ctx.get_output_image(0);
-
-            pixel_ctx.stage_image(classified_weak);
-            pixel_ctx.set_push_constants(ClassifyPC { .threshold = p.high_threshold, .value = 1.0F });
-            pixel_ctx.prepare_output_image(w, h);
-            {
-                const auto f = pixel_ctx.dispatch_async({});
-                foundry.wait_for_fence(f);
-                foundry.release_fence(f);
-            }
-            auto classified = pixel_ctx.get_output_image(0);
-
-            constexpr uint32_t k_max_hysteresis_rounds = 64;
-            label_ctx.set_output_size(2, sizeof(uint32_t));
-            label_ctx.set_output_dimensions(w, h);
-            label_ctx.swap_shader({
-                .shader_path = "canny_hysteresis.comp.spv",
-                .workgroup_size = k_wg2d,
-                .push_constant_size = sizeof(HysteresisPC),
-            });
-            label_ctx.stage_image_at(0, classified, GpuBufferBinding::ElementType::IMAGE_STORAGE);
-            label_ctx.slot_binding(0).direction = GpuBufferBinding::Direction::INPUT_OUTPUT;
-            {
-                uint32_t zero = 0;
-                label_ctx.set_binding_data(2, std::span<const uint32_t>(&zero, 1));
-                const HysteresisPC hpc { .width = w, .height = h };
-                ExecutionContext chained_ctx;
-                chained_ctx.mode = ExecutionMode::CHAINED;
-                chained_ctx.parameters = ChainedParams {
-                    .pass_count = k_max_hysteresis_rounds,
-                    .pc_updater = [hpc](uint32_t, void* dst) { std::memcpy(dst, &hpc, sizeof(HysteresisPC)); },
-                    .passes_per_batch = k_max_hysteresis_rounds,
-                };
-                label_ctx.execute(Datum<> {}, chained_ctx);
-            }
-            label_ctx.slot_binding(0).direction = GpuBufferBinding::Direction::OUTPUT;
-            auto hysteresis_result = classified;
-
-            const auto finalize_cfg = config_from_spec(
-                ShaderSpec::Assemble {}
-                    .storage_image("out", BindingDirection::Output)
-                    .storage_image("src", BindingDirection::Input)
-                    .pc("threshold")
-                    .op(KernelOp::CompareGE)
-                    .workgroup(k_wg2d[0], k_wg2d[1])
-                    .build());
-            pixel_ctx.swap_shader(finalize_cfg);
-            pixel_ctx.stage_image(hysteresis_result);
-            pixel_ctx.set_push_constants(FinalizePC { .threshold = 1.0F });
-            pixel_ctx.prepare_output_image(w, h);
-            {
-                const auto f = pixel_ctx.dispatch_async({});
-                foundry.wait_for_fence(f);
-                foundry.release_fence(f);
-            }
-            auto finalized = pixel_ctx.get_output_image(0);
-
-            completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = { .output = finalized, .input = canny_input };
-
-            contexts.pass.result.debug_labels = finalized;
-            contexts.pass.current = finalized;
+            completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = op_canny(contexts, completed_ops, step.params,
+                std::get<CannyParams>(step.params));
             last_staged = contexts.pass.current;
-            contexts.pass.result.structured = std::monostate {};
             continue;
         }
         case VisionOp::HarrisResponse: {

--- a/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
+++ b/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
@@ -433,6 +433,470 @@ GpuComputeConfig VisionGpuExecutor::config(VisionOp op, const VisionParams& /*pa
     }
 }
 
+void VisionGpuExecutor::op_extract_peaks(
+    VisionGpuContexts& contexts,
+    const VisionSequence& sequence,
+    const ExtractPeaksParams& p)
+{
+    auto& structured_ctx = contexts.structured;
+    auto w = contexts.pass.w;
+    auto h = contexts.pass.h;
+    auto& foundry = Portal::Graphics::get_shader_foundry();
+
+    constexpr uint32_t k_max_kp = 4096;
+
+    structured_ctx.swap_shader({
+        .shader_path = "extract_peaks.comp.spv",
+        .workgroup_size = { 8, 8, 1 },
+        .push_constant_size = sizeof(ExtractPeaksPC),
+    });
+
+    structured_ctx.set_output_size(1, sizeof(uint32_t));
+    structured_ctx.set_output_size(2, static_cast<size_t>(k_max_kp) * 4 * sizeof(float));
+
+    structured_ctx.stage_image(contexts.pass.current);
+    structured_ctx.set_push_constants(ExtractPeaksPC {
+        .threshold = p.threshold,
+        .nms_radius = p.nms_radius,
+        .width = w,
+        .height = h,
+        .max_keypoints = k_max_kp,
+    });
+
+    structured_ctx.set_output_dimensions(w, h);
+    const auto fence = structured_ctx.dispatch_async({});
+    structured_ctx.clear_output_dimensions();
+    foundry.wait_for_fence(fence);
+    foundry.release_fence(fence);
+
+    if (sequence.track_follows_peaks) {
+        contexts.pass.result.structured = std::monostate {};
+        contexts.pass.result.w = w;
+        contexts.pass.result.h = h;
+        return;
+    }
+
+    const auto gpu_result = structured_ctx.collect_result();
+
+    uint32_t count = 0;
+    if (auto it = gpu_result.aux.find(1); it != gpu_result.aux.end())
+        std::memcpy(&count, it->second.data(), sizeof(uint32_t));
+    count = std::min(count, k_max_kp);
+
+    struct GpuKp {
+        float x, y, response, pad;
+    };
+    std::vector<GpuKp> raw(count);
+    if (count > 0) {
+        if (auto it = gpu_result.aux.find(2); it != gpu_result.aux.end())
+            std::memcpy(raw.data(), it->second.data(), count * sizeof(GpuKp));
+    }
+
+    std::vector<Kinesis::Vision::Keypoint> kpts;
+    kpts.reserve(count);
+    for (const auto& kp : raw) {
+        kpts.push_back({ .position = { kp.x, kp.y },
+            .response = kp.response,
+            .scale = 1.0F,
+            .angle = 0.0F });
+    }
+    std::ranges::sort(kpts, [](const auto& a, const auto& b) { return a.response > b.response; });
+
+    contexts.pass.result.structured = std::move(kpts);
+    contexts.pass.result.w = 0;
+    contexts.pass.result.h = 0;
+}
+
+void VisionGpuExecutor::op_connected_components(
+    VisionGpuContexts& contexts,
+    const ConnectedComponentsParams& p)
+{
+    auto& cc_pipeline = contexts.cc_pipeline;
+    auto w = contexts.pass.w;
+    auto h = contexts.pass.h;
+    auto& foundry = Portal::Graphics::get_shader_foundry();
+
+    const auto seed_input = contexts.pass.current;
+
+    const uint32_t block_width = (w + 1U) / 2U;
+    const uint32_t block_height = (h + 1U) / 2U;
+    const double block_diagonal = std::sqrt(
+        static_cast<double>(block_width) * block_width + static_cast<double>(block_height) * block_height);
+    const auto k_compress_passes = static_cast<uint32_t>(std::ceil(std::log2(std::max(2.0, block_diagonal))));
+
+    cc_pipeline.ensure_shared_buffer(0, 2, static_cast<size_t>(block_width) * block_height, GpuBufferBinding::ElementType::UINT32);
+    cc_pipeline.ensure_shared_buffer(0, 3, 1, GpuBufferBinding::ElementType::UINT32);
+    cc_pipeline.ensure_shared_buffer(0, 4, static_cast<size_t>(block_width) * block_height, GpuBufferBinding::ElementType::UINT32);
+    cc_pipeline.ensure_shared_buffer(0, 5, 1, GpuBufferBinding::ElementType::UINT32);
+    cc_pipeline.ensure_shared_buffer(0, 6, static_cast<size_t>(w) * h, GpuBufferBinding::ElementType::UINT32);
+    cc_pipeline.ensure_shared_buffer(0, 7, static_cast<size_t>(k_max_components) * 2, GpuBufferBinding::ElementType::UINT32);
+    cc_pipeline.ensure_shared_buffer(0, 8, static_cast<size_t>(k_max_components) * 2, GpuBufferBinding::ElementType::UINT32);
+    cc_pipeline.ensure_shared_buffer(0, 9, k_max_components, GpuBufferBinding::ElementType::UINT32);
+
+    const CCBlockInitPC init_pc { .width = w, .height = h, .block_width = block_width, .block_height = block_height };
+    const CCMergePC merge_pc { .width = w, .height = h, .block_width = block_width, .block_height = block_height };
+    const CCFinalLabelPC final_pc { .width = w, .height = h, .block_width = block_width, .block_height = block_height, .max_components = k_max_components, .export_labels = 1U };
+
+    cc_pipeline.swap_shader({ .shader_path = "cc_reset.comp.spv", .workgroup_size = { 256, 1, 1 }, .push_constant_size = sizeof(CCResetPC) });
+    cc_pipeline.set_push_constants(CCResetPC {
+        .lut_size = block_width * block_height,
+        .max_components = k_max_components,
+    });
+    cc_pipeline.set_output_dimensions(std::max(block_width * block_height, k_max_components), 1);
+    {
+        const auto reset_fence = cc_pipeline.dispatch_async({});
+        foundry.wait_for_fence(reset_fence);
+        foundry.release_fence(reset_fence);
+    }
+    cc_pipeline.clear_output_dimensions();
+
+    const std::array<uint32_t, 3> block_groups {
+        (block_width + k_wg2d[0] - 1U) / k_wg2d[0],
+        (block_height + k_wg2d[1] - 1U) / k_wg2d[1],
+        1U
+    };
+
+    std::vector<DependencyStage> cc_stages;
+
+    cc_stages.push_back({
+        .config = { .shader_path = "cc_block_init.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(CCBlockInitPC) },
+        .stage_fn = [&](GpuDispatchCore& ctx) {
+        cc_pipeline.stage_image_at(1, seed_input, GpuBufferBinding::ElementType::IMAGE_STORAGE);
+        ctx.set_push_constants(init_pc);
+        cc_pipeline.set_output_dimensions(block_width, block_height); },
+        .hazard_fn = [&](GpuDispatchCore& ctx) -> std::vector<Portal::Graphics::HazardResource> {
+            return {
+                ctx.shared_buffer_hazard(
+                    { .set = 0, .binding = 2, .direction = GpuBufferBinding::Direction::INPUT_OUTPUT, .element_type = GpuBufferBinding::ElementType::UINT32 }),
+            };
+        },
+        .explicit_groups = block_groups,
+    });
+
+    cc_stages.push_back({
+        .config = { .shader_path = "cc_merge.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(CCMergePC) },
+        .stage_fn = [&](GpuDispatchCore& ctx) {
+        cc_pipeline.stage_image_at(1, seed_input, GpuBufferBinding::ElementType::IMAGE_STORAGE);
+        ctx.set_push_constants(merge_pc);
+        cc_pipeline.set_output_dimensions(block_width, block_height); },
+        .hazard_fn = [&](GpuDispatchCore& ctx) -> std::vector<Portal::Graphics::HazardResource> {
+            return {
+                ctx.shared_buffer_hazard(
+                    { .set = 0, .binding = 2, .direction = GpuBufferBinding::Direction::INPUT_OUTPUT, .element_type = GpuBufferBinding::ElementType::UINT32 }),
+            };
+        },
+        .explicit_groups = block_groups,
+    });
+
+    ExecutionContext cc_ctx;
+    cc_ctx.mode = ExecutionMode::DEPENDENCY;
+    DependencyParams params;
+    params.stages = cc_stages;
+    cc_ctx.parameters = params;
+    cc_pipeline.execute(Datum<> {}, cc_ctx);
+
+    cc_pipeline.ensure_shared_buffer(0, 10, 3, GpuBufferBinding::ElementType::UINT32,
+        Portal::Graphics::BufferUsageHint::INDIRECT);
+    const std::array<uint32_t, 3> full_grid_indirect {
+        (block_width + 7U) / 8U,
+        (block_height + 7U) / 8U,
+        1U
+    };
+    cc_pipeline.upload_shared_raw(0, 10, reinterpret_cast<const uint8_t*>(full_grid_indirect.data()), full_grid_indirect.size() * sizeof(uint32_t));
+
+    cc_pipeline.swap_shader({ .shader_path = "cc_compress.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(CCCompressPC) });
+    cc_pipeline.set_push_constants(CCCompressPC { .block_width = block_width, .block_height = block_height });
+    cc_pipeline.set_output_dimensions(block_width, block_height);
+    {
+        const auto fence = cc_pipeline.dispatch_async({});
+        foundry.wait_for_fence(fence);
+        foundry.release_fence(fence);
+    }
+    cc_pipeline.clear_output_dimensions();
+
+    cc_pipeline.swap_shader({ .shader_path = "cc_final_label.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(CCFinalLabelPC) });
+    cc_pipeline.stage_image_at(1, seed_input, GpuBufferBinding::ElementType::IMAGE_STORAGE);
+    cc_pipeline.set_push_constants(final_pc);
+    cc_pipeline.set_output_dimensions(w, h);
+    cc_pipeline.prepare_output_image(w, h);
+    {
+        const auto fence = cc_pipeline.dispatch_async({});
+        foundry.wait_for_fence(fence);
+        foundry.release_fence(fence);
+    }
+    cc_pipeline.clear_output_dimensions();
+
+    contexts.pass.result.debug_labels = p.with_colors ? cc_pipeline.get_output_image(0) : nullptr;
+
+    uint32_t compact_count = 0;
+    cc_pipeline.download_shared(0, 5, &compact_count, sizeof(uint32_t));
+    compact_count = std::min(compact_count, k_max_components);
+
+    Kinesis::Vision::ComponentResult cc_result;
+    cc_result.count = compact_count;
+    cc_result.boxes.reserve(compact_count);
+
+    if (compact_count > 0) {
+        std::vector<glm::uvec2> bmin(compact_count);
+        std::vector<glm::uvec2> bmax(compact_count);
+        std::vector<uint32_t> bcount(compact_count);
+        cc_pipeline.download_shared(0, 7, bmin.data(), bmin.size() * sizeof(glm::uvec2));
+        cc_pipeline.download_shared(0, 8, bmax.data(), bmax.size() * sizeof(glm::uvec2));
+        cc_pipeline.download_shared(0, 9, bcount.data(), bcount.size() * sizeof(uint32_t));
+
+        const float inv_w = 1.0F / static_cast<float>(w);
+        const float inv_h = 1.0F / static_cast<float>(h);
+
+        for (uint32_t i = 0; i < compact_count; ++i) {
+            if (bcount[i] == 0)
+                continue;
+            const float x = static_cast<float>(bmin[i].x) * inv_w;
+            const float y = static_cast<float>(bmin[i].y) * inv_h;
+            const float bw = static_cast<float>(bmax[i].x - bmin[i].x + 1) * inv_w;
+            const float bh = static_cast<float>(bmax[i].y - bmin[i].y + 1) * inv_h;
+            cc_result.boxes.push_back({ .x = x, .y = y, .w = bw, .h = bh, .confidence = 1.0F, .label_id = i + 1 });
+        }
+    }
+
+    contexts.pass.result.structured = std::move(cc_result);
+    contexts.pass.result.w = 0;
+    contexts.pass.result.h = 0;
+}
+
+bool VisionGpuExecutor::op_find_contours(
+    VisionGpuContexts& contexts,
+    const VisionSequence& sequence,
+    const std::shared_ptr<Core::VKImage>& image,
+    const FindContoursParams& p)
+{
+    if (!sequence.contours_follow_cc) {
+        MF_ERROR(Journal::Component::Yantra, Journal::Context::ComputeMatrix,
+            "run_gpu: FindContours requires ConnectedComponents(export_labels=true) as the immediately preceding step");
+        return false;
+    }
+
+    auto& cc_pipeline = contexts.cc_pipeline;
+    auto w = contexts.pass.w;
+    auto h = contexts.pass.h;
+    auto& foundry = Portal::Graphics::get_shader_foundry();
+
+    cc_pipeline.ensure_shared_buffer(1, 4, static_cast<size_t>(k_max_components) + 1U, GpuBufferBinding::ElementType::UINT32);
+    cc_pipeline.ensure_shared_buffer(1, 5, static_cast<size_t>(k_max_components) * k_max_holes_per_label, GpuBufferBinding::ElementType::UINT32);
+    cc_pipeline.ensure_shared_buffer(1, 6, static_cast<size_t>(k_max_trace_slots) * 2U, GpuBufferBinding::ElementType::UINT32);
+    cc_pipeline.ensure_shared_buffer(1, 7, 1U, GpuBufferBinding::ElementType::UINT32);
+    cc_pipeline.ensure_shared_buffer(1, 8, static_cast<size_t>(k_max_trace_slots) * k_max_points_per_contour * 2U, GpuBufferBinding::ElementType::FLOAT32);
+    cc_pipeline.ensure_shared_buffer(1, 9, 1U, GpuBufferBinding::ElementType::UINT32);
+    cc_pipeline.ensure_shared_buffer(1, 10, static_cast<size_t>(k_max_trace_slots) * 4U, GpuBufferBinding::ElementType::UINT32);
+    cc_pipeline.ensure_shared_buffer(1, 11, static_cast<size_t>(k_max_trace_slots) * 2U, GpuBufferBinding::ElementType::FLOAT32);
+    cc_pipeline.ensure_shared_buffer(2, 0, k_max_components, GpuBufferBinding::ElementType::FLOAT32);
+    cc_pipeline.ensure_shared_buffer(2, 1, k_max_components, GpuBufferBinding::ElementType::FLOAT32);
+
+    {
+        std::vector<uint32_t> owner_reset(static_cast<size_t>(k_max_components) + 1U, CC_UNCLAIMED_HOST);
+        cc_pipeline.upload_shared_raw(1, 4, reinterpret_cast<const uint8_t*>(owner_reset.data()), owner_reset.size() * sizeof(uint32_t));
+
+        std::vector<uint32_t> hole_owner_reset(static_cast<size_t>(k_max_components) * k_max_holes_per_label, CC_UNCLAIMED_HOST);
+        cc_pipeline.upload_shared_raw(1, 5, reinterpret_cast<const uint8_t*>(hole_owner_reset.data()), hole_owner_reset.size() * sizeof(uint32_t));
+
+        const uint32_t zero = 0;
+        cc_pipeline.upload_shared_raw(1, 7, reinterpret_cast<const uint8_t*>(&zero), sizeof(uint32_t));
+        cc_pipeline.upload_shared_raw(1, 9, reinterpret_cast<const uint8_t*>(&zero), sizeof(uint32_t));
+    }
+
+    auto max_points = p.max_points_per_contour > 0 ? std::min<uint32_t>(p.max_points_per_contour, k_max_points_per_contour) : k_max_points_per_contour;
+    cc_pipeline.swap_shader({ .shader_path = "contour_march.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(ContourMarchPC) });
+    cc_pipeline.stage_image_at(1, image, GpuBufferBinding::ElementType::IMAGE_SAMPLED);
+    cc_pipeline.prepare_output_image(w, h);
+    cc_pipeline.set_push_constants(ContourMarchPC {
+        .width = w,
+        .height = h,
+        .max_components = k_max_components,
+        .max_points_per_contour = max_points,
+        .max_holes_per_label = k_max_holes_per_label,
+        .phase = 0U,
+        .min_area = p.min_area,
+        .compacted_count = 0U });
+
+    cc_pipeline.set_output_dimensions(w, h);
+    {
+        const auto fence = cc_pipeline.dispatch_async({});
+        foundry.wait_for_fence(fence);
+        foundry.release_fence(fence);
+    }
+
+    cc_pipeline.set_push_constants(ContourMarchPC {
+        .width = w,
+        .height = h,
+        .max_components = k_max_components,
+        .max_points_per_contour = max_points,
+        .max_holes_per_label = k_max_holes_per_label,
+        .phase = 1U,
+        .min_area = p.min_area,
+        .compacted_count = 0U });
+    {
+        const auto fence = cc_pipeline.dispatch_async({});
+        foundry.wait_for_fence(fence);
+        foundry.release_fence(fence);
+    }
+
+    cc_pipeline.clear_output_dimensions();
+
+    cc_pipeline.swap_shader({ .shader_path = "contour_compact.comp.spv", .workgroup_size = { 256, 1, 1 }, .push_constant_size = sizeof(ContourCompactPC) });
+    cc_pipeline.set_push_constants(ContourCompactPC { .max_components = k_max_components, .max_holes_per_label = k_max_holes_per_label });
+    const uint32_t total_owner_slots = k_max_components * (1U + k_max_holes_per_label);
+    cc_pipeline.set_output_dimensions(total_owner_slots, 1);
+    {
+        const auto fence = cc_pipeline.dispatch_async({});
+        foundry.wait_for_fence(fence);
+        foundry.release_fence(fence);
+    }
+    cc_pipeline.clear_output_dimensions();
+
+    uint32_t compacted_count = 0;
+    cc_pipeline.download_shared(1, 7, &compacted_count, sizeof(uint32_t));
+
+    cc_pipeline.swap_shader({ .shader_path = "contour_march.comp.spv", .workgroup_size = { 256, 1, 1 }, .push_constant_size = sizeof(ContourMarchPC) });
+    cc_pipeline.set_push_constants(ContourMarchPC {
+        .width = w,
+        .height = h,
+        .max_components = k_max_components,
+        .max_points_per_contour = max_points,
+        .max_holes_per_label = k_max_holes_per_label,
+        .phase = 2U,
+        .min_area = p.min_area,
+        .compacted_count = compacted_count });
+    cc_pipeline.set_output_dimensions(std::max(compacted_count, 1U), 1);
+    {
+        const auto fence = cc_pipeline.dispatch_async({});
+        foundry.wait_for_fence(fence);
+        foundry.release_fence(fence);
+    }
+    cc_pipeline.clear_output_dimensions();
+
+    if (p.max_contours > 0U) {
+        constexpr uint32_t k = 12U;
+        constexpr uint32_t total_passes = k * (k + 1U) / 2U;
+
+        cc_pipeline.swap_shader(config_from_spec(
+            ShaderSpec::Assemble {}
+                .tmpl(KernelTemplate::BitonicSort)
+                .start_set(2)
+                .ssbo("keys", BindingDirection::InOut, Kakshya::GpuDataFormat::FLOAT32)
+                .ssbo("indices", BindingDirection::InOut, Kakshya::GpuDataFormat::FLOAT32)
+                .pc("stage", Kakshya::GpuDataFormat::UINT32)
+                .pc("pass", Kakshya::GpuDataFormat::UINT32)
+                .pc("count", Kakshya::GpuDataFormat::UINT32)
+                .pc("descending", Kakshya::GpuDataFormat::UINT32)
+                .workgroup(256)
+                .build()));
+
+        cc_pipeline.set_output_dimensions(k_max_components, 1U);
+
+        ExecutionContext bitonic_ctx;
+        bitonic_ctx.mode = ExecutionMode::CHAINED;
+        bitonic_ctx.parameters = ChainedParams {
+            .pass_count = total_passes,
+            .pc_updater = [k](uint32_t p_idx, void* pc_ptr) {
+                uint32_t stage = 0, pass = 0, remaining = p_idx;
+                for (uint32_t s = 0; s < k; ++s) {
+                    if (remaining <= s) {
+                        stage = s;
+                        pass = remaining;
+                        break;
+                    }
+                    remaining -= (s + 1);
+                }
+                struct PC {
+                    uint32_t stage, pass, count, descending;
+                };
+                *static_cast<PC*>(pc_ptr) = { .stage = stage, .pass = pass, .count = k_max_components, .descending = 1U };
+            },
+        };
+
+        cc_pipeline.execute(Datum<std::vector<Kakshya::DataVariant>> {}, bitonic_ctx);
+        cc_pipeline.clear_output_dimensions();
+    }
+
+    if (p.as_image) {
+        cc_pipeline.swap_shader({ .shader_path = "contour_render_clear.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(ContourClearPC) });
+        cc_pipeline.prepare_output_image(w, h);
+        cc_pipeline.set_push_constants(ContourClearPC { .width = w, .height = h });
+        cc_pipeline.set_output_dimensions(w, h);
+        {
+            const auto fence = cc_pipeline.dispatch_async({});
+            foundry.wait_for_fence(fence);
+            foundry.release_fence(fence);
+        }
+        cc_pipeline.clear_output_dimensions();
+
+        cc_pipeline.swap_shader({ .shader_path = "contour_render.comp.spv", .workgroup_size = { 256, 1, 1 }, .push_constant_size = sizeof(ContourRenderPC) });
+        cc_pipeline.set_push_constants(ContourRenderPC { .width = w, .height = h, .max_components = k_max_components, .max_points_per_contour = k_max_points_per_contour, .max_contours = p.max_contours });
+        const uint32_t render_slots = p.max_contours > 0U ? std::min(p.max_contours, k_max_components) : k_max_trace_slots;
+        cc_pipeline.set_output_dimensions(render_slots * k_max_points_per_contour, 1U);
+        {
+            const auto fence = cc_pipeline.dispatch_async({});
+            foundry.wait_for_fence(fence);
+            foundry.release_fence(fence);
+        }
+        cc_pipeline.clear_output_dimensions();
+
+        contexts.pass.result.debug_contours = cc_pipeline.get_output_image(0);
+        contexts.pass.result.structured = std::monostate {};
+        contexts.pass.result.w = 0;
+        contexts.pass.result.h = 0;
+        return true;
+    }
+
+    std::vector<glm::uvec4> meta(compacted_count);
+    cc_pipeline.download_shared(1, 10, meta.data(), compacted_count * sizeof(glm::uvec4));
+    std::vector<glm::vec2> area_perim(compacted_count);
+    cc_pipeline.download_shared(1, 11, area_perim.data(), compacted_count * sizeof(glm::vec2));
+    uint32_t points_written = 0;
+    cc_pipeline.download_shared(1, 9, &points_written, sizeof(uint32_t));
+    std::vector<glm::vec2> flat_points_full(points_written);
+
+    if (points_written > 0)
+        cc_pipeline.download_shared(1, 8, flat_points_full.data(), static_cast<size_t>(points_written) * sizeof(glm::vec2));
+
+    std::vector<uint32_t> order;
+    if (p.max_contours > 0U) {
+        const uint32_t take = std::min(p.max_contours, compacted_count);
+        std::vector<float> sorted_indices(take);
+        cc_pipeline.download_shared(2, 1, sorted_indices.data(), take * sizeof(float));
+        order.reserve(take);
+        for (float f : sorted_indices)
+            order.push_back(static_cast<uint32_t>(f));
+    } else {
+        order.resize(compacted_count);
+        for (uint32_t i = 0; i < compacted_count; ++i)
+            order[i] = i;
+    }
+
+    std::vector<Kinesis::Vision::Contour> out_contours;
+    out_contours.reserve(order.size());
+
+    for (uint32_t idx : order) {
+        if (idx >= compacted_count)
+            continue;
+        const auto& m = meta[idx];
+        if (m.y < 3)
+            continue;
+        if (m.x > points_written || m.y > points_written - m.x)
+            continue;
+
+        std::vector<glm::vec2> pts(
+            flat_points_full.begin() + m.x,
+            flat_points_full.begin() + m.x + m.y);
+        const glm::vec2 ap = area_perim[idx];
+        out_contours.push_back({ .points = std::move(pts), .area = ap.x, .perimeter = ap.y, .parent_label = m.z });
+    }
+
+    contexts.pass.result.structured = std::move(out_contours);
+    contexts.pass.result.w = 0;
+    contexts.pass.result.h = 0;
+    return true;
+}
+
 // ============================================================================
 // run_gpu
 // ============================================================================
@@ -877,68 +1341,7 @@ VisionResult VisionGpuExecutor::run(
         }
         case VisionOp::ExtractPeaks: {
             const auto& p = std::get<ExtractPeaksParams>(step.params);
-            constexpr uint32_t k_max_kp = 4096;
-
-            structured_ctx.swap_shader({
-                .shader_path = "extract_peaks.comp.spv",
-                .workgroup_size = { 8, 8, 1 },
-                .push_constant_size = sizeof(ExtractPeaksPC),
-            });
-
-            structured_ctx.set_output_size(1, sizeof(uint32_t));
-            structured_ctx.set_output_size(2, static_cast<size_t>(k_max_kp) * 4 * sizeof(float));
-
-            structured_ctx.stage_image(contexts.pass.current);
-            structured_ctx.set_push_constants(ExtractPeaksPC {
-                .threshold = p.threshold,
-                .nms_radius = p.nms_radius,
-                .width = w,
-                .height = h,
-                .max_keypoints = k_max_kp,
-            });
-
-            structured_ctx.set_output_dimensions(w, h);
-            const auto fence = structured_ctx.dispatch_async({});
-            structured_ctx.clear_output_dimensions();
-            foundry.wait_for_fence(fence);
-            foundry.release_fence(fence);
-
-            if (sequence.track_follows_peaks) {
-                contexts.pass.result.structured = std::monostate {};
-                contexts.pass.result.w = w;
-                contexts.pass.result.h = h;
-                continue;
-            }
-
-            const auto gpu_result = structured_ctx.collect_result();
-
-            uint32_t count = 0;
-            if (auto it = gpu_result.aux.find(1); it != gpu_result.aux.end())
-                std::memcpy(&count, it->second.data(), sizeof(uint32_t));
-            count = std::min(count, k_max_kp);
-
-            struct GpuKp {
-                float x, y, response, pad;
-            };
-            std::vector<GpuKp> raw(count);
-            if (count > 0) {
-                if (auto it = gpu_result.aux.find(2); it != gpu_result.aux.end())
-                    std::memcpy(raw.data(), it->second.data(), count * sizeof(GpuKp));
-            }
-
-            std::vector<Kinesis::Vision::Keypoint> kpts;
-            kpts.reserve(count);
-            for (const auto& kp : raw) {
-                kpts.push_back({ .position = { kp.x, kp.y },
-                    .response = kp.response,
-                    .scale = 1.0F,
-                    .angle = 0.0F });
-            }
-            std::ranges::sort(kpts, [](const auto& a, const auto& b) { return a.response > b.response; });
-
-            contexts.pass.result.structured = std::move(kpts);
-            contexts.pass.result.w = 0;
-            contexts.pass.result.h = 0;
+            op_extract_peaks(contexts, sequence, p);
             continue;
         }
         case VisionOp::ConnectedComponents: {
@@ -948,374 +1351,13 @@ VisionResult VisionGpuExecutor::run(
                 continue;
             }
 
-            const auto seed_input = contexts.pass.current;
-
-            const uint32_t block_width = (w + 1U) / 2U;
-            const uint32_t block_height = (h + 1U) / 2U;
-            const double block_diagonal = std::sqrt(
-                static_cast<double>(block_width) * block_width + static_cast<double>(block_height) * block_height);
-            const auto k_compress_passes = static_cast<uint32_t>(std::ceil(std::log2(std::max(2.0, block_diagonal))));
-
-            cc_pipeline.ensure_shared_buffer(0, 2, static_cast<size_t>(block_width) * block_height, GpuBufferBinding::ElementType::UINT32);
-            cc_pipeline.ensure_shared_buffer(0, 3, 1, GpuBufferBinding::ElementType::UINT32);
-            cc_pipeline.ensure_shared_buffer(0, 4, static_cast<size_t>(block_width) * block_height, GpuBufferBinding::ElementType::UINT32);
-            cc_pipeline.ensure_shared_buffer(0, 5, 1, GpuBufferBinding::ElementType::UINT32);
-            cc_pipeline.ensure_shared_buffer(0, 6, static_cast<size_t>(w) * h, GpuBufferBinding::ElementType::UINT32);
-            cc_pipeline.ensure_shared_buffer(0, 7, static_cast<size_t>(k_max_components) * 2, GpuBufferBinding::ElementType::UINT32);
-            cc_pipeline.ensure_shared_buffer(0, 8, static_cast<size_t>(k_max_components) * 2, GpuBufferBinding::ElementType::UINT32);
-            cc_pipeline.ensure_shared_buffer(0, 9, k_max_components, GpuBufferBinding::ElementType::UINT32);
-
-            const CCBlockInitPC init_pc { .width = w, .height = h, .block_width = block_width, .block_height = block_height };
-            const CCMergePC merge_pc { .width = w, .height = h, .block_width = block_width, .block_height = block_height };
-            const CCFinalLabelPC final_pc { .width = w, .height = h, .block_width = block_width, .block_height = block_height, .max_components = k_max_components, .export_labels = 1U };
-
-            cc_pipeline.swap_shader({ .shader_path = "cc_reset.comp.spv", .workgroup_size = { 256, 1, 1 }, .push_constant_size = sizeof(CCResetPC) });
-            cc_pipeline.set_push_constants(CCResetPC {
-                .lut_size = block_width * block_height,
-                .max_components = k_max_components,
-            });
-            cc_pipeline.set_output_dimensions(std::max(block_width * block_height, k_max_components), 1);
-            {
-                const auto reset_fence = cc_pipeline.dispatch_async({});
-                foundry.wait_for_fence(reset_fence);
-                foundry.release_fence(reset_fence);
-            }
-            cc_pipeline.clear_output_dimensions();
-
-            const std::array<uint32_t, 3> block_groups {
-                (block_width + k_wg2d[0] - 1U) / k_wg2d[0],
-                (block_height + k_wg2d[1] - 1U) / k_wg2d[1],
-                1U
-            };
-
-            std::vector<DependencyStage> cc_stages;
-
-            cc_stages.push_back({
-                .config = { .shader_path = "cc_block_init.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(CCBlockInitPC) },
-                .stage_fn = [&](GpuDispatchCore& ctx) {
-        cc_pipeline.stage_image_at(1, seed_input, GpuBufferBinding::ElementType::IMAGE_STORAGE);
-        ctx.set_push_constants(init_pc);
-        cc_pipeline.set_output_dimensions(block_width, block_height); },
-                .hazard_fn = [&](GpuDispatchCore& ctx) -> std::vector<Portal::Graphics::HazardResource> {
-                    return {
-                        ctx.shared_buffer_hazard(
-                            { .set = 0, .binding = 2, .direction = GpuBufferBinding::Direction::INPUT_OUTPUT, .element_type = GpuBufferBinding::ElementType::UINT32 }),
-                    };
-                },
-                .explicit_groups = block_groups,
-            });
-
-            cc_stages.push_back({
-                .config = { .shader_path = "cc_merge.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(CCMergePC) },
-                .stage_fn = [&](GpuDispatchCore& ctx) {
-        cc_pipeline.stage_image_at(1, seed_input, GpuBufferBinding::ElementType::IMAGE_STORAGE);
-        ctx.set_push_constants(merge_pc);
-        cc_pipeline.set_output_dimensions(block_width, block_height); },
-                .hazard_fn = [&](GpuDispatchCore& ctx) -> std::vector<Portal::Graphics::HazardResource> {
-                    return {
-                        ctx.shared_buffer_hazard(
-                            { .set = 0, .binding = 2, .direction = GpuBufferBinding::Direction::INPUT_OUTPUT, .element_type = GpuBufferBinding::ElementType::UINT32 }),
-                    };
-                },
-                .explicit_groups = block_groups,
-            });
-
-            ExecutionContext cc_ctx;
-            cc_ctx.mode = ExecutionMode::DEPENDENCY;
-            DependencyParams params;
-            params.stages = cc_stages;
-            cc_ctx.parameters = params;
-            cc_pipeline.execute(Datum<> {}, cc_ctx);
-
-            cc_pipeline.ensure_shared_buffer(0, 10, 3, GpuBufferBinding::ElementType::UINT32,
-                Portal::Graphics::BufferUsageHint::INDIRECT);
-            const std::array<uint32_t, 3> full_grid_indirect {
-                (block_width + 7U) / 8U,
-                (block_height + 7U) / 8U,
-                1U
-            };
-            cc_pipeline.upload_shared_raw(0, 10, reinterpret_cast<const uint8_t*>(full_grid_indirect.data()), full_grid_indirect.size() * sizeof(uint32_t));
-
-            cc_pipeline.swap_shader({ .shader_path = "cc_compress.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(CCCompressPC) });
-            cc_pipeline.set_push_constants(CCCompressPC { .block_width = block_width, .block_height = block_height });
-            cc_pipeline.set_output_dimensions(block_width, block_height);
-            {
-                const auto fence = cc_pipeline.dispatch_async({});
-                foundry.wait_for_fence(fence);
-                foundry.release_fence(fence);
-            }
-            cc_pipeline.clear_output_dimensions();
-
-            cc_pipeline.swap_shader({ .shader_path = "cc_final_label.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(CCFinalLabelPC) });
-            cc_pipeline.stage_image_at(1, seed_input, GpuBufferBinding::ElementType::IMAGE_STORAGE);
-            cc_pipeline.set_push_constants(final_pc);
-            cc_pipeline.set_output_dimensions(w, h);
-            cc_pipeline.prepare_output_image(w, h);
-            {
-                const auto fence = cc_pipeline.dispatch_async({});
-                foundry.wait_for_fence(fence);
-                foundry.release_fence(fence);
-            }
-            cc_pipeline.clear_output_dimensions();
-
-            contexts.pass.result.debug_labels = p.with_colors ? cc_pipeline.get_output_image(0) : nullptr;
-
-            uint32_t compact_count = 0;
-            cc_pipeline.download_shared(0, 5, &compact_count, sizeof(uint32_t));
-            compact_count = std::min(compact_count, k_max_components);
-
-            Kinesis::Vision::ComponentResult cc_result;
-            cc_result.count = compact_count;
-            cc_result.boxes.reserve(compact_count);
-
-            if (compact_count > 0) {
-                std::vector<glm::uvec2> bmin(compact_count);
-                std::vector<glm::uvec2> bmax(compact_count);
-                std::vector<uint32_t> bcount(compact_count);
-                cc_pipeline.download_shared(0, 7, bmin.data(), bmin.size() * sizeof(glm::uvec2));
-                cc_pipeline.download_shared(0, 8, bmax.data(), bmax.size() * sizeof(glm::uvec2));
-                cc_pipeline.download_shared(0, 9, bcount.data(), bcount.size() * sizeof(uint32_t));
-
-                const float inv_w = 1.0F / static_cast<float>(w);
-                const float inv_h = 1.0F / static_cast<float>(h);
-
-                for (uint32_t i = 0; i < compact_count; ++i) {
-                    if (bcount[i] == 0)
-                        continue;
-                    const float x = static_cast<float>(bmin[i].x) * inv_w;
-                    const float y = static_cast<float>(bmin[i].y) * inv_h;
-                    const float bw = static_cast<float>(bmax[i].x - bmin[i].x + 1) * inv_w;
-                    const float bh = static_cast<float>(bmax[i].y - bmin[i].y + 1) * inv_h;
-                    cc_result.boxes.push_back({ .x = x, .y = y, .w = bw, .h = bh, .confidence = 1.0F, .label_id = i + 1 });
-                }
-            }
-
-            contexts.pass.result.structured = std::move(cc_result);
-            contexts.pass.result.w = 0;
-            contexts.pass.result.h = 0;
+            op_connected_components(contexts, p);
             continue;
         }
         case VisionOp::FindContours: {
-            if (!sequence.contours_follow_cc) {
-                MF_ERROR(Journal::Component::Yantra, Journal::Context::ComputeMatrix,
-                    "run_gpu: FindContours requires ConnectedComponents(export_labels=true) as the immediately preceding step");
+            if (!op_find_contours(contexts, sequence, image,
+                    std::get<Kinesis::Vision::FindContoursParams>(step.params)))
                 return VisionResult {};
-            }
-
-            const auto& p = std::get<Kinesis::Vision::FindContoursParams>(step.params);
-
-            cc_pipeline.ensure_shared_buffer(1, 4, static_cast<size_t>(k_max_components) + 1U, GpuBufferBinding::ElementType::UINT32);
-            cc_pipeline.ensure_shared_buffer(1, 5, static_cast<size_t>(k_max_components) * k_max_holes_per_label, GpuBufferBinding::ElementType::UINT32);
-            cc_pipeline.ensure_shared_buffer(1, 6, static_cast<size_t>(k_max_trace_slots) * 2U, GpuBufferBinding::ElementType::UINT32);
-            cc_pipeline.ensure_shared_buffer(1, 7, 1U, GpuBufferBinding::ElementType::UINT32);
-            cc_pipeline.ensure_shared_buffer(1, 8, static_cast<size_t>(k_max_trace_slots) * k_max_points_per_contour * 2U, GpuBufferBinding::ElementType::FLOAT32);
-            cc_pipeline.ensure_shared_buffer(1, 9, 1U, GpuBufferBinding::ElementType::UINT32);
-            cc_pipeline.ensure_shared_buffer(1, 10, static_cast<size_t>(k_max_trace_slots) * 4U, GpuBufferBinding::ElementType::UINT32);
-            cc_pipeline.ensure_shared_buffer(1, 11, static_cast<size_t>(k_max_trace_slots) * 2U, GpuBufferBinding::ElementType::FLOAT32);
-            cc_pipeline.ensure_shared_buffer(2, 0, k_max_components, GpuBufferBinding::ElementType::FLOAT32);
-            cc_pipeline.ensure_shared_buffer(2, 1, k_max_components, GpuBufferBinding::ElementType::FLOAT32);
-
-            {
-                std::vector<uint32_t> owner_reset(static_cast<size_t>(k_max_components) + 1U, CC_UNCLAIMED_HOST);
-                cc_pipeline.upload_shared_raw(1, 4, reinterpret_cast<const uint8_t*>(owner_reset.data()), owner_reset.size() * sizeof(uint32_t));
-
-                std::vector<uint32_t> hole_owner_reset(static_cast<size_t>(k_max_components) * k_max_holes_per_label, CC_UNCLAIMED_HOST);
-                cc_pipeline.upload_shared_raw(1, 5, reinterpret_cast<const uint8_t*>(hole_owner_reset.data()), hole_owner_reset.size() * sizeof(uint32_t));
-
-                const uint32_t zero = 0;
-                cc_pipeline.upload_shared_raw(1, 7, reinterpret_cast<const uint8_t*>(&zero), sizeof(uint32_t));
-                cc_pipeline.upload_shared_raw(1, 9, reinterpret_cast<const uint8_t*>(&zero), sizeof(uint32_t));
-            }
-
-            auto max_points = p.max_points_per_contour > 0 ? std::min<uint32_t>(p.max_points_per_contour, k_max_points_per_contour) : k_max_points_per_contour;
-            cc_pipeline.swap_shader({ .shader_path = "contour_march.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(ContourMarchPC) });
-            cc_pipeline.stage_image_at(1, image, GpuBufferBinding::ElementType::IMAGE_SAMPLED);
-            cc_pipeline.prepare_output_image(w, h);
-            cc_pipeline.set_push_constants(ContourMarchPC {
-                .width = w,
-                .height = h,
-                .max_components = k_max_components,
-                .max_points_per_contour = max_points,
-                .max_holes_per_label = k_max_holes_per_label,
-                .phase = 0U,
-                .min_area = p.min_area,
-                .compacted_count = 0U });
-
-            cc_pipeline.set_output_dimensions(w, h);
-            {
-                const auto fence = cc_pipeline.dispatch_async({});
-                foundry.wait_for_fence(fence);
-                foundry.release_fence(fence);
-            }
-
-            cc_pipeline.set_push_constants(ContourMarchPC {
-                .width = w,
-                .height = h,
-                .max_components = k_max_components,
-                .max_points_per_contour = max_points,
-                .max_holes_per_label = k_max_holes_per_label,
-                .phase = 1U,
-                .min_area = p.min_area,
-                .compacted_count = 0U });
-            {
-                const auto fence = cc_pipeline.dispatch_async({});
-                foundry.wait_for_fence(fence);
-                foundry.release_fence(fence);
-            }
-
-            cc_pipeline.clear_output_dimensions();
-
-            cc_pipeline.swap_shader({ .shader_path = "contour_compact.comp.spv", .workgroup_size = { 256, 1, 1 }, .push_constant_size = sizeof(ContourCompactPC) });
-            cc_pipeline.set_push_constants(ContourCompactPC { .max_components = k_max_components, .max_holes_per_label = k_max_holes_per_label });
-            const uint32_t total_owner_slots = k_max_components * (1U + k_max_holes_per_label);
-            cc_pipeline.set_output_dimensions(total_owner_slots, 1);
-            {
-                const auto fence = cc_pipeline.dispatch_async({});
-                foundry.wait_for_fence(fence);
-                foundry.release_fence(fence);
-            }
-            cc_pipeline.clear_output_dimensions();
-
-            uint32_t compacted_count = 0;
-            cc_pipeline.download_shared(1, 7, &compacted_count, sizeof(uint32_t));
-
-            cc_pipeline.swap_shader({ .shader_path = "contour_march.comp.spv", .workgroup_size = { 256, 1, 1 }, .push_constant_size = sizeof(ContourMarchPC) });
-            cc_pipeline.set_push_constants(ContourMarchPC {
-                .width = w,
-                .height = h,
-                .max_components = k_max_components,
-                .max_points_per_contour = max_points,
-                .max_holes_per_label = k_max_holes_per_label,
-                .phase = 2U,
-                .min_area = p.min_area,
-                .compacted_count = compacted_count });
-            cc_pipeline.set_output_dimensions(std::max(compacted_count, 1U), 1);
-            {
-                const auto fence = cc_pipeline.dispatch_async({});
-                foundry.wait_for_fence(fence);
-                foundry.release_fence(fence);
-            }
-            cc_pipeline.clear_output_dimensions();
-
-            if (p.max_contours > 0U) {
-                constexpr uint32_t k = 12U;
-                constexpr uint32_t total_passes = k * (k + 1U) / 2U;
-
-                cc_pipeline.swap_shader(config_from_spec(
-                    ShaderSpec::Assemble {}
-                        .tmpl(KernelTemplate::BitonicSort)
-                        .start_set(2)
-                        .ssbo("keys", BindingDirection::InOut, Kakshya::GpuDataFormat::FLOAT32)
-                        .ssbo("indices", BindingDirection::InOut, Kakshya::GpuDataFormat::FLOAT32)
-                        .pc("stage", Kakshya::GpuDataFormat::UINT32)
-                        .pc("pass", Kakshya::GpuDataFormat::UINT32)
-                        .pc("count", Kakshya::GpuDataFormat::UINT32)
-                        .pc("descending", Kakshya::GpuDataFormat::UINT32)
-                        .workgroup(256)
-                        .build()));
-
-                cc_pipeline.set_output_dimensions(k_max_components, 1U);
-
-                ExecutionContext bitonic_ctx;
-                bitonic_ctx.mode = ExecutionMode::CHAINED;
-                bitonic_ctx.parameters = ChainedParams {
-                    .pass_count = total_passes,
-                    .pc_updater = [k](uint32_t p_idx, void* pc_ptr) {
-                        uint32_t stage = 0, pass = 0, remaining = p_idx;
-                        for (uint32_t s = 0; s < k; ++s) {
-                            if (remaining <= s) {
-                                stage = s;
-                                pass = remaining;
-                                break;
-                            }
-                            remaining -= (s + 1);
-                        }
-                        struct PC {
-                            uint32_t stage, pass, count, descending;
-                        };
-                        *static_cast<PC*>(pc_ptr) = { .stage = stage, .pass = pass, .count = k_max_components, .descending = 1U };
-                    },
-                };
-
-                cc_pipeline.execute(Datum<std::vector<Kakshya::DataVariant>> {}, bitonic_ctx);
-                cc_pipeline.clear_output_dimensions();
-            }
-
-            if (p.as_image) {
-                cc_pipeline.swap_shader({ .shader_path = "contour_render_clear.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(ContourClearPC) });
-                cc_pipeline.prepare_output_image(w, h);
-                cc_pipeline.set_push_constants(ContourClearPC { .width = w, .height = h });
-                cc_pipeline.set_output_dimensions(w, h);
-                {
-                    const auto fence = cc_pipeline.dispatch_async({});
-                    foundry.wait_for_fence(fence);
-                    foundry.release_fence(fence);
-                }
-                cc_pipeline.clear_output_dimensions();
-
-                cc_pipeline.swap_shader({ .shader_path = "contour_render.comp.spv", .workgroup_size = { 256, 1, 1 }, .push_constant_size = sizeof(ContourRenderPC) });
-                cc_pipeline.set_push_constants(ContourRenderPC { .width = w, .height = h, .max_components = k_max_components, .max_points_per_contour = k_max_points_per_contour, .max_contours = p.max_contours });
-                const uint32_t render_slots = p.max_contours > 0U ? std::min(p.max_contours, k_max_components) : k_max_trace_slots;
-                cc_pipeline.set_output_dimensions(render_slots * k_max_points_per_contour, 1U);
-                {
-                    const auto fence = cc_pipeline.dispatch_async({});
-                    foundry.wait_for_fence(fence);
-                    foundry.release_fence(fence);
-                }
-                cc_pipeline.clear_output_dimensions();
-
-                contexts.pass.result.debug_contours = cc_pipeline.get_output_image(0);
-                contexts.pass.result.structured = std::monostate {};
-                contexts.pass.result.w = 0;
-                contexts.pass.result.h = 0;
-                continue;
-            }
-
-            std::vector<glm::uvec4> meta(compacted_count);
-            cc_pipeline.download_shared(1, 10, meta.data(), compacted_count * sizeof(glm::uvec4));
-            std::vector<glm::vec2> area_perim(compacted_count);
-            cc_pipeline.download_shared(1, 11, area_perim.data(), compacted_count * sizeof(glm::vec2));
-            uint32_t points_written = 0;
-            cc_pipeline.download_shared(1, 9, &points_written, sizeof(uint32_t));
-            std::vector<glm::vec2> flat_points_full(points_written);
-
-            if (points_written > 0)
-                cc_pipeline.download_shared(1, 8, flat_points_full.data(), static_cast<size_t>(points_written) * sizeof(glm::vec2));
-
-            std::vector<uint32_t> order;
-            if (p.max_contours > 0U) {
-                const uint32_t take = std::min(p.max_contours, compacted_count);
-                std::vector<float> sorted_indices(take);
-                cc_pipeline.download_shared(2, 1, sorted_indices.data(), take * sizeof(float));
-                order.reserve(take);
-                for (float f : sorted_indices)
-                    order.push_back(static_cast<uint32_t>(f));
-            } else {
-                order.resize(compacted_count);
-                for (uint32_t i = 0; i < compacted_count; ++i)
-                    order[i] = i;
-            }
-
-            std::vector<Kinesis::Vision::Contour> out_contours;
-            out_contours.reserve(order.size());
-
-            for (uint32_t idx : order) {
-                if (idx >= compacted_count)
-                    continue;
-                const auto& m = meta[idx];
-                if (m.y < 3)
-                    continue;
-
-                std::vector<glm::vec2> pts(
-                    flat_points_full.begin() + m.x,
-                    flat_points_full.begin() + m.x + m.y);
-                const glm::vec2 ap = area_perim[idx];
-                out_contours.push_back({ .points = std::move(pts), .area = ap.x, .perimeter = ap.y, .parent_label = m.z });
-            }
-
-            contexts.pass.result.structured = std::move(out_contours);
-            contexts.pass.result.w = 0;
-            contexts.pass.result.h = 0;
             continue;
         }
         default:

--- a/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
+++ b/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
@@ -308,6 +308,9 @@ namespace {
         contexts.pass.current = thresholded;
         contexts.pass.result.structured = std::monostate {};
 
+        contexts.bound_config = apply_cfg;
+        contexts.bound_staged = otsu_input;
+
         return { .output = thresholded, .input = otsu_input };
     }
 
@@ -361,6 +364,9 @@ namespace {
         auto opened_closed = pixel_ctx.get_output_image(0);
         contexts.pass.current = opened_closed;
         contexts.pass.result.structured = std::monostate {};
+
+        contexts.bound_config = second_cfg;
+        contexts.bound_staged = intermediate;
 
         return { .output = opened_closed, .input = morph_input };
     }
@@ -507,6 +513,9 @@ namespace {
         contexts.pass.current = finalized;
         contexts.pass.result.structured = std::monostate {};
 
+        contexts.bound_config = finalize_cfg;
+        contexts.bound_staged = hysteresis_result;
+
         return { .output = finalized, .input = canny_input };
     }
 
@@ -571,6 +580,9 @@ namespace {
 
         contexts.pass.current = pixel_ctx.get_output_image(0);
         contexts.pass.result.structured = std::monostate {};
+
+        contexts.bound_config = harris_resp_cfg;
+        contexts.bound_staged = smoothed;
 
         return { .output = contexts.pass.current, .input = harris_input };
     }
@@ -1255,17 +1267,7 @@ VisionResult VisionGpuExecutor::run(
     auto& cc_pipeline = contexts.cc_pipeline;
 
     auto& foundry = Portal::Graphics::get_shader_foundry();
-
-    Portal::Graphics::ShaderID last_shader_id = Portal::Graphics::INVALID_SHADER;
-    std::string last_shader_path;
-    std::shared_ptr<Core::VKImage> last_staged;
-    uint32_t last_w = 0, last_h = 0;
     std::unordered_map<size_t, CompletedOp> completed_ops;
-
-    pixel_ctx.prepare_output_image(w, h);
-    last_w = w;
-    last_h = h;
-
     size_t begin = 0;
 
     if (contexts.suspended.is_active()) {
@@ -1300,19 +1302,19 @@ VisionResult VisionGpuExecutor::run(
             return VisionResult {};
         }
 
-        if (cfg.shader_id != last_shader_id || cfg.shader_path != last_shader_path) {
+        if (cfg.shader_id != contexts.bound_config.shader_id
+            || cfg.shader_path != contexts.bound_config.shader_path) {
             pixel_ctx.swap_shader(cfg);
-            last_shader_id = cfg.shader_id;
-            last_shader_path = cfg.shader_path;
+            contexts.bound_config = cfg;
         }
-        if (contexts.pass.current != last_staged) {
+        if (contexts.pass.current != contexts.bound_staged) {
             pixel_ctx.stage_image(contexts.pass.current);
-            last_staged = contexts.pass.current;
+            contexts.bound_staged = contexts.pass.current;
         }
-        if (w != last_w || h != last_h) {
+        if (w != contexts.pass.storage_w || h != contexts.pass.storage_h) {
             pixel_ctx.prepare_output_image(w, h);
-            last_w = w;
-            last_h = h;
+            contexts.pass.storage_w = w;
+            contexts.pass.storage_h = h;
         }
         pixel_ctx.set_output_dimensions(w, h);
 
@@ -1333,11 +1335,11 @@ VisionResult VisionGpuExecutor::run(
             auto downsampled = pixel_ctx.get_output_image(0);
             completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = { .output = downsampled, .input = contexts.pass.current };
             contexts.pass.current = downsampled;
-            last_staged = contexts.pass.current;
+            contexts.bound_staged = contexts.pass.current;
 
             contexts.pass.set_geometry(new_w, new_h);
-            last_w = new_w;
-            last_h = new_h;
+            contexts.pass.storage_w = new_w;
+            contexts.pass.storage_h = new_h;
 
             continue;
         }
@@ -1377,19 +1379,16 @@ VisionResult VisionGpuExecutor::run(
         }
         case VisionOp::ThresholdOtsu: {
             completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = op_threshold_otsu(contexts);
-            last_staged = contexts.pass.current;
             continue;
         }
         case VisionOp::Open:
         case VisionOp::Close: {
             completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = op_open_close(contexts, step.op, std::get<MorphParams>(step.params));
-            last_staged = contexts.pass.current;
             continue;
         }
         case VisionOp::Canny: {
             completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = op_canny(contexts, completed_ops, step.params,
                 std::get<CannyParams>(step.params));
-            last_staged = contexts.pass.current;
             continue;
         }
         case VisionOp::HarrisResponse: {
@@ -1435,7 +1434,7 @@ VisionResult VisionGpuExecutor::run(
 
         pixel_ctx.clear_output_dimensions();
         contexts.pass.current = pixel_ctx.get_output_image(0);
-        last_staged = contexts.pass.current;
+        contexts.bound_staged = contexts.pass.current;
         completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = { .output = contexts.pass.current, .input = dispatch_input };
     }
 

--- a/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
+++ b/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
@@ -233,6 +233,667 @@ namespace {
         return cache.emplace(key, std::move(k)).first->second;
     }
 
+    CompletedOp op_threshold_otsu(VisionGpuContexts& contexts)
+    {
+        auto& pixel_ctx = contexts.pixel;
+        auto& structured_ctx = contexts.structured;
+        auto w = contexts.pass.w;
+        auto h = contexts.pass.h;
+        auto& foundry = Portal::Graphics::get_shader_foundry();
+
+        const auto otsu_input = contexts.pass.current;
+
+        structured_ctx.swap_shader({
+            .shader_path = "otsu_histogram.comp.spv",
+            .workgroup_size = k_wg2d,
+            .push_constant_size = sizeof(OtsuHistPC),
+        });
+        std::vector<uint32_t> zeros(256, 0);
+        structured_ctx.set_binding_data(3, std::span<const uint32_t>(zeros));
+        structured_ctx.stage_image(contexts.pass.current);
+        structured_ctx.set_push_constants(OtsuHistPC { .width = w, .height = h });
+        structured_ctx.set_output_dimensions(w, h);
+        {
+            const auto f = structured_ctx.dispatch_async({});
+            structured_ctx.clear_output_dimensions();
+            foundry.wait_for_fence(f);
+            foundry.release_fence(f);
+        }
+
+        const auto hist_check = structured_ctx.collect_result();
+        std::vector<uint32_t> hist_readback(256, 0);
+        if (auto it = hist_check.aux.find(3); it != hist_check.aux.end())
+            std::memcpy(hist_readback.data(), it->second.data(), 256 * sizeof(uint32_t));
+
+        structured_ctx.swap_shader({
+            .shader_path = "otsu_select.comp.spv",
+            .workgroup_size = { 256, 1, 1 },
+        });
+        structured_ctx.set_binding_data(3, std::span<const uint32_t>(hist_readback));
+        structured_ctx.set_output_dimensions(256, 1);
+
+        {
+            const auto f = structured_ctx.dispatch_async({});
+            structured_ctx.clear_output_dimensions();
+            foundry.wait_for_fence(f);
+            foundry.release_fence(f);
+        }
+
+        const auto sel_result = structured_ctx.collect_result();
+        uint32_t best_bin = 0;
+        if (auto it = sel_result.aux.find(4); it != sel_result.aux.end())
+            std::memcpy(&best_bin, it->second.data(), sizeof(uint32_t));
+        const float t_norm = static_cast<float>(best_bin) / 255.0F;
+
+        const auto apply_cfg = config_from_spec(
+            ShaderSpec::Assemble {}
+                .storage_image("out", BindingDirection::Output)
+                .storage_image("src", BindingDirection::Input)
+                .pc("threshold")
+                .op(KernelOp::CompareGE)
+                .workgroup(k_wg2d[0], k_wg2d[1])
+                .build());
+        pixel_ctx.swap_shader(apply_cfg);
+        pixel_ctx.stage_image(contexts.pass.current);
+        pixel_ctx.set_push_constants(ThresholdPC { .value = t_norm });
+        pixel_ctx.prepare_output_image(w, h);
+        {
+            const auto f = pixel_ctx.dispatch_async({});
+            foundry.wait_for_fence(f);
+            foundry.release_fence(f);
+        }
+        auto thresholded = pixel_ctx.get_output_image(0);
+
+        contexts.pass.result.debug_labels = thresholded;
+        contexts.pass.current = thresholded;
+        contexts.pass.result.structured = std::monostate {};
+
+        return { .output = thresholded, .input = otsu_input };
+    }
+
+    CompletedOp op_open_close(
+        VisionGpuContexts& contexts,
+        VisionOp op,
+        const MorphParams& p)
+    {
+        auto& pixel_ctx = contexts.pixel;
+        auto w = contexts.pass.w;
+        auto h = contexts.pass.h;
+        auto& foundry = Portal::Graphics::get_shader_foundry();
+
+        const auto morph_input = contexts.pass.current;
+        const auto radius = p.radius;
+        const bool is_open = (op == VisionOp::Open);
+
+        const GpuComputeConfig first_cfg {
+            .shader_path = is_open ? "erode.comp.spv" : "dilate.comp.spv",
+            .workgroup_size = k_wg2d,
+            .push_constant_size = sizeof(MorphPC),
+        };
+        pixel_ctx.swap_shader(first_cfg);
+        pixel_ctx.stage_image(contexts.pass.current);
+        pixel_ctx.set_push_constants(MorphPC { .radius = radius });
+        pixel_ctx.prepare_output_image(w, h);
+        pixel_ctx.set_output_dimensions(w, h);
+        {
+            const auto f = pixel_ctx.dispatch_async({});
+            foundry.wait_for_fence(f);
+            foundry.release_fence(f);
+        }
+        auto intermediate = pixel_ctx.get_output_image(0);
+
+        const GpuComputeConfig second_cfg {
+            .shader_path = is_open ? "dilate.comp.spv" : "erode.comp.spv",
+            .workgroup_size = k_wg2d,
+            .push_constant_size = sizeof(MorphPC),
+        };
+        pixel_ctx.swap_shader(second_cfg);
+        pixel_ctx.stage_image(intermediate);
+        pixel_ctx.set_push_constants(MorphPC { .radius = radius });
+        pixel_ctx.prepare_output_image(w, h);
+        pixel_ctx.set_output_dimensions(w, h);
+        {
+            const auto f = pixel_ctx.dispatch_async({});
+            foundry.wait_for_fence(f);
+            foundry.release_fence(f);
+        }
+
+        auto opened_closed = pixel_ctx.get_output_image(0);
+        contexts.pass.current = opened_closed;
+        contexts.pass.result.structured = std::monostate {};
+
+        return { .output = opened_closed, .input = morph_input };
+    }
+
+    CompletedOp op_harris_response(
+        VisionGpuContexts& contexts,
+        const HarrisParams& p)
+    {
+        auto& pixel_ctx = contexts.pixel;
+        auto w = contexts.pass.w;
+        auto h = contexts.pass.h;
+        auto& foundry = Portal::Graphics::get_shader_foundry();
+
+        const auto radius = static_cast<uint32_t>(std::ceil(p.sigma * 3.0F));
+        const auto& weights = gaussian_kernel_1d(radius, p.sigma);
+
+        const auto harris_input = contexts.pass.current;
+
+        pixel_ctx.swap_shader({ .shader_path = "harris_grad_pack.comp.spv", .workgroup_size = k_wg2d });
+        pixel_ctx.stage_image(harris_input);
+        pixel_ctx.prepare_output_image(w, h);
+        {
+            const auto f = pixel_ctx.dispatch_async({});
+            foundry.wait_for_fence(f);
+            foundry.release_fence(f);
+        }
+        auto packed = pixel_ctx.get_output_image(0);
+
+        const auto blur_cfg = VisionGpuExecutor::config(VisionOp::GaussianBlur, GaussianBlurParams { .sigma = p.sigma });
+        pixel_ctx.swap_shader(blur_cfg);
+        pixel_ctx.stage_image(packed);
+        pixel_ctx.set_binding_data(2, std::span<const float>(weights));
+        pixel_ctx.set_push_constants(GaussianPC { .radius = radius, .width = w, .height = h });
+        pixel_ctx.prepare_output_image(w, h);
+        {
+            const auto f = pixel_ctx.dispatch_async({});
+            foundry.wait_for_fence(f);
+            foundry.release_fence(f);
+        }
+        auto smoothed = pixel_ctx.get_output_image(0);
+
+        const GpuComputeConfig harris_resp_cfg {
+            .shader_path = "harris_response.comp.spv",
+            .workgroup_size = k_wg2d,
+            .push_constant_size = sizeof(HarrisPC),
+        };
+        pixel_ctx.swap_shader(harris_resp_cfg);
+        pixel_ctx.stage_image(smoothed);
+        pixel_ctx.set_push_constants(HarrisPC { .k = p.k, .pass = 0U, .width = w, .height = h });
+        pixel_ctx.prepare_output_image(w, h);
+        {
+            const auto f = pixel_ctx.dispatch_async({});
+            foundry.wait_for_fence(f);
+            foundry.release_fence(f);
+        }
+
+        pixel_ctx.set_push_constants(HarrisPC { .k = p.k, .pass = 1U, .width = w, .height = h });
+        {
+            const auto f = pixel_ctx.dispatch_async({});
+            foundry.wait_for_fence(f);
+            foundry.release_fence(f);
+        }
+
+        contexts.pass.current = pixel_ctx.get_output_image(0);
+        contexts.pass.result.structured = std::monostate {};
+
+        return { .output = contexts.pass.current, .input = harris_input };
+    }
+
+    void op_extract_peaks(
+        VisionGpuContexts& contexts,
+        const VisionSequence& sequence,
+        const ExtractPeaksParams& p)
+    {
+        auto& structured_ctx = contexts.structured;
+        auto w = contexts.pass.w;
+        auto h = contexts.pass.h;
+        auto& foundry = Portal::Graphics::get_shader_foundry();
+
+        constexpr uint32_t k_max_kp = 4096;
+
+        structured_ctx.swap_shader({
+            .shader_path = "extract_peaks.comp.spv",
+            .workgroup_size = { 8, 8, 1 },
+            .push_constant_size = sizeof(ExtractPeaksPC),
+        });
+
+        structured_ctx.set_output_size(1, sizeof(uint32_t));
+        structured_ctx.set_output_size(2, static_cast<size_t>(k_max_kp) * 4 * sizeof(float));
+
+        structured_ctx.stage_image(contexts.pass.current);
+        structured_ctx.set_push_constants(ExtractPeaksPC {
+            .threshold = p.threshold,
+            .nms_radius = p.nms_radius,
+            .width = w,
+            .height = h,
+            .max_keypoints = k_max_kp,
+        });
+
+        structured_ctx.set_output_dimensions(w, h);
+        const auto fence = structured_ctx.dispatch_async({});
+        structured_ctx.clear_output_dimensions();
+        foundry.wait_for_fence(fence);
+        foundry.release_fence(fence);
+
+        if (sequence.track_follows_peaks) {
+            contexts.pass.result.structured = std::monostate {};
+            contexts.pass.result.w = w;
+            contexts.pass.result.h = h;
+            return;
+        }
+
+        const auto gpu_result = structured_ctx.collect_result();
+
+        uint32_t count = 0;
+        if (auto it = gpu_result.aux.find(1); it != gpu_result.aux.end())
+            std::memcpy(&count, it->second.data(), sizeof(uint32_t));
+        count = std::min(count, k_max_kp);
+
+        struct GpuKp {
+            float x, y, response, pad;
+        };
+        std::vector<GpuKp> raw(count);
+        if (count > 0) {
+            if (auto it = gpu_result.aux.find(2); it != gpu_result.aux.end())
+                std::memcpy(raw.data(), it->second.data(), count * sizeof(GpuKp));
+        }
+
+        std::vector<Kinesis::Vision::Keypoint> kpts;
+        kpts.reserve(count);
+        for (const auto& kp : raw) {
+            kpts.push_back({ .position = { kp.x, kp.y },
+                .response = kp.response,
+                .scale = 1.0F,
+                .angle = 0.0F });
+        }
+        std::ranges::sort(kpts, [](const auto& a, const auto& b) { return a.response > b.response; });
+
+        contexts.pass.result.structured = std::move(kpts);
+        contexts.pass.result.w = 0;
+        contexts.pass.result.h = 0;
+    }
+
+    void op_connected_components(
+        VisionGpuContexts& contexts,
+        const ConnectedComponentsParams& p)
+    {
+        auto& cc_pipeline = contexts.cc_pipeline;
+        auto w = contexts.pass.w;
+        auto h = contexts.pass.h;
+        auto& foundry = Portal::Graphics::get_shader_foundry();
+
+        const auto seed_input = contexts.pass.current;
+
+        const uint32_t block_width = (w + 1U) / 2U;
+        const uint32_t block_height = (h + 1U) / 2U;
+        const double block_diagonal = std::sqrt(
+            static_cast<double>(block_width) * block_width + static_cast<double>(block_height) * block_height);
+        const auto k_compress_passes = static_cast<uint32_t>(std::ceil(std::log2(std::max(2.0, block_diagonal))));
+
+        cc_pipeline.ensure_shared_buffer(0, 2, static_cast<size_t>(block_width) * block_height, GpuBufferBinding::ElementType::UINT32);
+        cc_pipeline.ensure_shared_buffer(0, 3, 1, GpuBufferBinding::ElementType::UINT32);
+        cc_pipeline.ensure_shared_buffer(0, 4, static_cast<size_t>(block_width) * block_height, GpuBufferBinding::ElementType::UINT32);
+        cc_pipeline.ensure_shared_buffer(0, 5, 1, GpuBufferBinding::ElementType::UINT32);
+        cc_pipeline.ensure_shared_buffer(0, 6, static_cast<size_t>(w) * h, GpuBufferBinding::ElementType::UINT32);
+        cc_pipeline.ensure_shared_buffer(0, 7, static_cast<size_t>(k_max_components) * 2, GpuBufferBinding::ElementType::UINT32);
+        cc_pipeline.ensure_shared_buffer(0, 8, static_cast<size_t>(k_max_components) * 2, GpuBufferBinding::ElementType::UINT32);
+        cc_pipeline.ensure_shared_buffer(0, 9, k_max_components, GpuBufferBinding::ElementType::UINT32);
+
+        const CCBlockInitPC init_pc { .width = w, .height = h, .block_width = block_width, .block_height = block_height };
+        const CCMergePC merge_pc { .width = w, .height = h, .block_width = block_width, .block_height = block_height };
+        const CCFinalLabelPC final_pc { .width = w, .height = h, .block_width = block_width, .block_height = block_height, .max_components = k_max_components, .export_labels = 1U };
+
+        cc_pipeline.swap_shader({ .shader_path = "cc_reset.comp.spv", .workgroup_size = { 256, 1, 1 }, .push_constant_size = sizeof(CCResetPC) });
+        cc_pipeline.set_push_constants(CCResetPC {
+            .lut_size = block_width * block_height,
+            .max_components = k_max_components,
+        });
+        cc_pipeline.set_output_dimensions(std::max(block_width * block_height, k_max_components), 1);
+        {
+            const auto reset_fence = cc_pipeline.dispatch_async({});
+            foundry.wait_for_fence(reset_fence);
+            foundry.release_fence(reset_fence);
+        }
+        cc_pipeline.clear_output_dimensions();
+
+        const std::array<uint32_t, 3> block_groups {
+            (block_width + k_wg2d[0] - 1U) / k_wg2d[0],
+            (block_height + k_wg2d[1] - 1U) / k_wg2d[1],
+            1U
+        };
+
+        std::vector<DependencyStage> cc_stages;
+
+        cc_stages.push_back({
+            .config = { .shader_path = "cc_block_init.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(CCBlockInitPC) },
+            .stage_fn = [&](GpuDispatchCore& ctx) {
+        cc_pipeline.stage_image_at(1, seed_input, GpuBufferBinding::ElementType::IMAGE_STORAGE);
+        ctx.set_push_constants(init_pc);
+        cc_pipeline.set_output_dimensions(block_width, block_height); },
+            .hazard_fn = [&](GpuDispatchCore& ctx) -> std::vector<Portal::Graphics::HazardResource> {
+                return {
+                    ctx.shared_buffer_hazard(
+                        { .set = 0, .binding = 2, .direction = GpuBufferBinding::Direction::INPUT_OUTPUT, .element_type = GpuBufferBinding::ElementType::UINT32 }),
+                };
+            },
+            .explicit_groups = block_groups,
+        });
+
+        cc_stages.push_back({
+            .config = { .shader_path = "cc_merge.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(CCMergePC) },
+            .stage_fn = [&](GpuDispatchCore& ctx) {
+        cc_pipeline.stage_image_at(1, seed_input, GpuBufferBinding::ElementType::IMAGE_STORAGE);
+        ctx.set_push_constants(merge_pc);
+        cc_pipeline.set_output_dimensions(block_width, block_height); },
+            .hazard_fn = [&](GpuDispatchCore& ctx) -> std::vector<Portal::Graphics::HazardResource> {
+                return {
+                    ctx.shared_buffer_hazard(
+                        { .set = 0, .binding = 2, .direction = GpuBufferBinding::Direction::INPUT_OUTPUT, .element_type = GpuBufferBinding::ElementType::UINT32 }),
+                };
+            },
+            .explicit_groups = block_groups,
+        });
+
+        ExecutionContext cc_ctx;
+        cc_ctx.mode = ExecutionMode::DEPENDENCY;
+        DependencyParams params;
+        params.stages = cc_stages;
+        cc_ctx.parameters = params;
+        cc_pipeline.execute(Datum<> {}, cc_ctx);
+
+        cc_pipeline.ensure_shared_buffer(0, 10, 3, GpuBufferBinding::ElementType::UINT32,
+            Portal::Graphics::BufferUsageHint::INDIRECT);
+        const std::array<uint32_t, 3> full_grid_indirect {
+            (block_width + 7U) / 8U,
+            (block_height + 7U) / 8U,
+            1U
+        };
+        cc_pipeline.upload_shared_raw(0, 10, reinterpret_cast<const uint8_t*>(full_grid_indirect.data()), full_grid_indirect.size() * sizeof(uint32_t));
+
+        cc_pipeline.swap_shader({ .shader_path = "cc_compress.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(CCCompressPC) });
+        cc_pipeline.set_push_constants(CCCompressPC { .block_width = block_width, .block_height = block_height });
+        cc_pipeline.set_output_dimensions(block_width, block_height);
+        {
+            const auto fence = cc_pipeline.dispatch_async({});
+            foundry.wait_for_fence(fence);
+            foundry.release_fence(fence);
+        }
+        cc_pipeline.clear_output_dimensions();
+
+        cc_pipeline.swap_shader({ .shader_path = "cc_final_label.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(CCFinalLabelPC) });
+        cc_pipeline.stage_image_at(1, seed_input, GpuBufferBinding::ElementType::IMAGE_STORAGE);
+        cc_pipeline.set_push_constants(final_pc);
+        cc_pipeline.set_output_dimensions(w, h);
+        cc_pipeline.prepare_output_image(w, h);
+        {
+            const auto fence = cc_pipeline.dispatch_async({});
+            foundry.wait_for_fence(fence);
+            foundry.release_fence(fence);
+        }
+        cc_pipeline.clear_output_dimensions();
+
+        contexts.pass.result.debug_labels = p.with_colors ? cc_pipeline.get_output_image(0) : nullptr;
+
+        uint32_t compact_count = 0;
+        cc_pipeline.download_shared(0, 5, &compact_count, sizeof(uint32_t));
+        compact_count = std::min(compact_count, k_max_components);
+
+        Kinesis::Vision::ComponentResult cc_result;
+        cc_result.count = compact_count;
+        cc_result.boxes.reserve(compact_count);
+
+        if (compact_count > 0) {
+            std::vector<glm::uvec2> bmin(compact_count);
+            std::vector<glm::uvec2> bmax(compact_count);
+            std::vector<uint32_t> bcount(compact_count);
+            cc_pipeline.download_shared(0, 7, bmin.data(), bmin.size() * sizeof(glm::uvec2));
+            cc_pipeline.download_shared(0, 8, bmax.data(), bmax.size() * sizeof(glm::uvec2));
+            cc_pipeline.download_shared(0, 9, bcount.data(), bcount.size() * sizeof(uint32_t));
+
+            const float inv_w = 1.0F / static_cast<float>(w);
+            const float inv_h = 1.0F / static_cast<float>(h);
+
+            for (uint32_t i = 0; i < compact_count; ++i) {
+                if (bcount[i] == 0)
+                    continue;
+                const float x = static_cast<float>(bmin[i].x) * inv_w;
+                const float y = static_cast<float>(bmin[i].y) * inv_h;
+                const float bw = static_cast<float>(bmax[i].x - bmin[i].x + 1) * inv_w;
+                const float bh = static_cast<float>(bmax[i].y - bmin[i].y + 1) * inv_h;
+                cc_result.boxes.push_back({ .x = x, .y = y, .w = bw, .h = bh, .confidence = 1.0F, .label_id = i + 1 });
+            }
+        }
+
+        contexts.pass.result.structured = std::move(cc_result);
+        contexts.pass.result.w = 0;
+        contexts.pass.result.h = 0;
+    }
+
+    bool op_find_contours(
+        VisionGpuContexts& contexts,
+        const VisionSequence& sequence,
+        const std::shared_ptr<Core::VKImage>& image,
+        const FindContoursParams& p)
+    {
+        if (!sequence.contours_follow_cc) {
+            MF_ERROR(Journal::Component::Yantra, Journal::Context::ComputeMatrix,
+                "run_gpu: FindContours requires ConnectedComponents(export_labels=true) as the immediately preceding step");
+            return false;
+        }
+
+        auto& cc_pipeline = contexts.cc_pipeline;
+        auto w = contexts.pass.w;
+        auto h = contexts.pass.h;
+        auto& foundry = Portal::Graphics::get_shader_foundry();
+
+        cc_pipeline.ensure_shared_buffer(1, 4, static_cast<size_t>(k_max_components) + 1U, GpuBufferBinding::ElementType::UINT32);
+        cc_pipeline.ensure_shared_buffer(1, 5, static_cast<size_t>(k_max_components) * k_max_holes_per_label, GpuBufferBinding::ElementType::UINT32);
+        cc_pipeline.ensure_shared_buffer(1, 6, static_cast<size_t>(k_max_trace_slots) * 2U, GpuBufferBinding::ElementType::UINT32);
+        cc_pipeline.ensure_shared_buffer(1, 7, 1U, GpuBufferBinding::ElementType::UINT32);
+        cc_pipeline.ensure_shared_buffer(1, 8, static_cast<size_t>(k_max_trace_slots) * k_max_points_per_contour * 2U, GpuBufferBinding::ElementType::FLOAT32);
+        cc_pipeline.ensure_shared_buffer(1, 9, 1U, GpuBufferBinding::ElementType::UINT32);
+        cc_pipeline.ensure_shared_buffer(1, 10, static_cast<size_t>(k_max_trace_slots) * 4U, GpuBufferBinding::ElementType::UINT32);
+        cc_pipeline.ensure_shared_buffer(1, 11, static_cast<size_t>(k_max_trace_slots) * 2U, GpuBufferBinding::ElementType::FLOAT32);
+        cc_pipeline.ensure_shared_buffer(2, 0, k_max_components, GpuBufferBinding::ElementType::FLOAT32);
+        cc_pipeline.ensure_shared_buffer(2, 1, k_max_components, GpuBufferBinding::ElementType::FLOAT32);
+
+        {
+            std::vector<uint32_t> owner_reset(static_cast<size_t>(k_max_components) + 1U, CC_UNCLAIMED_HOST);
+            cc_pipeline.upload_shared_raw(1, 4, reinterpret_cast<const uint8_t*>(owner_reset.data()), owner_reset.size() * sizeof(uint32_t));
+
+            std::vector<uint32_t> hole_owner_reset(static_cast<size_t>(k_max_components) * k_max_holes_per_label, CC_UNCLAIMED_HOST);
+            cc_pipeline.upload_shared_raw(1, 5, reinterpret_cast<const uint8_t*>(hole_owner_reset.data()), hole_owner_reset.size() * sizeof(uint32_t));
+
+            const uint32_t zero = 0;
+            cc_pipeline.upload_shared_raw(1, 7, reinterpret_cast<const uint8_t*>(&zero), sizeof(uint32_t));
+            cc_pipeline.upload_shared_raw(1, 9, reinterpret_cast<const uint8_t*>(&zero), sizeof(uint32_t));
+        }
+
+        auto max_points = p.max_points_per_contour > 0 ? std::min<uint32_t>(p.max_points_per_contour, k_max_points_per_contour) : k_max_points_per_contour;
+        cc_pipeline.swap_shader({ .shader_path = "contour_march.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(ContourMarchPC) });
+        cc_pipeline.stage_image_at(1, image, GpuBufferBinding::ElementType::IMAGE_SAMPLED);
+        cc_pipeline.prepare_output_image(w, h);
+        cc_pipeline.set_push_constants(ContourMarchPC {
+            .width = w,
+            .height = h,
+            .max_components = k_max_components,
+            .max_points_per_contour = max_points,
+            .max_holes_per_label = k_max_holes_per_label,
+            .phase = 0U,
+            .min_area = p.min_area,
+            .compacted_count = 0U });
+
+        cc_pipeline.set_output_dimensions(w, h);
+        {
+            const auto fence = cc_pipeline.dispatch_async({});
+            foundry.wait_for_fence(fence);
+            foundry.release_fence(fence);
+        }
+
+        cc_pipeline.set_push_constants(ContourMarchPC {
+            .width = w,
+            .height = h,
+            .max_components = k_max_components,
+            .max_points_per_contour = max_points,
+            .max_holes_per_label = k_max_holes_per_label,
+            .phase = 1U,
+            .min_area = p.min_area,
+            .compacted_count = 0U });
+        {
+            const auto fence = cc_pipeline.dispatch_async({});
+            foundry.wait_for_fence(fence);
+            foundry.release_fence(fence);
+        }
+
+        cc_pipeline.clear_output_dimensions();
+
+        cc_pipeline.swap_shader({ .shader_path = "contour_compact.comp.spv", .workgroup_size = { 256, 1, 1 }, .push_constant_size = sizeof(ContourCompactPC) });
+        cc_pipeline.set_push_constants(ContourCompactPC { .max_components = k_max_components, .max_holes_per_label = k_max_holes_per_label });
+        const uint32_t total_owner_slots = k_max_components * (1U + k_max_holes_per_label);
+        cc_pipeline.set_output_dimensions(total_owner_slots, 1);
+        {
+            const auto fence = cc_pipeline.dispatch_async({});
+            foundry.wait_for_fence(fence);
+            foundry.release_fence(fence);
+        }
+        cc_pipeline.clear_output_dimensions();
+
+        uint32_t compacted_count = 0;
+        cc_pipeline.download_shared(1, 7, &compacted_count, sizeof(uint32_t));
+
+        cc_pipeline.swap_shader({ .shader_path = "contour_march.comp.spv", .workgroup_size = { 256, 1, 1 }, .push_constant_size = sizeof(ContourMarchPC) });
+        cc_pipeline.set_push_constants(ContourMarchPC {
+            .width = w,
+            .height = h,
+            .max_components = k_max_components,
+            .max_points_per_contour = max_points,
+            .max_holes_per_label = k_max_holes_per_label,
+            .phase = 2U,
+            .min_area = p.min_area,
+            .compacted_count = compacted_count });
+        cc_pipeline.set_output_dimensions(std::max(compacted_count, 1U), 1);
+        {
+            const auto fence = cc_pipeline.dispatch_async({});
+            foundry.wait_for_fence(fence);
+            foundry.release_fence(fence);
+        }
+        cc_pipeline.clear_output_dimensions();
+
+        if (p.max_contours > 0U) {
+            constexpr uint32_t k = 12U;
+            constexpr uint32_t total_passes = k * (k + 1U) / 2U;
+
+            cc_pipeline.swap_shader(config_from_spec(
+                ShaderSpec::Assemble {}
+                    .tmpl(KernelTemplate::BitonicSort)
+                    .start_set(2)
+                    .ssbo("keys", BindingDirection::InOut, Kakshya::GpuDataFormat::FLOAT32)
+                    .ssbo("indices", BindingDirection::InOut, Kakshya::GpuDataFormat::FLOAT32)
+                    .pc("stage", Kakshya::GpuDataFormat::UINT32)
+                    .pc("pass", Kakshya::GpuDataFormat::UINT32)
+                    .pc("count", Kakshya::GpuDataFormat::UINT32)
+                    .pc("descending", Kakshya::GpuDataFormat::UINT32)
+                    .workgroup(256)
+                    .build()));
+
+            cc_pipeline.set_output_dimensions(k_max_components, 1U);
+
+            ExecutionContext bitonic_ctx;
+            bitonic_ctx.mode = ExecutionMode::CHAINED;
+            bitonic_ctx.parameters = ChainedParams {
+                .pass_count = total_passes,
+                .pc_updater = [k](uint32_t p_idx, void* pc_ptr) {
+                    uint32_t stage = 0, pass = 0, remaining = p_idx;
+                    for (uint32_t s = 0; s < k; ++s) {
+                        if (remaining <= s) {
+                            stage = s;
+                            pass = remaining;
+                            break;
+                        }
+                        remaining -= (s + 1);
+                    }
+                    struct PC {
+                        uint32_t stage, pass, count, descending;
+                    };
+                    *static_cast<PC*>(pc_ptr) = { .stage = stage, .pass = pass, .count = k_max_components, .descending = 1U };
+                },
+            };
+
+            cc_pipeline.execute(Datum<std::vector<Kakshya::DataVariant>> {}, bitonic_ctx);
+            cc_pipeline.clear_output_dimensions();
+        }
+
+        if (p.as_image) {
+            cc_pipeline.swap_shader({ .shader_path = "contour_render_clear.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(ContourClearPC) });
+            cc_pipeline.prepare_output_image(w, h);
+            cc_pipeline.set_push_constants(ContourClearPC { .width = w, .height = h });
+            cc_pipeline.set_output_dimensions(w, h);
+            {
+                const auto fence = cc_pipeline.dispatch_async({});
+                foundry.wait_for_fence(fence);
+                foundry.release_fence(fence);
+            }
+            cc_pipeline.clear_output_dimensions();
+
+            cc_pipeline.swap_shader({ .shader_path = "contour_render.comp.spv", .workgroup_size = { 256, 1, 1 }, .push_constant_size = sizeof(ContourRenderPC) });
+            cc_pipeline.set_push_constants(ContourRenderPC { .width = w, .height = h, .max_components = k_max_components, .max_points_per_contour = k_max_points_per_contour, .max_contours = p.max_contours });
+            const uint32_t render_slots = p.max_contours > 0U ? std::min(p.max_contours, k_max_components) : k_max_trace_slots;
+            cc_pipeline.set_output_dimensions(render_slots * k_max_points_per_contour, 1U);
+            {
+                const auto fence = cc_pipeline.dispatch_async({});
+                foundry.wait_for_fence(fence);
+                foundry.release_fence(fence);
+            }
+            cc_pipeline.clear_output_dimensions();
+
+            contexts.pass.result.debug_contours = cc_pipeline.get_output_image(0);
+            contexts.pass.result.structured = std::monostate {};
+            contexts.pass.result.w = 0;
+            contexts.pass.result.h = 0;
+            return true;
+        }
+
+        std::vector<glm::uvec4> meta(compacted_count);
+        cc_pipeline.download_shared(1, 10, meta.data(), compacted_count * sizeof(glm::uvec4));
+        std::vector<glm::vec2> area_perim(compacted_count);
+        cc_pipeline.download_shared(1, 11, area_perim.data(), compacted_count * sizeof(glm::vec2));
+        uint32_t points_written = 0;
+        cc_pipeline.download_shared(1, 9, &points_written, sizeof(uint32_t));
+        std::vector<glm::vec2> flat_points_full(points_written);
+
+        if (points_written > 0)
+            cc_pipeline.download_shared(1, 8, flat_points_full.data(), static_cast<size_t>(points_written) * sizeof(glm::vec2));
+
+        std::vector<uint32_t> order;
+        if (p.max_contours > 0U) {
+            const uint32_t take = std::min(p.max_contours, compacted_count);
+            std::vector<float> sorted_indices(take);
+            cc_pipeline.download_shared(2, 1, sorted_indices.data(), take * sizeof(float));
+            order.reserve(take);
+            for (float f : sorted_indices)
+                order.push_back(static_cast<uint32_t>(f));
+        } else {
+            order.resize(compacted_count);
+            for (uint32_t i = 0; i < compacted_count; ++i)
+                order[i] = i;
+        }
+
+        std::vector<Kinesis::Vision::Contour> out_contours;
+        out_contours.reserve(order.size());
+
+        for (uint32_t idx : order) {
+            if (idx >= compacted_count)
+                continue;
+            const auto& m = meta[idx];
+            if (m.y < 3)
+                continue;
+            if (m.x > points_written || m.y > points_written - m.x)
+                continue;
+
+            std::vector<glm::vec2> pts(
+                flat_points_full.begin() + m.x,
+                flat_points_full.begin() + m.x + m.y);
+            const glm::vec2 ap = area_perim[idx];
+            out_contours.push_back({ .points = std::move(pts), .area = ap.x, .perimeter = ap.y, .parent_label = m.z });
+        }
+
+        contexts.pass.result.structured = std::move(out_contours);
+        contexts.pass.result.w = 0;
+        contexts.pass.result.h = 0;
+        return true;
+    }
+
 } // namespace
 
 VisionGpuContexts::VisionGpuContexts()
@@ -433,470 +1094,6 @@ GpuComputeConfig VisionGpuExecutor::config(VisionOp op, const VisionParams& /*pa
     }
 }
 
-void VisionGpuExecutor::op_extract_peaks(
-    VisionGpuContexts& contexts,
-    const VisionSequence& sequence,
-    const ExtractPeaksParams& p)
-{
-    auto& structured_ctx = contexts.structured;
-    auto w = contexts.pass.w;
-    auto h = contexts.pass.h;
-    auto& foundry = Portal::Graphics::get_shader_foundry();
-
-    constexpr uint32_t k_max_kp = 4096;
-
-    structured_ctx.swap_shader({
-        .shader_path = "extract_peaks.comp.spv",
-        .workgroup_size = { 8, 8, 1 },
-        .push_constant_size = sizeof(ExtractPeaksPC),
-    });
-
-    structured_ctx.set_output_size(1, sizeof(uint32_t));
-    structured_ctx.set_output_size(2, static_cast<size_t>(k_max_kp) * 4 * sizeof(float));
-
-    structured_ctx.stage_image(contexts.pass.current);
-    structured_ctx.set_push_constants(ExtractPeaksPC {
-        .threshold = p.threshold,
-        .nms_radius = p.nms_radius,
-        .width = w,
-        .height = h,
-        .max_keypoints = k_max_kp,
-    });
-
-    structured_ctx.set_output_dimensions(w, h);
-    const auto fence = structured_ctx.dispatch_async({});
-    structured_ctx.clear_output_dimensions();
-    foundry.wait_for_fence(fence);
-    foundry.release_fence(fence);
-
-    if (sequence.track_follows_peaks) {
-        contexts.pass.result.structured = std::monostate {};
-        contexts.pass.result.w = w;
-        contexts.pass.result.h = h;
-        return;
-    }
-
-    const auto gpu_result = structured_ctx.collect_result();
-
-    uint32_t count = 0;
-    if (auto it = gpu_result.aux.find(1); it != gpu_result.aux.end())
-        std::memcpy(&count, it->second.data(), sizeof(uint32_t));
-    count = std::min(count, k_max_kp);
-
-    struct GpuKp {
-        float x, y, response, pad;
-    };
-    std::vector<GpuKp> raw(count);
-    if (count > 0) {
-        if (auto it = gpu_result.aux.find(2); it != gpu_result.aux.end())
-            std::memcpy(raw.data(), it->second.data(), count * sizeof(GpuKp));
-    }
-
-    std::vector<Kinesis::Vision::Keypoint> kpts;
-    kpts.reserve(count);
-    for (const auto& kp : raw) {
-        kpts.push_back({ .position = { kp.x, kp.y },
-            .response = kp.response,
-            .scale = 1.0F,
-            .angle = 0.0F });
-    }
-    std::ranges::sort(kpts, [](const auto& a, const auto& b) { return a.response > b.response; });
-
-    contexts.pass.result.structured = std::move(kpts);
-    contexts.pass.result.w = 0;
-    contexts.pass.result.h = 0;
-}
-
-void VisionGpuExecutor::op_connected_components(
-    VisionGpuContexts& contexts,
-    const ConnectedComponentsParams& p)
-{
-    auto& cc_pipeline = contexts.cc_pipeline;
-    auto w = contexts.pass.w;
-    auto h = contexts.pass.h;
-    auto& foundry = Portal::Graphics::get_shader_foundry();
-
-    const auto seed_input = contexts.pass.current;
-
-    const uint32_t block_width = (w + 1U) / 2U;
-    const uint32_t block_height = (h + 1U) / 2U;
-    const double block_diagonal = std::sqrt(
-        static_cast<double>(block_width) * block_width + static_cast<double>(block_height) * block_height);
-    const auto k_compress_passes = static_cast<uint32_t>(std::ceil(std::log2(std::max(2.0, block_diagonal))));
-
-    cc_pipeline.ensure_shared_buffer(0, 2, static_cast<size_t>(block_width) * block_height, GpuBufferBinding::ElementType::UINT32);
-    cc_pipeline.ensure_shared_buffer(0, 3, 1, GpuBufferBinding::ElementType::UINT32);
-    cc_pipeline.ensure_shared_buffer(0, 4, static_cast<size_t>(block_width) * block_height, GpuBufferBinding::ElementType::UINT32);
-    cc_pipeline.ensure_shared_buffer(0, 5, 1, GpuBufferBinding::ElementType::UINT32);
-    cc_pipeline.ensure_shared_buffer(0, 6, static_cast<size_t>(w) * h, GpuBufferBinding::ElementType::UINT32);
-    cc_pipeline.ensure_shared_buffer(0, 7, static_cast<size_t>(k_max_components) * 2, GpuBufferBinding::ElementType::UINT32);
-    cc_pipeline.ensure_shared_buffer(0, 8, static_cast<size_t>(k_max_components) * 2, GpuBufferBinding::ElementType::UINT32);
-    cc_pipeline.ensure_shared_buffer(0, 9, k_max_components, GpuBufferBinding::ElementType::UINT32);
-
-    const CCBlockInitPC init_pc { .width = w, .height = h, .block_width = block_width, .block_height = block_height };
-    const CCMergePC merge_pc { .width = w, .height = h, .block_width = block_width, .block_height = block_height };
-    const CCFinalLabelPC final_pc { .width = w, .height = h, .block_width = block_width, .block_height = block_height, .max_components = k_max_components, .export_labels = 1U };
-
-    cc_pipeline.swap_shader({ .shader_path = "cc_reset.comp.spv", .workgroup_size = { 256, 1, 1 }, .push_constant_size = sizeof(CCResetPC) });
-    cc_pipeline.set_push_constants(CCResetPC {
-        .lut_size = block_width * block_height,
-        .max_components = k_max_components,
-    });
-    cc_pipeline.set_output_dimensions(std::max(block_width * block_height, k_max_components), 1);
-    {
-        const auto reset_fence = cc_pipeline.dispatch_async({});
-        foundry.wait_for_fence(reset_fence);
-        foundry.release_fence(reset_fence);
-    }
-    cc_pipeline.clear_output_dimensions();
-
-    const std::array<uint32_t, 3> block_groups {
-        (block_width + k_wg2d[0] - 1U) / k_wg2d[0],
-        (block_height + k_wg2d[1] - 1U) / k_wg2d[1],
-        1U
-    };
-
-    std::vector<DependencyStage> cc_stages;
-
-    cc_stages.push_back({
-        .config = { .shader_path = "cc_block_init.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(CCBlockInitPC) },
-        .stage_fn = [&](GpuDispatchCore& ctx) {
-        cc_pipeline.stage_image_at(1, seed_input, GpuBufferBinding::ElementType::IMAGE_STORAGE);
-        ctx.set_push_constants(init_pc);
-        cc_pipeline.set_output_dimensions(block_width, block_height); },
-        .hazard_fn = [&](GpuDispatchCore& ctx) -> std::vector<Portal::Graphics::HazardResource> {
-            return {
-                ctx.shared_buffer_hazard(
-                    { .set = 0, .binding = 2, .direction = GpuBufferBinding::Direction::INPUT_OUTPUT, .element_type = GpuBufferBinding::ElementType::UINT32 }),
-            };
-        },
-        .explicit_groups = block_groups,
-    });
-
-    cc_stages.push_back({
-        .config = { .shader_path = "cc_merge.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(CCMergePC) },
-        .stage_fn = [&](GpuDispatchCore& ctx) {
-        cc_pipeline.stage_image_at(1, seed_input, GpuBufferBinding::ElementType::IMAGE_STORAGE);
-        ctx.set_push_constants(merge_pc);
-        cc_pipeline.set_output_dimensions(block_width, block_height); },
-        .hazard_fn = [&](GpuDispatchCore& ctx) -> std::vector<Portal::Graphics::HazardResource> {
-            return {
-                ctx.shared_buffer_hazard(
-                    { .set = 0, .binding = 2, .direction = GpuBufferBinding::Direction::INPUT_OUTPUT, .element_type = GpuBufferBinding::ElementType::UINT32 }),
-            };
-        },
-        .explicit_groups = block_groups,
-    });
-
-    ExecutionContext cc_ctx;
-    cc_ctx.mode = ExecutionMode::DEPENDENCY;
-    DependencyParams params;
-    params.stages = cc_stages;
-    cc_ctx.parameters = params;
-    cc_pipeline.execute(Datum<> {}, cc_ctx);
-
-    cc_pipeline.ensure_shared_buffer(0, 10, 3, GpuBufferBinding::ElementType::UINT32,
-        Portal::Graphics::BufferUsageHint::INDIRECT);
-    const std::array<uint32_t, 3> full_grid_indirect {
-        (block_width + 7U) / 8U,
-        (block_height + 7U) / 8U,
-        1U
-    };
-    cc_pipeline.upload_shared_raw(0, 10, reinterpret_cast<const uint8_t*>(full_grid_indirect.data()), full_grid_indirect.size() * sizeof(uint32_t));
-
-    cc_pipeline.swap_shader({ .shader_path = "cc_compress.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(CCCompressPC) });
-    cc_pipeline.set_push_constants(CCCompressPC { .block_width = block_width, .block_height = block_height });
-    cc_pipeline.set_output_dimensions(block_width, block_height);
-    {
-        const auto fence = cc_pipeline.dispatch_async({});
-        foundry.wait_for_fence(fence);
-        foundry.release_fence(fence);
-    }
-    cc_pipeline.clear_output_dimensions();
-
-    cc_pipeline.swap_shader({ .shader_path = "cc_final_label.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(CCFinalLabelPC) });
-    cc_pipeline.stage_image_at(1, seed_input, GpuBufferBinding::ElementType::IMAGE_STORAGE);
-    cc_pipeline.set_push_constants(final_pc);
-    cc_pipeline.set_output_dimensions(w, h);
-    cc_pipeline.prepare_output_image(w, h);
-    {
-        const auto fence = cc_pipeline.dispatch_async({});
-        foundry.wait_for_fence(fence);
-        foundry.release_fence(fence);
-    }
-    cc_pipeline.clear_output_dimensions();
-
-    contexts.pass.result.debug_labels = p.with_colors ? cc_pipeline.get_output_image(0) : nullptr;
-
-    uint32_t compact_count = 0;
-    cc_pipeline.download_shared(0, 5, &compact_count, sizeof(uint32_t));
-    compact_count = std::min(compact_count, k_max_components);
-
-    Kinesis::Vision::ComponentResult cc_result;
-    cc_result.count = compact_count;
-    cc_result.boxes.reserve(compact_count);
-
-    if (compact_count > 0) {
-        std::vector<glm::uvec2> bmin(compact_count);
-        std::vector<glm::uvec2> bmax(compact_count);
-        std::vector<uint32_t> bcount(compact_count);
-        cc_pipeline.download_shared(0, 7, bmin.data(), bmin.size() * sizeof(glm::uvec2));
-        cc_pipeline.download_shared(0, 8, bmax.data(), bmax.size() * sizeof(glm::uvec2));
-        cc_pipeline.download_shared(0, 9, bcount.data(), bcount.size() * sizeof(uint32_t));
-
-        const float inv_w = 1.0F / static_cast<float>(w);
-        const float inv_h = 1.0F / static_cast<float>(h);
-
-        for (uint32_t i = 0; i < compact_count; ++i) {
-            if (bcount[i] == 0)
-                continue;
-            const float x = static_cast<float>(bmin[i].x) * inv_w;
-            const float y = static_cast<float>(bmin[i].y) * inv_h;
-            const float bw = static_cast<float>(bmax[i].x - bmin[i].x + 1) * inv_w;
-            const float bh = static_cast<float>(bmax[i].y - bmin[i].y + 1) * inv_h;
-            cc_result.boxes.push_back({ .x = x, .y = y, .w = bw, .h = bh, .confidence = 1.0F, .label_id = i + 1 });
-        }
-    }
-
-    contexts.pass.result.structured = std::move(cc_result);
-    contexts.pass.result.w = 0;
-    contexts.pass.result.h = 0;
-}
-
-bool VisionGpuExecutor::op_find_contours(
-    VisionGpuContexts& contexts,
-    const VisionSequence& sequence,
-    const std::shared_ptr<Core::VKImage>& image,
-    const FindContoursParams& p)
-{
-    if (!sequence.contours_follow_cc) {
-        MF_ERROR(Journal::Component::Yantra, Journal::Context::ComputeMatrix,
-            "run_gpu: FindContours requires ConnectedComponents(export_labels=true) as the immediately preceding step");
-        return false;
-    }
-
-    auto& cc_pipeline = contexts.cc_pipeline;
-    auto w = contexts.pass.w;
-    auto h = contexts.pass.h;
-    auto& foundry = Portal::Graphics::get_shader_foundry();
-
-    cc_pipeline.ensure_shared_buffer(1, 4, static_cast<size_t>(k_max_components) + 1U, GpuBufferBinding::ElementType::UINT32);
-    cc_pipeline.ensure_shared_buffer(1, 5, static_cast<size_t>(k_max_components) * k_max_holes_per_label, GpuBufferBinding::ElementType::UINT32);
-    cc_pipeline.ensure_shared_buffer(1, 6, static_cast<size_t>(k_max_trace_slots) * 2U, GpuBufferBinding::ElementType::UINT32);
-    cc_pipeline.ensure_shared_buffer(1, 7, 1U, GpuBufferBinding::ElementType::UINT32);
-    cc_pipeline.ensure_shared_buffer(1, 8, static_cast<size_t>(k_max_trace_slots) * k_max_points_per_contour * 2U, GpuBufferBinding::ElementType::FLOAT32);
-    cc_pipeline.ensure_shared_buffer(1, 9, 1U, GpuBufferBinding::ElementType::UINT32);
-    cc_pipeline.ensure_shared_buffer(1, 10, static_cast<size_t>(k_max_trace_slots) * 4U, GpuBufferBinding::ElementType::UINT32);
-    cc_pipeline.ensure_shared_buffer(1, 11, static_cast<size_t>(k_max_trace_slots) * 2U, GpuBufferBinding::ElementType::FLOAT32);
-    cc_pipeline.ensure_shared_buffer(2, 0, k_max_components, GpuBufferBinding::ElementType::FLOAT32);
-    cc_pipeline.ensure_shared_buffer(2, 1, k_max_components, GpuBufferBinding::ElementType::FLOAT32);
-
-    {
-        std::vector<uint32_t> owner_reset(static_cast<size_t>(k_max_components) + 1U, CC_UNCLAIMED_HOST);
-        cc_pipeline.upload_shared_raw(1, 4, reinterpret_cast<const uint8_t*>(owner_reset.data()), owner_reset.size() * sizeof(uint32_t));
-
-        std::vector<uint32_t> hole_owner_reset(static_cast<size_t>(k_max_components) * k_max_holes_per_label, CC_UNCLAIMED_HOST);
-        cc_pipeline.upload_shared_raw(1, 5, reinterpret_cast<const uint8_t*>(hole_owner_reset.data()), hole_owner_reset.size() * sizeof(uint32_t));
-
-        const uint32_t zero = 0;
-        cc_pipeline.upload_shared_raw(1, 7, reinterpret_cast<const uint8_t*>(&zero), sizeof(uint32_t));
-        cc_pipeline.upload_shared_raw(1, 9, reinterpret_cast<const uint8_t*>(&zero), sizeof(uint32_t));
-    }
-
-    auto max_points = p.max_points_per_contour > 0 ? std::min<uint32_t>(p.max_points_per_contour, k_max_points_per_contour) : k_max_points_per_contour;
-    cc_pipeline.swap_shader({ .shader_path = "contour_march.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(ContourMarchPC) });
-    cc_pipeline.stage_image_at(1, image, GpuBufferBinding::ElementType::IMAGE_SAMPLED);
-    cc_pipeline.prepare_output_image(w, h);
-    cc_pipeline.set_push_constants(ContourMarchPC {
-        .width = w,
-        .height = h,
-        .max_components = k_max_components,
-        .max_points_per_contour = max_points,
-        .max_holes_per_label = k_max_holes_per_label,
-        .phase = 0U,
-        .min_area = p.min_area,
-        .compacted_count = 0U });
-
-    cc_pipeline.set_output_dimensions(w, h);
-    {
-        const auto fence = cc_pipeline.dispatch_async({});
-        foundry.wait_for_fence(fence);
-        foundry.release_fence(fence);
-    }
-
-    cc_pipeline.set_push_constants(ContourMarchPC {
-        .width = w,
-        .height = h,
-        .max_components = k_max_components,
-        .max_points_per_contour = max_points,
-        .max_holes_per_label = k_max_holes_per_label,
-        .phase = 1U,
-        .min_area = p.min_area,
-        .compacted_count = 0U });
-    {
-        const auto fence = cc_pipeline.dispatch_async({});
-        foundry.wait_for_fence(fence);
-        foundry.release_fence(fence);
-    }
-
-    cc_pipeline.clear_output_dimensions();
-
-    cc_pipeline.swap_shader({ .shader_path = "contour_compact.comp.spv", .workgroup_size = { 256, 1, 1 }, .push_constant_size = sizeof(ContourCompactPC) });
-    cc_pipeline.set_push_constants(ContourCompactPC { .max_components = k_max_components, .max_holes_per_label = k_max_holes_per_label });
-    const uint32_t total_owner_slots = k_max_components * (1U + k_max_holes_per_label);
-    cc_pipeline.set_output_dimensions(total_owner_slots, 1);
-    {
-        const auto fence = cc_pipeline.dispatch_async({});
-        foundry.wait_for_fence(fence);
-        foundry.release_fence(fence);
-    }
-    cc_pipeline.clear_output_dimensions();
-
-    uint32_t compacted_count = 0;
-    cc_pipeline.download_shared(1, 7, &compacted_count, sizeof(uint32_t));
-
-    cc_pipeline.swap_shader({ .shader_path = "contour_march.comp.spv", .workgroup_size = { 256, 1, 1 }, .push_constant_size = sizeof(ContourMarchPC) });
-    cc_pipeline.set_push_constants(ContourMarchPC {
-        .width = w,
-        .height = h,
-        .max_components = k_max_components,
-        .max_points_per_contour = max_points,
-        .max_holes_per_label = k_max_holes_per_label,
-        .phase = 2U,
-        .min_area = p.min_area,
-        .compacted_count = compacted_count });
-    cc_pipeline.set_output_dimensions(std::max(compacted_count, 1U), 1);
-    {
-        const auto fence = cc_pipeline.dispatch_async({});
-        foundry.wait_for_fence(fence);
-        foundry.release_fence(fence);
-    }
-    cc_pipeline.clear_output_dimensions();
-
-    if (p.max_contours > 0U) {
-        constexpr uint32_t k = 12U;
-        constexpr uint32_t total_passes = k * (k + 1U) / 2U;
-
-        cc_pipeline.swap_shader(config_from_spec(
-            ShaderSpec::Assemble {}
-                .tmpl(KernelTemplate::BitonicSort)
-                .start_set(2)
-                .ssbo("keys", BindingDirection::InOut, Kakshya::GpuDataFormat::FLOAT32)
-                .ssbo("indices", BindingDirection::InOut, Kakshya::GpuDataFormat::FLOAT32)
-                .pc("stage", Kakshya::GpuDataFormat::UINT32)
-                .pc("pass", Kakshya::GpuDataFormat::UINT32)
-                .pc("count", Kakshya::GpuDataFormat::UINT32)
-                .pc("descending", Kakshya::GpuDataFormat::UINT32)
-                .workgroup(256)
-                .build()));
-
-        cc_pipeline.set_output_dimensions(k_max_components, 1U);
-
-        ExecutionContext bitonic_ctx;
-        bitonic_ctx.mode = ExecutionMode::CHAINED;
-        bitonic_ctx.parameters = ChainedParams {
-            .pass_count = total_passes,
-            .pc_updater = [k](uint32_t p_idx, void* pc_ptr) {
-                uint32_t stage = 0, pass = 0, remaining = p_idx;
-                for (uint32_t s = 0; s < k; ++s) {
-                    if (remaining <= s) {
-                        stage = s;
-                        pass = remaining;
-                        break;
-                    }
-                    remaining -= (s + 1);
-                }
-                struct PC {
-                    uint32_t stage, pass, count, descending;
-                };
-                *static_cast<PC*>(pc_ptr) = { .stage = stage, .pass = pass, .count = k_max_components, .descending = 1U };
-            },
-        };
-
-        cc_pipeline.execute(Datum<std::vector<Kakshya::DataVariant>> {}, bitonic_ctx);
-        cc_pipeline.clear_output_dimensions();
-    }
-
-    if (p.as_image) {
-        cc_pipeline.swap_shader({ .shader_path = "contour_render_clear.comp.spv", .workgroup_size = k_wg2d, .push_constant_size = sizeof(ContourClearPC) });
-        cc_pipeline.prepare_output_image(w, h);
-        cc_pipeline.set_push_constants(ContourClearPC { .width = w, .height = h });
-        cc_pipeline.set_output_dimensions(w, h);
-        {
-            const auto fence = cc_pipeline.dispatch_async({});
-            foundry.wait_for_fence(fence);
-            foundry.release_fence(fence);
-        }
-        cc_pipeline.clear_output_dimensions();
-
-        cc_pipeline.swap_shader({ .shader_path = "contour_render.comp.spv", .workgroup_size = { 256, 1, 1 }, .push_constant_size = sizeof(ContourRenderPC) });
-        cc_pipeline.set_push_constants(ContourRenderPC { .width = w, .height = h, .max_components = k_max_components, .max_points_per_contour = k_max_points_per_contour, .max_contours = p.max_contours });
-        const uint32_t render_slots = p.max_contours > 0U ? std::min(p.max_contours, k_max_components) : k_max_trace_slots;
-        cc_pipeline.set_output_dimensions(render_slots * k_max_points_per_contour, 1U);
-        {
-            const auto fence = cc_pipeline.dispatch_async({});
-            foundry.wait_for_fence(fence);
-            foundry.release_fence(fence);
-        }
-        cc_pipeline.clear_output_dimensions();
-
-        contexts.pass.result.debug_contours = cc_pipeline.get_output_image(0);
-        contexts.pass.result.structured = std::monostate {};
-        contexts.pass.result.w = 0;
-        contexts.pass.result.h = 0;
-        return true;
-    }
-
-    std::vector<glm::uvec4> meta(compacted_count);
-    cc_pipeline.download_shared(1, 10, meta.data(), compacted_count * sizeof(glm::uvec4));
-    std::vector<glm::vec2> area_perim(compacted_count);
-    cc_pipeline.download_shared(1, 11, area_perim.data(), compacted_count * sizeof(glm::vec2));
-    uint32_t points_written = 0;
-    cc_pipeline.download_shared(1, 9, &points_written, sizeof(uint32_t));
-    std::vector<glm::vec2> flat_points_full(points_written);
-
-    if (points_written > 0)
-        cc_pipeline.download_shared(1, 8, flat_points_full.data(), static_cast<size_t>(points_written) * sizeof(glm::vec2));
-
-    std::vector<uint32_t> order;
-    if (p.max_contours > 0U) {
-        const uint32_t take = std::min(p.max_contours, compacted_count);
-        std::vector<float> sorted_indices(take);
-        cc_pipeline.download_shared(2, 1, sorted_indices.data(), take * sizeof(float));
-        order.reserve(take);
-        for (float f : sorted_indices)
-            order.push_back(static_cast<uint32_t>(f));
-    } else {
-        order.resize(compacted_count);
-        for (uint32_t i = 0; i < compacted_count; ++i)
-            order[i] = i;
-    }
-
-    std::vector<Kinesis::Vision::Contour> out_contours;
-    out_contours.reserve(order.size());
-
-    for (uint32_t idx : order) {
-        if (idx >= compacted_count)
-            continue;
-        const auto& m = meta[idx];
-        if (m.y < 3)
-            continue;
-        if (m.x > points_written || m.y > points_written - m.x)
-            continue;
-
-        std::vector<glm::vec2> pts(
-            flat_points_full.begin() + m.x,
-            flat_points_full.begin() + m.x + m.y);
-        const glm::vec2 ap = area_perim[idx];
-        out_contours.push_back({ .points = std::move(pts), .area = ap.x, .perimeter = ap.y, .parent_label = m.z });
-    }
-
-    contexts.pass.result.structured = std::move(out_contours);
-    contexts.pass.result.w = 0;
-    contexts.pass.result.h = 0;
-    return true;
-}
-
 // ============================================================================
 // run_gpu
 // ============================================================================
@@ -1034,117 +1231,14 @@ VisionResult VisionGpuExecutor::run(
             break;
         }
         case VisionOp::ThresholdOtsu: {
-            structured_ctx.swap_shader({
-                .shader_path = "otsu_histogram.comp.spv",
-                .workgroup_size = k_wg2d,
-                .push_constant_size = sizeof(OtsuHistPC),
-            });
-            std::vector<uint32_t> zeros(256, 0);
-            structured_ctx.set_binding_data(3, std::span<const uint32_t>(zeros));
-            structured_ctx.stage_image(contexts.pass.current);
-            structured_ctx.set_push_constants(OtsuHistPC { .width = w, .height = h });
-            structured_ctx.set_output_dimensions(w, h);
-            {
-                const auto f = structured_ctx.dispatch_async({});
-                structured_ctx.clear_output_dimensions();
-                foundry.wait_for_fence(f);
-                foundry.release_fence(f);
-            }
-
-            const auto hist_check = structured_ctx.collect_result();
-            std::vector<uint32_t> hist_readback(256, 0);
-            if (auto it = hist_check.aux.find(3); it != hist_check.aux.end())
-                std::memcpy(hist_readback.data(), it->second.data(), 256 * sizeof(uint32_t));
-
-            structured_ctx.swap_shader({
-                .shader_path = "otsu_select.comp.spv",
-                .workgroup_size = { 256, 1, 1 },
-            });
-            structured_ctx.set_binding_data(3, std::span<const uint32_t>(hist_readback));
-            structured_ctx.set_output_dimensions(256, 1);
-
-            {
-                const auto f = structured_ctx.dispatch_async({});
-                structured_ctx.clear_output_dimensions();
-                foundry.wait_for_fence(f);
-                foundry.release_fence(f);
-            }
-
-            const auto sel_result = structured_ctx.collect_result();
-            uint32_t best_bin = 0;
-            if (auto it = sel_result.aux.find(4); it != sel_result.aux.end())
-                std::memcpy(&best_bin, it->second.data(), sizeof(uint32_t));
-            const float t_norm = static_cast<float>(best_bin) / 255.0F;
-
-            const auto apply_cfg = config_from_spec(
-                ShaderSpec::Assemble {}
-                    .storage_image("out", BindingDirection::Output)
-                    .storage_image("src", BindingDirection::Input)
-                    .pc("threshold")
-                    .op(KernelOp::CompareGE)
-                    .workgroup(k_wg2d[0], k_wg2d[1])
-                    .build());
-            pixel_ctx.swap_shader(apply_cfg);
-            pixel_ctx.stage_image(contexts.pass.current);
-            pixel_ctx.set_push_constants(ThresholdPC { .value = t_norm });
-            pixel_ctx.prepare_output_image(w, h);
-            {
-                const auto f = pixel_ctx.dispatch_async({});
-                foundry.wait_for_fence(f);
-                foundry.release_fence(f);
-            }
-            auto thresholded = pixel_ctx.get_output_image(0);
-
-            completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = { .output = thresholded, .input = contexts.pass.current };
-            contexts.pass.result.debug_labels = thresholded;
-            contexts.pass.current = thresholded;
+            completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = op_threshold_otsu(contexts);
             last_staged = contexts.pass.current;
-            contexts.pass.result.structured = std::monostate {};
             continue;
         }
         case VisionOp::Open:
         case VisionOp::Close: {
-            const auto radius = std::get<MorphParams>(step.params).radius;
-            const bool is_open = (step.op == VisionOp::Open);
-
-            const GpuComputeConfig first_cfg {
-                .shader_path = is_open ? "erode.comp.spv" : "dilate.comp.spv",
-                .workgroup_size = k_wg2d,
-                .push_constant_size = sizeof(MorphPC),
-            };
-            pixel_ctx.swap_shader(first_cfg);
-            pixel_ctx.stage_image(contexts.pass.current);
-            pixel_ctx.set_push_constants(MorphPC { .radius = radius });
-            pixel_ctx.prepare_output_image(w, h);
-            pixel_ctx.set_output_dimensions(w, h);
-            {
-                const auto f = pixel_ctx.dispatch_async({});
-                foundry.wait_for_fence(f);
-                foundry.release_fence(f);
-            }
-            auto intermediate = pixel_ctx.get_output_image(0);
-
-            const GpuComputeConfig second_cfg {
-                .shader_path = is_open ? "dilate.comp.spv" : "erode.comp.spv",
-                .workgroup_size = k_wg2d,
-                .push_constant_size = sizeof(MorphPC),
-            };
-            pixel_ctx.swap_shader(second_cfg);
-            pixel_ctx.stage_image(intermediate);
-            pixel_ctx.set_push_constants(MorphPC { .radius = radius });
-            pixel_ctx.prepare_output_image(w, h);
-            pixel_ctx.set_output_dimensions(w, h);
-            {
-                const auto f = pixel_ctx.dispatch_async({});
-                foundry.wait_for_fence(f);
-                foundry.release_fence(f);
-            }
-
-            auto opened_closed = pixel_ctx.get_output_image(0);
-            completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = { .output = opened_closed, .input = contexts.pass.current };
-            contexts.pass.current = opened_closed;
+            completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = op_open_close(contexts, step.op, std::get<MorphParams>(step.params));
             last_staged = contexts.pass.current;
-            contexts.pass.result.structured = std::monostate {};
             continue;
         }
         case VisionOp::Canny: {
@@ -1284,74 +1378,18 @@ VisionResult VisionGpuExecutor::run(
             continue;
         }
         case VisionOp::HarrisResponse: {
-            const auto& p = std::get<HarrisParams>(step.params);
-            const auto radius = static_cast<uint32_t>(std::ceil(p.sigma * 3.0F));
-            const auto& weights = gaussian_kernel_1d(radius, p.sigma);
-
-            auto harris_input = contexts.pass.current;
-            pixel_ctx.swap_shader({ .shader_path = "harris_grad_pack.comp.spv", .workgroup_size = k_wg2d });
-            pixel_ctx.stage_image(contexts.pass.current);
-            pixel_ctx.prepare_output_image(w, h);
-            {
-                const auto f = pixel_ctx.dispatch_async({});
-                foundry.wait_for_fence(f);
-                foundry.release_fence(f);
-            }
-            auto packed = pixel_ctx.get_output_image(0);
-
-            const auto blur_cfg = config(VisionOp::GaussianBlur, GaussianBlurParams { .sigma = p.sigma });
-            pixel_ctx.swap_shader(blur_cfg);
-            pixel_ctx.stage_image(packed);
-            pixel_ctx.set_binding_data(2, std::span<const float>(weights));
-            pixel_ctx.set_push_constants(GaussianPC { .radius = radius, .width = w, .height = h });
-            pixel_ctx.prepare_output_image(w, h);
-            {
-                const auto f = pixel_ctx.dispatch_async({});
-                foundry.wait_for_fence(f);
-                foundry.release_fence(f);
-            }
-            auto smoothed = pixel_ctx.get_output_image(0);
-
-            const GpuComputeConfig harris_resp_cfg {
-                .shader_path = "harris_response.comp.spv",
-                .workgroup_size = k_wg2d,
-                .push_constant_size = sizeof(HarrisPC),
-            };
-            pixel_ctx.swap_shader(harris_resp_cfg);
-            pixel_ctx.stage_image(smoothed);
-            pixel_ctx.set_push_constants(HarrisPC { .k = p.k, .pass = 0U, .width = w, .height = h });
-            pixel_ctx.prepare_output_image(w, h);
-            {
-                const auto f = pixel_ctx.dispatch_async({});
-                foundry.wait_for_fence(f);
-                foundry.release_fence(f);
-            }
-
-            pixel_ctx.set_push_constants(HarrisPC { .k = p.k, .pass = 1U, .width = w, .height = h });
-            {
-                const auto f = pixel_ctx.dispatch_async({});
-                foundry.wait_for_fence(f);
-                foundry.release_fence(f);
-            }
-            contexts.pass.current = pixel_ctx.get_output_image(0);
-            completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = { .output = contexts.pass.current, .input = harris_input };
-
-            contexts.pass.result.structured = std::monostate {};
+            completed_ops[Kinesis::Vision::hash_vision_step(step.op, step.params)] = op_harris_response(contexts, std::get<HarrisParams>(step.params));
             continue;
         }
         case VisionOp::ExtractPeaks: {
-            const auto& p = std::get<ExtractPeaksParams>(step.params);
-            op_extract_peaks(contexts, sequence, p);
+            op_extract_peaks(contexts, sequence, std::get<ExtractPeaksParams>(step.params));
             continue;
         }
         case VisionOp::ConnectedComponents: {
-            const auto& p = std::get<Kinesis::Vision::ConnectedComponentsParams>(step.params);
-
             if (!contexts.pass.current) {
                 continue;
             }
-
-            op_connected_components(contexts, p);
+            op_connected_components(contexts, std::get<Kinesis::Vision::ConnectedComponentsParams>(step.params));
             continue;
         }
         case VisionOp::FindContours: {

--- a/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
+++ b/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.cpp
@@ -46,6 +46,10 @@ namespace {
     struct MorphPC {
         uint32_t radius;
     };
+    struct IngestPC {
+        uint32_t width;
+        uint32_t height;
+    };
     struct HarrisPC {
         float k;
         uint32_t pass;
@@ -1052,6 +1056,71 @@ namespace {
         return true;
     }
 
+    /**
+     * @brief Release the previous run's ingest fences (instant: long signalled).
+     */
+    void reap_ingest_fences(VisionGpuContexts& contexts)
+    {
+        auto& foundry = Portal::Graphics::get_shader_foundry();
+        for (auto* slot : { &contexts.ingest_fence, &contexts.ingest_barrier_fence }) {
+            if (*slot != Portal::Graphics::INVALID_FENCE) {
+                foundry.wait_for_fence(*slot);
+                foundry.release_fence(*slot);
+                *slot = Portal::Graphics::INVALID_FENCE;
+            }
+        }
+    }
+
+    /**
+     * @brief Convert a non-storage seed frame to an rgba32f storage image.
+     *
+     * Frames already carrying storage usage pass through. Otherwise
+     * vision_ingest.comp samples the frame as a texture (sampler does the
+     * unorm/sRGB decode) into contexts.ingest's rgba32f output. The dispatch
+     * is not awaited — a trailing compute barrier gives the memory
+     * dependency, fences are reaped on the next run.
+     */
+    std::shared_ptr<Core::VKImage> op_ingest(
+        VisionGpuContexts& contexts,
+        const std::shared_ptr<Core::VKImage>& frame,
+        uint32_t w, uint32_t h)
+    {
+        if (!frame || !frame->is_initialized())
+            return frame;
+        if (static_cast<bool>(frame->get_usage_flags() & vk::ImageUsageFlagBits::eStorage))
+            return frame;
+
+        auto& foundry = Portal::Graphics::get_shader_foundry();
+        auto& ingest = contexts.ingest;
+
+        ingest.swap_shader({
+            .shader_path = "vision_ingest.comp.spv",
+            .workgroup_size = k_wg2d,
+            .push_constant_size = sizeof(IngestPC),
+        });
+        ingest.stage_image(frame);
+        ingest.set_push_constants(IngestPC { .width = w, .height = h });
+        ingest.prepare_output_image(w, h);
+        ingest.set_output_dimensions(w, h);
+        contexts.ingest_fence = ingest.dispatch_async({});
+        ingest.clear_output_dimensions();
+
+        auto out = ingest.get_output_image(0);
+
+        if (out) {
+            const auto bcmd = foundry.begin_commands(
+                Portal::Graphics::ShaderFoundry::CommandBufferType::COMPUTE);
+            foundry.image_barrier(bcmd, out->get_image(),
+                vk::ImageLayout::eGeneral, vk::ImageLayout::eGeneral,
+                vk::AccessFlagBits::eShaderWrite, vk::AccessFlagBits::eShaderRead,
+                vk::PipelineStageFlagBits::eComputeShader,
+                vk::PipelineStageFlagBits::eComputeShader);
+            contexts.ingest_barrier_fence = foundry.submit_async(bcmd);
+        }
+
+        return out;
+    }
+
 } // namespace
 
 VisionGpuContexts::VisionGpuContexts()
@@ -1123,6 +1192,15 @@ VisionGpuContexts::VisionGpuContexts()
             { .set = 2, .binding = 1, .direction = GpuBufferBinding::Direction::INPUT_OUTPUT, .element_type = GpuBufferBinding::ElementType::FLOAT32 },
         },
         GpuBufferBinding::ElementType::IMAGE_STORAGE,
+        0,
+    }
+    , ingest {
+        GpuComputeConfig {},
+        Portal::Graphics::ImageFormat::RGBA32F,
+        TextureExecutionContext::OutputMode::IMAGE,
+        1,
+        std::vector<GpuBufferBinding> {},
+        GpuBufferBinding::ElementType::IMAGE_SAMPLED,
         0,
     }
 {
@@ -1259,6 +1337,8 @@ void VisionGpuExecutor::reset()
 
     auto& contexts = *m_contexts;
 
+    reap_ingest_fences(contexts);
+
     if (contexts.suspended.is_active()) {
         auto& foundry = Portal::Graphics::get_shader_foundry();
         foundry.wait_for_fence(contexts.suspended.fence);
@@ -1315,9 +1395,11 @@ VisionResult VisionGpuExecutor::run(
 
         begin = contexts.pass.index + 1;
     } else {
+        reap_ingest_fences(contexts);
         contexts.pass.begin(sequence, w, h);
-        contexts.pass.current = image;
-        contexts.source = image;
+        const auto seed = op_ingest(contexts, image, w, h);
+        contexts.pass.current = seed;
+        contexts.source = seed;
     }
 
     for (contexts.pass.index = begin; contexts.pass.index < sequence.steps.size(); ++contexts.pass.index) {

--- a/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.hpp
+++ b/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.hpp
@@ -204,21 +204,6 @@ public:
 
 private:
     std::unique_ptr<VisionGpuContexts> m_contexts;
-
-    void op_extract_peaks(
-        VisionGpuContexts& contexts,
-        const Kinesis::Vision::VisionSequence& sequence,
-        const Kinesis::Vision::ExtractPeaksParams& p);
-
-    void op_connected_components(
-        VisionGpuContexts& contexts,
-        const Kinesis::Vision::ConnectedComponentsParams& p);
-
-    bool op_find_contours(
-        VisionGpuContexts& contexts,
-        const Kinesis::Vision::VisionSequence& sequence,
-        const std::shared_ptr<Core::VKImage>& image,
-        const Kinesis::Vision::FindContoursParams& p);
 };
 
 } // namespace MayaFlux::Yantra

--- a/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.hpp
+++ b/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.hpp
@@ -55,6 +55,33 @@ struct MAYAFLUX_API VisionGpuContexts {
     TextureExecutionContext cc_pipeline;
 
     /**
+     * @brief Outstanding work at a deferred step, and the point to resume.
+     *
+     * fence is INVALID_FENCE when nothing is outstanding. While live, run
+     * polls it and does nothing else: the prefix already executed on the
+     * call that armed this, and its outputs are held here.
+     *
+     * working is the image the deferred step consumed, retained so the
+     * remainder of the sequence sees the pixels the submission was made
+     * against rather than whatever the caller passes on the polling call.
+     */
+    struct Suspension {
+        Portal::Graphics::FenceID fence { Portal::Graphics::INVALID_FENCE };
+        size_t step_index { 0 };
+        std::shared_ptr<Core::VKImage> working;
+        uint32_t w { 0 };
+        uint32_t h { 0 };
+        Kinesis::Vision::VisionResult partial;
+
+        [[nodiscard]] bool is_active() const
+        {
+            return fence != Portal::Graphics::INVALID_FENCE;
+        }
+    };
+
+    Suspension suspended;
+
+    /**
      * @brief Construct all three contexts in place with the one correct
      *        binding layout for every currently GPU-implemented VisionOp.
      *
@@ -147,6 +174,24 @@ public:
         const Kinesis::Vision::VisionSequence& sequence,
         const std::shared_ptr<Core::VKImage>& image,
         uint32_t w, uint32_t h);
+
+    /**
+     * @brief Abandon outstanding work and clear the resume point.
+     *
+     * Waits on the fence before releasing it, then discards the retained
+     * working image and partial result. Call when the pixel source changes
+     * so the next run starts a fresh sequence. Safe with nothing outstanding.
+     */
+    void reset();
+
+    /**
+     * @brief True when a deferred step has work outstanding and the next run
+     *        will poll rather than start a fresh sequence.
+     */
+    [[nodiscard]] bool is_suspended() const
+    {
+        return m_contexts && m_contexts->suspended.is_active();
+    }
 
     VisionGpuExecutor() = default;
     ~VisionGpuExecutor() = default;

--- a/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.hpp
+++ b/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.hpp
@@ -2,7 +2,7 @@
 
 #include "TextureExecutionContext.hpp"
 
-#include "MayaFlux/Kinesis/Vision/VisionExecutor.hpp"
+#include "MayaFlux/Kinesis/Vision/VisionContext.hpp"
 
 namespace MayaFlux::Yantra {
 

--- a/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.hpp
+++ b/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.hpp
@@ -204,6 +204,21 @@ public:
 
 private:
     std::unique_ptr<VisionGpuContexts> m_contexts;
+
+    void op_extract_peaks(
+        VisionGpuContexts& contexts,
+        const Kinesis::Vision::VisionSequence& sequence,
+        const Kinesis::Vision::ExtractPeaksParams& p);
+
+    void op_connected_components(
+        VisionGpuContexts& contexts,
+        const Kinesis::Vision::ConnectedComponentsParams& p);
+
+    bool op_find_contours(
+        VisionGpuContexts& contexts,
+        const Kinesis::Vision::VisionSequence& sequence,
+        const std::shared_ptr<Core::VKImage>& image,
+        const Kinesis::Vision::FindContoursParams& p);
 };
 
 } // namespace MayaFlux::Yantra

--- a/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.hpp
+++ b/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.hpp
@@ -65,6 +65,20 @@ struct MAYAFLUX_API VisionGpuContexts {
     Kinesis::Vision::GpuVisionPass pass;
 
     /**
+     * @brief Input image the current walk started from.
+     *
+     * Ops needing the original frame rather than the working image read this
+     * (contour_march stages it at binding 1). Set on a fresh run and untouched
+     * across suspensions, so a polling call uses the frame the sequence began
+     * on rather than whatever argument it was passed.
+     *
+     * GPU-only. The CPU pass has no equivalent: its handle is an index into a
+     * reused slot pool, so retaining the input handle would retain a slot whose
+     * contents the ping-pong overwrites.
+     */
+    std::shared_ptr<Core::VKImage> source;
+
+    /**
      * @brief Shader currently bound on pixel, and the image staged into it.
      *
      * TextureExecutionContext does not report its own state, so run tracks

--- a/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.hpp
+++ b/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.hpp
@@ -65,6 +65,17 @@ struct MAYAFLUX_API VisionGpuContexts {
     Kinesis::Vision::GpuVisionPass pass;
 
     /**
+     * @brief Shader currently bound on pixel, and the image staged into it.
+     *
+     * TextureExecutionContext does not report its own state, so run tracks
+     * it. Held here rather than as a run local: a swap_shader or stage_image
+     * elided on one call stays elided on the next. The allocated output
+     * dimensions live in pass.storage_w / pass.storage_h.
+     */
+    GpuComputeConfig bound_config;
+    std::shared_ptr<Core::VKImage> bound_staged;
+
+    /**
      * @brief Outstanding work at a deferred step, and the point to resume.
      *
      * fence is INVALID_FENCE when nothing is outstanding. While live, run

--- a/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.hpp
+++ b/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.hpp
@@ -53,6 +53,11 @@ struct MAYAFLUX_API VisionGpuContexts {
                                     ///< data (ConnectedComponents,
                                     ///< FindContours).
     TextureExecutionContext cc_pipeline;
+    TextureExecutionContext ingest; ///< Sampled-in, rgba32f-storage-out.
+                                    ///< IMAGE mode. Runs vision_ingest.comp
+                                    ///< at the top of a fresh run to convert
+                                    ///< a non-storage seed frame before any
+                                    ///< rgba32f op reads it.
 
     /**
      * @brief Walk state for the current run: sequence position, geometry,
@@ -107,6 +112,11 @@ struct MAYAFLUX_API VisionGpuContexts {
     };
 
     Suspension suspended;
+
+    /// op_ingest's dispatch + trailing-barrier fences. Not awaited by run();
+    /// reaped by reap_ingest_fences on the next fresh run and in reset().
+    Portal::Graphics::FenceID ingest_fence { Portal::Graphics::INVALID_FENCE };
+    Portal::Graphics::FenceID ingest_barrier_fence { Portal::Graphics::INVALID_FENCE };
 
     /**
      * @brief Construct all three contexts in place with the one correct

--- a/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.hpp
+++ b/src/MayaFlux/Yantra/Executors/VisionGpuDispatch.hpp
@@ -55,23 +55,25 @@ struct MAYAFLUX_API VisionGpuContexts {
     TextureExecutionContext cc_pipeline;
 
     /**
+     * @brief Walk state for the current run: sequence position, geometry,
+     *        working image, and the result under construction.
+     *
+     * Lives here rather than as a run local so a deferred step's yield
+     * preserves it without copying. Reset by begin() at the top of a fresh
+     * run; left intact across a suspension.
+     */
+    Kinesis::Vision::GpuVisionPass pass;
+
+    /**
      * @brief Outstanding work at a deferred step, and the point to resume.
      *
      * fence is INVALID_FENCE when nothing is outstanding. While live, run
-     * polls it and does nothing else: the prefix already executed on the
-     * call that armed this, and its outputs are held here.
-     *
-     * working is the image the deferred step consumed, retained so the
-     * remainder of the sequence sees the pixels the submission was made
-     * against rather than whatever the caller passes on the polling call.
+     * polls it and does nothing else. The working image, geometry, and
+     * partial result the resumed sequence needs are already in pass, which
+     * is not reset while a suspension is active.
      */
     struct Suspension {
         Portal::Graphics::FenceID fence { Portal::Graphics::INVALID_FENCE };
-        size_t step_index { 0 };
-        std::shared_ptr<Core::VKImage> working;
-        uint32_t w { 0 };
-        uint32_t h { 0 };
-        Kinesis::Vision::VisionResult partial;
 
         [[nodiscard]] bool is_active() const
         {


### PR DESCRIPTION
A vision step can now be marked deferred: it submits its dispatch and returns without waiting, and `run` hands back `SUSPENDED` instead of a result. Call it again and it polls the fence, then carries on from the next step. `is_ready()` tells you whether a result is worth looking at. Sequences that don't use the flag run exactly as they did before.

## Making the executor interruptible

Most of the diff is this, because it wasn't.

`VisionPass<Handle>` now holds everything a run walks through, where it is in the sequence, the geometry, the working image, the memo. Both executors use it, so ops have one shape across CPU and GPU: `Handle` is a slot index on one side and a `VKImage` on the other. Suspension ended up needing just a fence, since everything a resume wants is already in the pass.

The dispatch switch is a table of op functions now. Shader and staging elision moved onto `VisionGpuContexts` instead of being thrown away and redone every call.

## VisionSequence's derived booleans

All three are gone. Two of them were only ever asking "what's the next step", which `ahead()` and `behind()` answer where it's actually asked.

The third came with a worse problem: `build()` reached into a step's params and flipped `export_labels`, so editing a sequence after building it quietly broke things. `ConnectedComponents` works it out for itself now, and can skip writing the full label buffer when nothing downstream wants it.

## NVIDIA

The pipeline was returning empty output on the proprietary driver while RADV was fine. Two causes:

- The seed frame was bound as an 8-bit sampled texture into an rgba32f storage slot. It's now converted on the GPU first, via a small ingest prelude.
- The CC and Harris shaders were missing `std430` and `coherent volatile` on buffers spun on in atomic loops. RADV didn't care; NVIDIA hoisted the loads.

Also fixed along the way: a Harris binding collision between the blur weights and the peak accumulator, a stale `ExtractPeaks` config entry, and a few parameters missing from `hash_vision_step`.

## Notes

`op_ingest` submits without awaiting. Ordering holds because the next op is on the same compute queue, with a trailing barrier for the memory dependency.

Deferral only reaches single-dispatch ops so far. Canny, ConnectedComponents, FindContours, Harris, Otsu and Open/Close ignore the flag, suspending partway through one needs a sub-step position that doesn't exist yet.