### PR TITLE
Volume import: VolumeReader, IOManager::load_volume, VolumeGridBuffer::ensure_fields

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -104,6 +104,7 @@ file(GLOB TINYVDB_SOURCES CONFIGURE_DEPENDS
     ${CMAKE_SOURCE_DIR}/third_party/tinyvdb/*.cc
 )
 list(FILTER TINYVDB_SOURCES EXCLUDE REGEX "tinyvdb_gpu\\.c$")
+list(FILTER TINYVDB_SOURCES EXCLUDE REGEX "tinyvdb_io\\.cc$")
 
 add_library(tinyvdb STATIC ${TINYVDB_SOURCES})
 set_target_properties(tinyvdb PROPERTIES

--- a/cmake/pch.h
+++ b/cmake/pch.h
@@ -124,8 +124,24 @@ concept SafeIntegerConversion = IntegerData<From> && IntegerData<To> && (sizeof(
 template <typename From, typename To>
 concept SafeDecimalConversion = DecimalData<From> && DecimalData<To> && (sizeof(From) <= sizeof(To));
 
+/**
+ * @brief Same-domain widening only: integer to a same-signedness,
+ *        no-narrower integer, or decimal to a no-narrower decimal.
+ *
+ * Deliberately excludes integer-to-decimal, which this concept used to
+ * include unconditionally regardless of width — int64_t -> float satisfied
+ * it despite being lossy for any value outside float's 24-bit mantissa
+ * range, and int32_t -> float satisfied it too despite being same-width
+ * rather than narrower, which is what the old sizeof(From) > sizeof(To)
+ * precision check downstream relied on to flag it and didn't. Both
+ * remaining disjuncts are provably lossless for every value of From, not
+ * just typical ones, which is the property that lets try_convert skip a
+ * runtime check for them entirely — nothing else in this codebase earns
+ * that shortcut, and int-to-decimal, decimal-to-int, and any narrowing or
+ * sign-mismatched pair all fall through to try_convert's general path.
+ */
 template <typename From, typename To>
-concept SafeArithmeticConversion = ArithmeticData<From> && ArithmeticData<To> && (SafeIntegerConversion<From, To> || SafeDecimalConversion<From, To> || (IntegerData<From> && DecimalData<To>));
+concept SafeArithmeticConversion = SafeIntegerConversion<From, To> || SafeDecimalConversion<From, To>;
 
 // === Safe Any Cast System ===
 
@@ -154,6 +170,22 @@ struct CastResult {
     }
 };
 
+/**
+ * @brief Convert value to To, reporting whether the round trip is exact.
+ *
+ * A SafeArithmeticConversion pair — same-domain widening, provably lossless
+ * for every value of From — skips the runtime check entirely and reports
+ * precision_loss = false unconditionally, since it is a compile-time fact
+ * rather than something any particular value could contradict. Every other
+ * arithmetic pair — narrowing, cross-domain (int to decimal or back), or
+ * sign-mismatched — is checked by converting to To and back to From and
+ * comparing against the original: a direction-agnostic check that replaces
+ * what used to be a sizeof(From) > sizeof(To) heuristic applied too broadly
+ * (int32_t -> float satisfied the old SafeArithmeticConversion despite
+ * being same-width, not narrower, and losing precision above 2^24) and a
+ * decimal-to-integer-only floor check that left decimal-to-decimal
+ * narrowing, including double -> float, unchecked entirely.
+ */
 template <typename To, typename From>
 CastResult<To> try_convert(const From& value)
 {
@@ -168,13 +200,10 @@ CastResult<To> try_convert(const From& value)
         result.value = value;
     } else if constexpr (SafeArithmeticConversion<From, To>) {
         result.value = static_cast<To>(value);
-        result.precision_loss = (sizeof(From) > sizeof(To));
     } else if constexpr (ArithmeticData<From> && ArithmeticData<To>) {
-        if constexpr (DecimalData<From> && IntegerData<To>) {
-            if (std::floor(value) != value)
-                result.precision_loss = true;
-        }
-        result.value = static_cast<To>(value);
+        const To converted = static_cast<To>(value);
+        result.value = converted;
+        result.precision_loss = (static_cast<From>(converted) != value);
     } else if constexpr (ComplexData<From> && ArithmeticData<To>) {
         result.value = static_cast<To>(std::abs(value));
         result.precision_loss = (std::imag(value) != 0);

--- a/src/MayaFlux/API/Depot.cpp
+++ b/src/MayaFlux/API/Depot.cpp
@@ -10,6 +10,8 @@
 #include "MayaFlux/Kakshya/Source/SoundStreamContainer.hpp"
 
 #include "MayaFlux/Buffers/Geometry/MeshBuffer.hpp"
+#include "MayaFlux/Buffers/State/VolumeGridBuffer.hpp"
+#include "MayaFlux/IO/VolumeWriter.hpp"
 #include "MayaFlux/Nodes/Network/MeshNetwork.hpp"
 
 #include "MayaFlux/Portal/System/Dialog/Chooser.hpp"
@@ -60,6 +62,11 @@ namespace {
 
     const std::vector<Portal::System::Dialog::ChooserFilter> k_image_save_filters {
         { .name = "Image", .extensions = { "png", "jpg", "jpeg", "bmp", "tga", "exr", "hdr" } },
+        { .name = "All Files", .extensions = { "*" } }
+    };
+
+    const std::vector<Portal::System::Dialog::ChooserFilter> k_volume_filters {
+        { .name = "Volume", .extensions = { "vdb" } },
         { .name = "All Files", .extensions = { "*" } }
     };
 
@@ -176,6 +183,17 @@ std::shared_ptr<Nodes::Network::MeshNetwork> choose_mesh_network(IO::TextureReso
         k_mesh_filters);
 }
 
+std::shared_ptr<Buffers::VolumeGridBuffer> choose_volume()
+{
+    if (!require_portal("choose_volume"))
+        return nullptr;
+
+    return Portal::System::Dialog::open_file<std::shared_ptr<Buffers::VolumeGridBuffer>>(
+        [](const fs::path& p) { return get_io_manager()->load_volume(p.string()); },
+        [](Core::SystemDialogError) { },
+        k_volume_filters);
+}
+
 // ---------------------------------------------------------------------------
 // Dialog-backed save
 // ---------------------------------------------------------------------------
@@ -249,6 +267,53 @@ bool save_image(
         [](Core::SystemDialogError) { },
         suggested_name,
         k_image_save_filters);
+}
+
+bool save_volume(
+    const std::shared_ptr<Buffers::VolumeGridBuffer>& volume,
+    const std::string& suggested_name)
+{
+    if (!require_portal("save_volume"))
+        return false;
+
+    auto iom = get_io_manager();
+    if (!iom) {
+        MF_ERROR(Journal::Component::API, Journal::Context::Runtime,
+            "save_volume: IOManager unavailable");
+        return false;
+    }
+
+    return Portal::System::Dialog::save_file<bool>(
+        [&iom, &volume](const fs::path& p) {
+            return iom->save_volume(volume, p.string(), IO::VolumeWriteOptions {});
+        },
+        [](Core::SystemDialogError) { },
+        suggested_name,
+        k_volume_filters);
+}
+
+bool save_volume(
+    const std::shared_ptr<Buffers::VolumeGridBuffer>& volume,
+    const std::string& suggested_name,
+    const IO::VolumeWriteOptions& options)
+{
+    if (!require_portal("save_volume"))
+        return false;
+
+    auto iom = get_io_manager();
+    if (!iom) {
+        MF_ERROR(Journal::Component::API, Journal::Context::Runtime,
+            "save_volume: IOManager unavailable");
+        return false;
+    }
+
+    return Portal::System::Dialog::save_file<bool>(
+        [&iom, &volume, &options](const fs::path& p) {
+            return iom->save_volume(volume, p.string(), options);
+        },
+        [](Core::SystemDialogError) { },
+        suggested_name,
+        k_volume_filters);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/MayaFlux/API/Depot.hpp
+++ b/src/MayaFlux/API/Depot.hpp
@@ -22,6 +22,7 @@ namespace Core {
 namespace IO {
     class IOManager;
     struct ImageWriteOptions;
+    struct VolumeWriteOptions;
     using TextureResolver = std::function<std::shared_ptr<Core::VKImage>(const std::string&)>; // add
 }
 
@@ -36,6 +37,7 @@ namespace Buffers {
     class SoundContainerBuffer;
     class TextureBuffer;
     class MeshBuffer;
+    class VolumeGridBuffer;
 }
 
 namespace Nodes::Network {
@@ -130,6 +132,15 @@ MAYAFLUX_API std::vector<std::shared_ptr<Buffers::MeshBuffer>> choose_mesh();
 MAYAFLUX_API std::shared_ptr<Nodes::Network::MeshNetwork>
 choose_mesh_network(IO::TextureResolver resolver = nullptr);
 
+/**
+ * @brief Present a native open-file dialog filtered to volume formats and
+ *        load the chosen file via IOManager::load_volume().
+ *
+ * Blocks until the user confirms or cancels. Returns nullptr on cancellation,
+ * backend error, or if Portal::System is not initialized.
+ */
+MAYAFLUX_API std::shared_ptr<Buffers::VolumeGridBuffer> choose_volume();
+
 // ─────────────────────────────────────────────────────────────────────────
 // Dialog-backed save
 // ─────────────────────────────────────────────────────────────────────────
@@ -181,6 +192,39 @@ MAYAFLUX_API bool save_image(
     const std::shared_ptr<Buffers::TextureBuffer>& buffer,
     const std::string& suggested_name,
     const IO::ImageWriteOptions& options);
+
+/**
+ * @brief Present a native save-file dialog filtered to volume formats and save
+ *        @p volume to the chosen path via IOManager::save_volume().
+ *
+ * Blocks until the user confirms or cancels. The download and encode task
+ * are queued asynchronously; this function returns once the path is chosen
+ * and the task is enqueued. Returns false on cancellation, backend error,
+ * or if Portal::System is not initialized.
+ *
+ * @param volume         Source VolumeGridBuffer to download and encode.
+ * @param suggested_name Filename pre-filled in the dialog name field.
+ */
+MAYAFLUX_API bool save_volume(
+    const std::shared_ptr<Buffers::VolumeGridBuffer>& volume,
+    const std::string& suggested_name = "output.vdb");
+
+/**
+ * @brief Present a native save-file dialog filtered to volume formats and save
+ *        @p volume to the chosen path via IOManager::save_volume().
+ *
+ * Blocks until the user confirms or cancels. The download and encode task
+ * are queued asynchronously. Returns false on cancellation, backend error,
+ * or if Portal::System is not initialized.
+ *
+ * @param volume         Source VolumeGridBuffer to download and encode.
+ * @param suggested_name Filename pre-filled in the dialog name field.
+ * @param options        Writer options forwarded to IOManager.
+ */
+MAYAFLUX_API bool save_volume(
+    const std::shared_ptr<Buffers::VolumeGridBuffer>& volume,
+    const std::string& suggested_name,
+    const IO::VolumeWriteOptions& options);
 
 /**
  * @brief Retrieves the global IOManager instance for file loading and buffer management

--- a/src/MayaFlux/Buffers/State/VolumeGridBuffer.cpp
+++ b/src/MayaFlux/Buffers/State/VolumeGridBuffer.cpp
@@ -198,6 +198,26 @@ VectorRef VolumeGridBuffer::declare_vector(std::string name, Kinesis::LatticeSem
     };
 }
 
+std::vector<std::string> VolumeGridBuffer::ensure_fields(const std::vector<FieldDecl>& decls)
+{
+    std::vector<std::string> declared;
+    declared.reserve(decls.size());
+
+    for (const auto& decl : decls) {
+        if (has_field(decl.name)) {
+            MF_DEBUG(Journal::Component::Buffers, Journal::Context::Init,
+                "VolumeGridBuffer::ensure_fields: '{}' already present, reused", decl.name);
+            continue;
+        }
+
+        if (allocate_field(decl.name, decl.stride_bytes, decl.double_buffered, decl.semantics)) {
+            declared.push_back(decl.name);
+        }
+    }
+
+    return declared;
+}
+
 void VolumeGridBuffer::setup_processors(ProcessingToken token)
 {
     auto chain = get_processing_chain();

--- a/src/MayaFlux/Buffers/State/VolumeGridBuffer.hpp
+++ b/src/MayaFlux/Buffers/State/VolumeGridBuffer.hpp
@@ -441,6 +441,37 @@ public:
     VectorRef declare_vector(std::string name, Kinesis::LatticeSemantics semantics = {});
 
     /**
+     * @brief Declare whichever of @p decls are not already present.
+     *
+     * Built for a buffer whose fields were not all declared by the same
+     * call: IOManager::load_volume declares one field per grid a file
+     * reported, and a caller then wanting to run a simulation over that
+     * data needs velocity, pressure and the rest besides. Declaring those
+     * blind risks exactly what allocate_field already logs an error for —
+     * a name the file also happened to use, silently discarded, cascading
+     * into an empty-name ref everywhere that field is passed next. This
+     * checks first, so a name already present — whether reported by a
+     * loader or declared earlier by hand, nothing here distinguishes the
+     * two — is left alone rather than collided with.
+     *
+     * A caller who wants a ScalarRef/VectorRef for an entry already present
+     * builds one directly: `ScalarRef{name, owner}` from its own name and
+     * this buffer, the same way declare_scalar builds the ref for a field
+     * it also just allocated. This does not return refs itself, since
+     * FieldDecl does not distinguish scalar from vector cleanly enough to
+     * hand back a uniformly typed collection.
+     *
+     * @param decls Fields to ensure exist. Semantics and stride only take
+     *              effect for an entry actually declared here; an entry
+     *              already present keeps whatever it already has.
+     * @return Names of the entries actually declared — not already present,
+     *         and not rejected for the reasons allocate_field logs. A
+     *         caller seeding initial values should seed exactly these and
+     *         leave every other named field's existing data untouched.
+     */
+    std::vector<std::string> ensure_fields(const std::vector<FieldDecl>& decls);
+
+    /**
      * @brief Write initial values into a scalar field from a Kinesis field.
      * @param name Field name. Must have stride sizeof(float).
      * @param field Sampled at each cell centre in world space.

--- a/src/MayaFlux/IO/IOManager.cpp
+++ b/src/MayaFlux/IO/IOManager.cpp
@@ -18,6 +18,7 @@
 #include "MayaFlux/Buffers/Textures/TextureBuffer.hpp"
 
 #include "MayaFlux/Buffers/Geometry/MeshBuffer.hpp"
+#include "MayaFlux/Buffers/State/VolumeGridBuffer.hpp"
 #include "MayaFlux/Buffers/Textures/TextBuffer.hpp"
 
 #include "MayaFlux/Registry/BackendRegistry.hpp"
@@ -1017,6 +1018,62 @@ bool IOManager::save_image(
     });
 
     return true;
+}
+
+std::shared_ptr<Buffers::VolumeGridBuffer>
+IOManager::load_volume(const std::string& filepath, const IO::VolumeReadOptions& options)
+{
+    IO::VolumeReader reader;
+
+    if (!reader.can_read(filepath)) {
+        MF_ERROR(Journal::Component::API, Journal::Context::FileIO,
+            "IOManager::load_volume: unsupported format '{}'", filepath);
+        return nullptr;
+    }
+
+    auto data = reader.load(filepath, options);
+    if (!data) {
+        MF_ERROR(Journal::Component::API, Journal::Context::FileIO,
+            "IOManager::load_volume: failed to load '{}' — {}",
+            filepath, reader.get_last_error());
+        return nullptr;
+    }
+
+    std::vector<Buffers::VolumeGridBuffer::FieldDecl> decls;
+    decls.reserve(data->fields.size());
+    for (const auto& field : data->fields) {
+        decls.push_back({
+            .name = field.name,
+            .stride_bytes = field.is_vector() ? sizeof(glm::vec4) : sizeof(float),
+            .double_buffered = true,
+            .semantics = field.semantics,
+        });
+    }
+
+    auto buffer = m_buffer_manager->create_graphics_buffer<Buffers::VolumeGridBuffer>(
+        Buffers::ProcessingToken::GRAPHICS_BACKEND,
+        data->lattice, decls);
+
+    if (!buffer) {
+        MF_ERROR(Journal::Component::API, Journal::Context::FileIO,
+            "IOManager::load_volume: failed to construct VolumeGridBuffer for '{}'", filepath);
+        return nullptr;
+    }
+
+    if (!IO::upload_volume(*data, buffer)) {
+        MF_ERROR(Journal::Component::API, Journal::Context::FileIO,
+            "IOManager::load_volume: upload failed for '{}'", filepath);
+        return nullptr;
+    }
+
+    m_loaded_volumes.push_back(buffer);
+
+    MF_INFO(Journal::Component::API, Journal::Context::FileIO,
+        "IOManager::load_volume: {} field(s) from '{}'",
+        data->fields.size(),
+        std::filesystem::path(filepath).filename().string());
+
+    return buffer;
 }
 
 bool IOManager::save_volume(

--- a/src/MayaFlux/IO/IOManager.cpp
+++ b/src/MayaFlux/IO/IOManager.cpp
@@ -1113,6 +1113,56 @@ bool IOManager::save_volume(
     return true;
 }
 
+bool IOManager::save_volume(
+    const std::shared_ptr<Buffers::VolumeGridBuffer>& volume,
+    const std::string& filepath,
+    const IO::VolumeWriteOptions& options,
+    const std::vector<std::string>& field_names)
+{
+    if (!volume) {
+        MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+            "save_volume: null volume");
+        return false;
+    }
+
+    auto fut = std::async(std::launch::async,
+        [volume, filepath, options, field_names]() -> bool {
+            auto data = IO::download_volume(volume, field_names);
+            if (!data) {
+                MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+                    "save_volume task: download failed for '{}'", filepath);
+                return false;
+            }
+
+            auto writer = IO::VolumeWriterRegistry::instance().create_writer(filepath);
+            if (!writer) {
+                MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+                    "save_volume task: no writer registered for '{}'", filepath);
+                return false;
+            }
+
+            const bool ok = writer->write(filepath, *data, options);
+            if (!ok) {
+                MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+                    "save_volume task: writer failed for '{}': {}",
+                    filepath, writer->get_last_error());
+            } else {
+                MF_INFO(Journal::Component::IO, Journal::Context::FileIO,
+                    "save_volume task: wrote '{}'", filepath);
+            }
+            return ok;
+        });
+
+    std::lock_guard lock(m_save_tasks_mutex);
+    m_save_tasks.push_back(std::move(fut));
+
+    std::erase_if(m_save_tasks, [](std::future<bool>& f) {
+        return f.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
+    });
+
+    return true;
+}
+
 uint32_t IOManager::capture_volume(
     const std::shared_ptr<Buffers::VolumeGridBuffer>& volume,
     const std::string& path_pattern,

--- a/src/MayaFlux/IO/IOManager.hpp
+++ b/src/MayaFlux/IO/IOManager.hpp
@@ -637,12 +637,6 @@ public:
      * Encode and disk flush are dispatched to a worker; failures are logged
      * but do not block.
      *
-     * There is deliberately no VolumeGridBuffer overload. read_field records
-     * a fenced device-to-host copy and needs command queue access, so unlike
-     * save_image(VKImage) the download cannot move into the task. Call
-     * IO::download_volume from a thread that has queue access, typically a
-     * GraphicsRoutine, then pass the result here.
-     *
      * The extension of @p filepath selects the writer via
      * VolumeWriterRegistry. For synchronous semantics use the
      * IO::save_volume free function in VolumeTransfer.hpp, and for a numbered
@@ -654,6 +648,28 @@ public:
         Kakshya::VolumeData data,
         const std::string& filepath,
         const IO::VolumeWriteOptions& options = {});
+
+    /**
+     * @brief Download and save a GPU-resident volume to disk asynchronously.
+     *
+     * Mirrors save_image(VKImage): download, writer lookup and write all
+     * happen inside the dispatched task, so this returns as soon as the
+     * task is queued rather than blocking the caller. The future is tracked
+     * in the same pool as every other save task; wait_for_pending_saves()
+     * waits on it like any other.
+     *
+     * @param volume      Volume to read from.
+     * @param filepath    Destination path; extension selects the writer.
+     * @param options     Writer options.
+     * @param field_names Fields to save. Empty means every declared field.
+     * @return True once the task is queued. Download or write failure is
+     *         logged from the task and does not surface here.
+     */
+    bool save_volume(
+        const std::shared_ptr<Buffers::VolumeGridBuffer>& volume,
+        const std::string& filepath,
+        const IO::VolumeWriteOptions& options = {},
+        const std::vector<std::string>& field_names = {});
 
     /**
      * @brief Begin recording a numbered .vdb sequence from a volume.

--- a/src/MayaFlux/IO/IOManager.hpp
+++ b/src/MayaFlux/IO/IOManager.hpp
@@ -5,6 +5,7 @@
 #include "SoundFileWriter.hpp"
 #include "VideoFileReader.hpp"
 #include "VideoFileWriter.hpp"
+#include "VolumeReader.hpp"
 #include "VolumeTransfer.hpp"
 #include "VolumeWriter.hpp"
 
@@ -586,6 +587,46 @@ public:
     void wait_for_pending_saves();
 
     // ─────────────────────────────────────────────────────────────────────────
+    // Volume — load
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * @brief Load a volume file into a newly constructed VolumeGridBuffer.
+     *
+     * Opens the file via IO::VolumeReader, reads every selected grid into
+     * VolumeData, constructs a VolumeGridBuffer with one FieldDecl per
+     * field — name and semantics from the file, stride sizeof(float) for a
+     * scalar field or sizeof(glm::vec4) for a vector one, the GPU layout
+     * every vector field uses regardless of what VolumeData stores — over
+     * the file's own lattice, and seeds it via IO::upload_volume. Mirrors
+     * load_mesh: construction and GPU registration only, nothing about
+     * processing chain or rendering.
+     *
+     * setup_processors() and any simulation wiring via setup_flow() are
+     * left to the caller, as VolumeGridBuffer's own usage example assumes.
+     * Nothing about an imported file says whether the caller wants to keep
+     * simulating what it loaded, run it once as a mask, or read it once and
+     * discard the buffer — so nothing here decides that for them.
+     *
+     * The returned buffer is retained for the lifetime of IOManager; see
+     * get_loaded_volumes().
+     *
+     * @param filepath Path to the volume file (.vdb).
+     * @param options  Grid selection, forwarded to VolumeReader::load().
+     * @return Constructed and seeded VolumeGridBuffer, or nullptr on failure.
+     */
+    [[nodiscard]] std::shared_ptr<Buffers::VolumeGridBuffer>
+    load_volume(
+        const std::string& filepath,
+        const IO::VolumeReadOptions& options = {});
+
+    /**
+     * @brief Returns all VolumeGridBuffers created via load_volume().
+     */
+    [[nodiscard]] std::vector<std::shared_ptr<Buffers::VolumeGridBuffer>>
+    get_loaded_volumes() const { return m_loaded_volumes; }
+
+    // ─────────────────────────────────────────────────────────────────────────
     // Volume — save
     // ─────────────────────────────────────────────────────────────────────────
 
@@ -751,11 +792,12 @@ private:
 
     std::vector<std::shared_ptr<VideoFileWriter>> m_video_writers;
 
-    // ── Volume Capture ──────────────────────────────────────────────────────
+    // ── Volume ──────────────────────────────────────────────────────
 
     std::atomic<uint32_t> m_next_volume_capture_id { 1 };
     mutable std::mutex m_volume_captures_mutex;
     std::unordered_map<uint32_t, std::unique_ptr<IO::VolumeCapture>> m_volume_captures;
+    std::vector<std::shared_ptr<Buffers::VolumeGridBuffer>> m_loaded_volumes;
 
     // ── readers ──────────────────────────────────────────────────────
 

--- a/src/MayaFlux/IO/IOManager.hpp
+++ b/src/MayaFlux/IO/IOManager.hpp
@@ -5,7 +5,7 @@
 #include "SoundFileWriter.hpp"
 #include "VideoFileReader.hpp"
 #include "VideoFileWriter.hpp"
-#include "VolumeExport.hpp"
+#include "VolumeTransfer.hpp"
 #include "VolumeWriter.hpp"
 
 #include <future>
@@ -604,7 +604,7 @@ public:
      *
      * The extension of @p filepath selects the writer via
      * VolumeWriterRegistry. For synchronous semantics use the
-     * IO::save_volume free function in VolumeExport.hpp, and for a numbered
+     * IO::save_volume free function in VolumeTransfer.hpp, and for a numbered
      * frame sequence use IO::VolumeCapture.
      *
      * @return True if the encode task was queued.

--- a/src/MayaFlux/IO/VDBArchive.cpp
+++ b/src/MayaFlux/IO/VDBArchive.cpp
@@ -118,10 +118,10 @@ namespace {
     /**
      * @brief World-space translation from a grid's transform.
      *
-     * AFFINE's translation is read from the last row, matching the
-     * row-major layout tvdb_transform_t documents; a column-major foreign
-     * writer would need this flipped, which is not detectable from the
-     * struct alone.
+     * AFFINE's translation is read from the last column, rows 0-2 — the
+     * standard [R | t; 0 0 0 1] row-major layout, confirmed directly
+     * against tinyvdb's own AffineMap read/write (tvdb->translation[i] =
+     * matrix[i][3], both directions), not assumed.
      */
     glm::vec3 grid_translation(const tvdb_transform_t& t)
     {
@@ -136,9 +136,9 @@ namespace {
             };
         case TVDB_TRANSFORM_AFFINE:
             return {
-                static_cast<float>(t.matrix[3][0]),
-                static_cast<float>(t.matrix[3][1]),
-                static_cast<float>(t.matrix[3][2]),
+                static_cast<float>(t.matrix[0][3]),
+                static_cast<float>(t.matrix[1][3]),
+                static_cast<float>(t.matrix[2][3]),
             };
         default:
             return glm::vec3(0.0F);

--- a/src/MayaFlux/IO/VDBArchive.cpp
+++ b/src/MayaFlux/IO/VDBArchive.cpp
@@ -181,64 +181,105 @@ namespace {
         return f;
     }
 
-    float narrow_scalar(tvdb_value_type_t vt, const void* bytes)
+    /**
+     * @brief Convert one raw scalar element to float via MayaFlux::try_convert.
+     *
+     * HALF is the one source type try_convert cannot see: it is a bit
+     * pattern, not a type try_convert's arithmetic concepts recognise, so
+     * it keeps its own decode. It is also the one case with no precision
+     * question to answer — float has strictly more range and mantissa bits
+     * than half, so widening it is always exact.
+     */
+    CastResult<float> narrow_scalar(tvdb_value_type_t vt, const void* bytes)
     {
         switch (vt) {
         case TVDB_VALUE_FLOAT: {
             float v {};
             std::memcpy(&v, bytes, sizeof(v));
-            return v;
+            return try_convert<float>(v);
         }
         case TVDB_VALUE_DOUBLE: {
-            double v = {};
+            double v {};
             std::memcpy(&v, bytes, sizeof(v));
-            return static_cast<float>(v);
+            return try_convert<float>(v);
         }
         case TVDB_VALUE_INT32: {
             int32_t v {};
             std::memcpy(&v, bytes, sizeof(v));
-            return static_cast<float>(v);
+            return try_convert<float>(v);
         }
         case TVDB_VALUE_INT64: {
             int64_t v {};
             std::memcpy(&v, bytes, sizeof(v));
-            return static_cast<float>(v);
+            return try_convert<float>(v);
         }
         case TVDB_VALUE_BOOL: {
             uint8_t v {};
             std::memcpy(&v, bytes, sizeof(v));
-            return v != 0 ? 1.0F : 0.0F;
+            return try_convert<float>(v != 0);
         }
         case TVDB_VALUE_HALF: {
             uint16_t v {};
             std::memcpy(&v, bytes, sizeof(v));
-            return half_to_float(v);
+            CastResult<float> result;
+            result.value = half_to_float(v);
+            return result;
         }
-        default:
-            return 0.0F;
+        default: {
+            CastResult<float> result;
+            result.value = 0.0F;
+            return result;
+        }
         }
     }
 
-    glm::vec3 narrow_vector(tvdb_value_type_t vt, const void* bytes)
+    /**
+     * @brief narrow_vector's result: the converted glm::vec3 and whether
+     *        any of its three components lost precision.
+     *
+     * A plain glm::vec3 cannot also carry precision_loss, and
+     * try_convert does not itself understand GLM types (it
+     * converts one arithmetic scalar at a time) so this aggregates three
+     * per-component try_convert calls rather than making one call over the
+     * vector as a whole.
+     */
+    struct VectorNarrowResult {
+        glm::vec3 value { 0.0F };
+        bool precision_loss { false };
+    };
+
+    VectorNarrowResult narrow_vector(tvdb_value_type_t vt, const void* bytes)
     {
         switch (vt) {
         case TVDB_VALUE_VEC3F: {
             float v[3];
             std::memcpy(v, bytes, sizeof(v));
-            return { v[0], v[1], v[2] };
+            return { { v[0], v[1], v[2] }, false };
         }
         case TVDB_VALUE_VEC3D: {
             double v[3];
             std::memcpy(v, bytes, sizeof(v));
-            return { static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]) };
+            const auto cx = try_convert<float>(v[0]);
+            const auto cy = try_convert<float>(v[1]);
+            const auto cz = try_convert<float>(v[2]);
+            return {
+                { cx.value.value_or(0.0F), cy.value.value_or(0.0F), cz.value.value_or(0.0F) },
+                cx.precision_loss || cy.precision_loss || cz.precision_loss,
+            };
         }
         case TVDB_VALUE_VEC3I: {
             int32_t v[3];
             std::memcpy(v, bytes, sizeof(v));
-            return { static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]) };
+            const auto cx = try_convert<float>(v[0]);
+            const auto cy = try_convert<float>(v[1]);
+            const auto cz = try_convert<float>(v[2]);
+            return {
+                { cx.value.value_or(0.0F), cy.value.value_or(0.0F), cz.value.value_or(0.0F) },
+                cx.precision_loss || cy.precision_loss || cz.precision_loss,
+            };
         }
         default:
-            return glm::vec3(0.0F);
+            return {};
         }
     }
 
@@ -247,7 +288,11 @@ namespace {
      *
      * Root index 0 is not a convention this reader invents: tinyvdb's own
      * tvdb_grid_set_background writes through tree.nodes[0].u.root, so a
-     * well-formed grid always has its root there.
+     * well-formed grid always has its root there. Background precision loss
+     * is not tracked separately from the active-cell kind read_dense_scalar/
+     * read_dense_vector report; a lossy background is rare enough (it is one
+     * value, not a whole grid's worth) that this returns the converted value
+     * only.
      */
     float grid_background_scalar(const tvdb_grid_t& grid)
     {
@@ -255,7 +300,7 @@ namespace {
             return 0.0F;
         }
         const tvdb_value_t& bg = grid.tree.nodes[0].u.root.background;
-        return narrow_scalar(bg.type, &bg.u);
+        return narrow_scalar(bg.type, &bg.u).value.value_or(0.0F);
     }
 
     glm::vec3 grid_background_vector(const tvdb_grid_t& grid)
@@ -264,7 +309,7 @@ namespace {
             return glm::vec3(0.0F);
         }
         const tvdb_value_t& bg = grid.tree.nodes[0].u.root.background;
-        return narrow_vector(bg.type, &bg.u);
+        return narrow_vector(bg.type, &bg.u).value;
     }
 
     /**
@@ -301,13 +346,16 @@ namespace {
      *
      * region_max is exclusive. elem_size is the leaf's own on-disk element
      * width, used to stride into the raw byte buffer regardless of what
-     * that element narrows to.
+     * that element narrows to. precision_lost, when non-null, accumulates
+     * across every element the visit touches — set true the first time any
+     * one of them loses precision and left alone afterward.
      */
     struct DenseCtx {
         glm::ivec3 region_min;
         glm::ivec3 region_max;
         tvdb_value_type_t vt;
         size_t elem_size;
+        bool* precision_lost { nullptr };
     };
 
     struct DenseScalarCtx : DenseCtx {
@@ -351,7 +399,11 @@ namespace {
             }
             const glm::ivec3 local = world - ctx->region_min;
             const size_t index = (static_cast<size_t>(local.z) * res.y + local.y) * res.x + local.x;
-            (*ctx->out)[index] = narrow_scalar(ctx->vt, base + static_cast<size_t>(s) * ctx->elem_size);
+            const auto converted = narrow_scalar(ctx->vt, base + static_cast<size_t>(s) * ctx->elem_size);
+            (*ctx->out)[index] = converted.value.value_or(0.0F);
+            if (converted.precision_loss && ctx->precision_lost) {
+                *ctx->precision_lost = true;
+            }
         }
         return 0;
     }
@@ -374,7 +426,11 @@ namespace {
             }
             const glm::ivec3 local = world - ctx->region_min;
             const size_t index = (static_cast<size_t>(local.z) * res.y + local.y) * res.x + local.x;
-            (*ctx->out)[index] = narrow_vector(ctx->vt, base + static_cast<size_t>(s) * ctx->elem_size);
+            const auto converted = narrow_vector(ctx->vt, base + static_cast<size_t>(s) * ctx->elem_size);
+            (*ctx->out)[index] = converted.value;
+            if (converted.precision_loss && ctx->precision_lost) {
+                *ctx->precision_lost = true;
+            }
         }
         return 0;
     }
@@ -680,7 +736,8 @@ bool VDBArchive::read_dense_scalar(
     const glm::ivec3& region_min,
     const glm::uvec3& resolution,
     float background,
-    std::vector<float>& out) const
+    std::vector<float>& out,
+    bool* precision_lost) const
 {
     if (!m_state->read_file_open || index >= m_state->read_file.num_grids) {
         m_last_error = "read_dense_scalar: grid index out of range";
@@ -705,6 +762,10 @@ bool VDBArchive::read_dense_scalar(
         return false;
     }
 
+    if (precision_lost) {
+        *precision_lost = false;
+    }
+
     out.assign(static_cast<size_t>(resolution.x) * resolution.y * resolution.z, background);
 
     DenseScalarCtx ctx {};
@@ -712,6 +773,7 @@ bool VDBArchive::read_dense_scalar(
     ctx.region_max = region_min + glm::ivec3(resolution);
     ctx.vt = vt;
     ctx.elem_size = elem_size;
+    ctx.precision_lost = precision_lost;
     ctx.out = &out;
 
     tvdb_grid_visit_leaves(&grid, dense_scalar_visit, &ctx);
@@ -723,7 +785,8 @@ bool VDBArchive::read_dense_vector(
     const glm::ivec3& region_min,
     const glm::uvec3& resolution,
     const glm::vec3& background,
-    std::vector<glm::vec3>& out) const
+    std::vector<glm::vec3>& out,
+    bool* precision_lost) const
 {
     if (!m_state->read_file_open || index >= m_state->read_file.num_grids) {
         m_last_error = "read_dense_vector: grid index out of range";
@@ -748,6 +811,10 @@ bool VDBArchive::read_dense_vector(
         return false;
     }
 
+    if (precision_lost) {
+        *precision_lost = false;
+    }
+
     out.assign(static_cast<size_t>(resolution.x) * resolution.y * resolution.z, background);
 
     DenseVectorCtx ctx {};
@@ -755,6 +822,7 @@ bool VDBArchive::read_dense_vector(
     ctx.region_max = region_min + glm::ivec3(resolution);
     ctx.vt = vt;
     ctx.elem_size = elem_size;
+    ctx.precision_lost = precision_lost;
     ctx.out = &out;
 
     tvdb_grid_visit_leaves(&grid, dense_vector_visit, &ctx);

--- a/src/MayaFlux/IO/VDBArchive.cpp
+++ b/src/MayaFlux/IO/VDBArchive.cpp
@@ -55,6 +55,330 @@ namespace {
         return is_vector ? "Tree_vec3s_5_4_3" : "Tree_float_5_4_3";
     }
 
+    // -------------------------------------------------------------------------
+    // Read path
+    // -------------------------------------------------------------------------
+
+    /**
+     * @brief The value type leaf-level cells of a grid are stored as.
+     */
+    tvdb_value_type_t leaf_value_type(const tvdb_grid_t& grid)
+    {
+        const int levels = grid.tree.layout.num_levels;
+        if (levels <= 0) {
+            return TVDB_VALUE_NULL;
+        }
+        return grid.tree.layout.levels[levels - 1].value_type;
+    }
+
+    constexpr bool is_vector_type(tvdb_value_type_t vt)
+    {
+        return vt == TVDB_VALUE_VEC3F || vt == TVDB_VALUE_VEC3D || vt == TVDB_VALUE_VEC3I;
+    }
+
+    constexpr bool needs_narrowing(tvdb_value_type_t vt)
+    {
+        return vt != TVDB_VALUE_FLOAT && vt != TVDB_VALUE_VEC3F;
+    }
+
+    /**
+     * @brief Per-axis voxel size from a grid's transform.
+     *
+     * SCALE_TRANSLATE — what add_grid writes — carries independent per-axis
+     * values directly. AFFINE, which no MayaFlux-written file uses, falls
+     * back to the matrix diagonal: exact for an axis-aligned scale, wrong
+     * for a sheared or rotated one, which this reader does not attempt to
+     * represent.
+     */
+    glm::vec3 grid_voxel_size(const tvdb_transform_t& t)
+    {
+        switch (t.type) {
+        case TVDB_TRANSFORM_UNIFORM_SCALE:
+        case TVDB_TRANSFORM_UNIFORM_SCALE_TRANSLATE:
+            return glm::vec3(static_cast<float>(t.voxel_size[0]));
+        case TVDB_TRANSFORM_SCALE:
+        case TVDB_TRANSFORM_SCALE_TRANSLATE:
+            return {
+                static_cast<float>(t.voxel_size[0]),
+                static_cast<float>(t.voxel_size[1]),
+                static_cast<float>(t.voxel_size[2]),
+            };
+        case TVDB_TRANSFORM_AFFINE:
+            return {
+                static_cast<float>(t.matrix[0][0]),
+                static_cast<float>(t.matrix[1][1]),
+                static_cast<float>(t.matrix[2][2]),
+            };
+        case TVDB_TRANSFORM_TRANSLATION:
+        default:
+            return glm::vec3(1.0F);
+        }
+    }
+
+    /**
+     * @brief World-space translation from a grid's transform.
+     *
+     * AFFINE's translation is read from the last row, matching the
+     * row-major layout tvdb_transform_t documents; a column-major foreign
+     * writer would need this flipped, which is not detectable from the
+     * struct alone.
+     */
+    glm::vec3 grid_translation(const tvdb_transform_t& t)
+    {
+        switch (t.type) {
+        case TVDB_TRANSFORM_UNIFORM_SCALE_TRANSLATE:
+        case TVDB_TRANSFORM_SCALE_TRANSLATE:
+        case TVDB_TRANSFORM_TRANSLATION:
+            return {
+                static_cast<float>(t.translation[0]),
+                static_cast<float>(t.translation[1]),
+                static_cast<float>(t.translation[2]),
+            };
+        case TVDB_TRANSFORM_AFFINE:
+            return {
+                static_cast<float>(t.matrix[3][0]),
+                static_cast<float>(t.matrix[3][1]),
+                static_cast<float>(t.matrix[3][2]),
+            };
+        default:
+            return glm::vec3(0.0F);
+        }
+    }
+
+    /**
+     * @brief IEEE 754 binary16 to binary32. tinyvdb decompresses on-disk half
+     *        storage transparently, so this path is defensive: it only fires
+     *        if a leaf's own declared value type is half, which no format
+     *        this reader has seen in practice produces.
+     */
+    float half_to_float(uint16_t h)
+    {
+        const uint32_t sign = static_cast<uint32_t>(h & 0x8000U) << 16;
+        uint32_t exp = (h >> 10) & 0x1FU;
+        uint32_t mant = h & 0x3FFU;
+        uint32_t bits {};
+
+        if (exp == 0) {
+            if (mant == 0) {
+                bits = sign;
+            } else {
+                exp = 1;
+                while ((mant & 0x400U) == 0) {
+                    mant <<= 1;
+                    --exp;
+                }
+                mant &= 0x3FFU;
+                bits = sign | ((exp + 112U) << 23) | (mant << 13);
+            }
+        } else if (exp == 0x1FU) {
+            bits = sign | 0x7F800000U | (mant << 13);
+        } else {
+            bits = sign | ((exp + 112U) << 23) | (mant << 13);
+        }
+
+        float f {};
+        std::memcpy(&f, &bits, sizeof(f));
+        return f;
+    }
+
+    float narrow_scalar(tvdb_value_type_t vt, const void* bytes)
+    {
+        switch (vt) {
+        case TVDB_VALUE_FLOAT: {
+            float v {};
+            std::memcpy(&v, bytes, sizeof(v));
+            return v;
+        }
+        case TVDB_VALUE_DOUBLE: {
+            double v = {};
+            std::memcpy(&v, bytes, sizeof(v));
+            return static_cast<float>(v);
+        }
+        case TVDB_VALUE_INT32: {
+            int32_t v {};
+            std::memcpy(&v, bytes, sizeof(v));
+            return static_cast<float>(v);
+        }
+        case TVDB_VALUE_INT64: {
+            int64_t v {};
+            std::memcpy(&v, bytes, sizeof(v));
+            return static_cast<float>(v);
+        }
+        case TVDB_VALUE_BOOL: {
+            uint8_t v {};
+            std::memcpy(&v, bytes, sizeof(v));
+            return v != 0 ? 1.0F : 0.0F;
+        }
+        case TVDB_VALUE_HALF: {
+            uint16_t v {};
+            std::memcpy(&v, bytes, sizeof(v));
+            return half_to_float(v);
+        }
+        default:
+            return 0.0F;
+        }
+    }
+
+    glm::vec3 narrow_vector(tvdb_value_type_t vt, const void* bytes)
+    {
+        switch (vt) {
+        case TVDB_VALUE_VEC3F: {
+            float v[3];
+            std::memcpy(v, bytes, sizeof(v));
+            return { v[0], v[1], v[2] };
+        }
+        case TVDB_VALUE_VEC3D: {
+            double v[3];
+            std::memcpy(v, bytes, sizeof(v));
+            return { static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]) };
+        }
+        case TVDB_VALUE_VEC3I: {
+            int32_t v[3];
+            std::memcpy(v, bytes, sizeof(v));
+            return { static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]) };
+        }
+        default:
+            return glm::vec3(0.0F);
+        }
+    }
+
+    /**
+     * @brief The root tile's background value, narrowed to float.
+     *
+     * Root index 0 is not a convention this reader invents: tinyvdb's own
+     * tvdb_grid_set_background writes through tree.nodes[0].u.root, so a
+     * well-formed grid always has its root there.
+     */
+    float grid_background_scalar(const tvdb_grid_t& grid)
+    {
+        if (grid.tree.num_nodes == 0) {
+            return 0.0F;
+        }
+        const tvdb_value_t& bg = grid.tree.nodes[0].u.root.background;
+        return narrow_scalar(bg.type, &bg.u);
+    }
+
+    glm::vec3 grid_background_vector(const tvdb_grid_t& grid)
+    {
+        if (grid.tree.num_nodes == 0) {
+            return glm::vec3(0.0F);
+        }
+        const tvdb_value_t& bg = grid.tree.nodes[0].u.root.background;
+        return narrow_vector(bg.type, &bg.u);
+    }
+
+    /**
+     * @brief Union of every leaf's voxel-index extent, tinyvdb's own
+     *        active-bbox definition, generalized past its float-only
+     *        tvdb_grid_active_bbox.
+     */
+    struct BBoxAcc {
+        glm::ivec3 min { 0 };
+        glm::ivec3 max { 0 };
+        bool has_any { false };
+    };
+
+    int bbox_visit(const tvdb_leaf_view_t* leaf, void* user)
+    {
+        auto* acc = static_cast<BBoxAcc*>(user);
+        const int32_t dim = 1 << leaf->log2dim;
+        const glm::ivec3 lo(leaf->origin[0], leaf->origin[1], leaf->origin[2]);
+        const glm::ivec3 hi = lo + glm::ivec3(dim);
+
+        if (!acc->has_any) {
+            acc->min = lo;
+            acc->max = hi;
+            acc->has_any = true;
+        } else {
+            acc->min = glm::min(acc->min, lo);
+            acc->max = glm::max(acc->max, hi);
+        }
+        return 0;
+    }
+
+    /**
+     * @brief Shared context for the dense-fill visitors.
+     *
+     * region_max is exclusive. elem_size is the leaf's own on-disk element
+     * width, used to stride into the raw byte buffer regardless of what
+     * that element narrows to.
+     */
+    struct DenseCtx {
+        glm::ivec3 region_min;
+        glm::ivec3 region_max;
+        tvdb_value_type_t vt;
+        size_t elem_size;
+    };
+
+    struct DenseScalarCtx : DenseCtx {
+        std::vector<float>* out;
+    };
+
+    struct DenseVectorCtx : DenseCtx {
+        std::vector<glm::vec3>* out;
+    };
+
+    /**
+     * @brief World-voxel coordinate of leaf slot s, OpenVDB's own
+     *        (x<<2L)|(y<<L)|z packing within a dim^3 block.
+     */
+    glm::ivec3 leaf_slot_coord(const tvdb_leaf_view_t& leaf, int32_t s)
+    {
+        const int32_t log2dim = leaf.log2dim;
+        const int32_t mask = (1 << log2dim) - 1;
+        return {
+            leaf.origin[0] + ((s >> (2 * log2dim)) & mask),
+            leaf.origin[1] + ((s >> log2dim) & mask),
+            leaf.origin[2] + (s & mask),
+        };
+    }
+
+    int dense_scalar_visit(const tvdb_leaf_view_t* leaf, void* user)
+    {
+        auto* ctx = static_cast<DenseScalarCtx*>(user);
+        const int32_t nslots = 1 << (3 * leaf->log2dim);
+        const auto* base = reinterpret_cast<const uint8_t*>(leaf->data);
+        const glm::ivec3 res = ctx->region_max - ctx->region_min;
+
+        for (int32_t s = 0; s < nslots; ++s) {
+            if (!tvdb_nodemask_is_on(leaf->value_mask, s)) {
+                continue;
+            }
+            const glm::ivec3 world = leaf_slot_coord(*leaf, s);
+            if (glm::any(glm::lessThan(world, ctx->region_min))
+                || glm::any(glm::greaterThanEqual(world, ctx->region_max))) {
+                continue;
+            }
+            const glm::ivec3 local = world - ctx->region_min;
+            const size_t index = (static_cast<size_t>(local.z) * res.y + local.y) * res.x + local.x;
+            (*ctx->out)[index] = narrow_scalar(ctx->vt, base + static_cast<size_t>(s) * ctx->elem_size);
+        }
+        return 0;
+    }
+
+    int dense_vector_visit(const tvdb_leaf_view_t* leaf, void* user)
+    {
+        auto* ctx = static_cast<DenseVectorCtx*>(user);
+        const int32_t nslots = 1 << (3 * leaf->log2dim);
+        const auto* base = reinterpret_cast<const uint8_t*>(leaf->data);
+        const glm::ivec3 res = ctx->region_max - ctx->region_min;
+
+        for (int32_t s = 0; s < nslots; ++s) {
+            if (!tvdb_nodemask_is_on(leaf->value_mask, s)) {
+                continue;
+            }
+            const glm::ivec3 world = leaf_slot_coord(*leaf, s);
+            if (glm::any(glm::lessThan(world, ctx->region_min))
+                || glm::any(glm::greaterThanEqual(world, ctx->region_max))) {
+                continue;
+            }
+            const glm::ivec3 local = world - ctx->region_min;
+            const size_t index = (static_cast<size_t>(local.z) * res.y + local.y) * res.x + local.x;
+            (*ctx->out)[index] = narrow_vector(ctx->vt, base + static_cast<size_t>(s) * ctx->elem_size);
+        }
+        return 0;
+    }
+
     constexpr size_t element_width(bool is_vector)
     {
         return is_vector ? sizeof(glm::vec3) : sizeof(float);
@@ -118,12 +442,20 @@ namespace {
  * Deques rather than vectors: entry arrays hold pointers into the string
  * storage, and grids hold pointers into the entry storage, so neither may
  * reallocate as more grids are added.
+ *
+ * read_file/read_file_open are the read path's entire state: open() parses
+ * a file into read_file and every accessor below indexes into it directly.
+ * Independent of the write-side members above — an instance may open() for
+ * reading without ever having called add_grid.
  */
 struct VDBArchive::State {
     std::vector<tvdb_grid_t> grids;
     std::deque<std::string> strings;
     std::deque<std::vector<tvdb_meta_entry_t>> entries;
     std::deque<std::array<char, 32>> type_tokens;
+
+    tvdb_file_t read_file {};
+    bool read_file_open { false };
 };
 
 VDBArchive::VDBArchive()
@@ -138,6 +470,10 @@ VDBArchive::~VDBArchive()
         grid.metadata.count = 0;
         grid.metadata.capacity = 0;
         tvdb_grid_destroy_owned(&grid);
+    }
+
+    if (m_state->read_file_open) {
+        tvdb_file_close(&m_state->read_file);
     }
 }
 
@@ -246,6 +582,182 @@ bool VDBArchive::save(const std::string& path, uint32_t compression, int level)
         return false;
     }
 
+    return true;
+}
+
+// =============================================================================
+// Read path
+// =============================================================================
+
+bool VDBArchive::open(const std::string& path)
+{
+    if (m_state->read_file_open) {
+        tvdb_file_close(&m_state->read_file);
+        m_state->read_file_open = false;
+    }
+
+    tvdb_error_t err;
+    std::memset(&err, 0, sizeof(err));
+
+    if (tvdb_file_open(&m_state->read_file, path.c_str(), nullptr, &err) != TVDB_OK) {
+        m_last_error = std::string("open failed: ")
+            + (err.message[0] != '\0' ? err.message : "unknown");
+        return false;
+    }
+    m_state->read_file_open = true;
+
+    if (tvdb_read_all_grids(&m_state->read_file, &err) != TVDB_OK) {
+        m_last_error = std::string("grid read failed: ")
+            + (err.message[0] != '\0' ? err.message : "unknown");
+        tvdb_file_close(&m_state->read_file);
+        m_state->read_file_open = false;
+        return false;
+    }
+
+    return true;
+}
+
+size_t VDBArchive::read_grid_count() const
+{
+    return m_state->read_file_open ? tvdb_grid_count(&m_state->read_file) : 0;
+}
+
+VDBGridSummary VDBArchive::grid_summary(size_t index) const
+{
+    VDBGridSummary out;
+
+    if (!m_state->read_file_open || index >= m_state->read_file.num_grids) {
+        return out;
+    }
+
+    const tvdb_grid_t& grid = m_state->read_file.grids[index];
+
+    const char* name = tvdb_grid_name(&m_state->read_file, index);
+    out.name = name ? name : "";
+
+    const tvdb_value_type_t vt = leaf_value_type(grid);
+    out.is_vector = is_vector_type(vt);
+    out.narrowed = needs_narrowing(vt);
+
+    out.voxel_size = grid_voxel_size(grid.transform);
+    out.translation = grid_translation(grid.transform);
+
+    BBoxAcc acc;
+    tvdb_grid_visit_leaves(&grid, bbox_visit, &acc);
+    out.has_active = acc.has_any;
+    out.active_min = acc.min;
+    out.active_max = acc.max;
+
+    out.background_scalar = grid_background_scalar(grid);
+    out.background_vector = grid_background_vector(grid);
+
+    return out;
+}
+
+std::string VDBArchive::grid_metadata(size_t index, std::string_view key) const
+{
+    if (!m_state->read_file_open || index >= m_state->read_file.num_grids) {
+        return {};
+    }
+
+    const tvdb_grid_t& grid = m_state->read_file.grids[index];
+
+    for (size_t i = 0; i < grid.metadata.count; ++i) {
+        const tvdb_meta_entry_t& entry = grid.metadata.entries[i];
+        if (!entry.name || key != entry.name) {
+            continue;
+        }
+        if (entry.value.type != TVDB_VALUE_STRING || !entry.value.u.s.str) {
+            return {};
+        }
+        return { entry.value.u.s.str, entry.value.u.s.len };
+    }
+    return {};
+}
+
+bool VDBArchive::read_dense_scalar(
+    size_t index,
+    const glm::ivec3& region_min,
+    const glm::uvec3& resolution,
+    float background,
+    std::vector<float>& out) const
+{
+    if (!m_state->read_file_open || index >= m_state->read_file.num_grids) {
+        m_last_error = "read_dense_scalar: grid index out of range";
+        return false;
+    }
+    if (resolution.x == 0 || resolution.y == 0 || resolution.z == 0) {
+        m_last_error = "read_dense_scalar: zero resolution";
+        return false;
+    }
+
+    const tvdb_grid_t& grid = m_state->read_file.grids[index];
+    const tvdb_value_type_t vt = leaf_value_type(grid);
+
+    if (is_vector_type(vt)) {
+        const char* name = tvdb_grid_name(&m_state->read_file, index);
+        m_last_error = "read_dense_scalar: grid '" + std::string(name ? name : "") + "' is vector-typed";
+        return false;
+    }
+    const size_t elem_size = tvdb_value_type_size(vt);
+    if (elem_size == 0) {
+        m_last_error = "read_dense_scalar: grid has an unsupported leaf value type";
+        return false;
+    }
+
+    out.assign(static_cast<size_t>(resolution.x) * resolution.y * resolution.z, background);
+
+    DenseScalarCtx ctx {};
+    ctx.region_min = region_min;
+    ctx.region_max = region_min + glm::ivec3(resolution);
+    ctx.vt = vt;
+    ctx.elem_size = elem_size;
+    ctx.out = &out;
+
+    tvdb_grid_visit_leaves(&grid, dense_scalar_visit, &ctx);
+    return true;
+}
+
+bool VDBArchive::read_dense_vector(
+    size_t index,
+    const glm::ivec3& region_min,
+    const glm::uvec3& resolution,
+    const glm::vec3& background,
+    std::vector<glm::vec3>& out) const
+{
+    if (!m_state->read_file_open || index >= m_state->read_file.num_grids) {
+        m_last_error = "read_dense_vector: grid index out of range";
+        return false;
+    }
+    if (resolution.x == 0 || resolution.y == 0 || resolution.z == 0) {
+        m_last_error = "read_dense_vector: zero resolution";
+        return false;
+    }
+
+    const tvdb_grid_t& grid = m_state->read_file.grids[index];
+    const tvdb_value_type_t vt = leaf_value_type(grid);
+
+    if (!is_vector_type(vt)) {
+        const char* name = tvdb_grid_name(&m_state->read_file, index);
+        m_last_error = "read_dense_vector: grid '" + std::string(name ? name : "") + "' is scalar-typed";
+        return false;
+    }
+    const size_t elem_size = tvdb_value_type_size(vt);
+    if (elem_size == 0) {
+        m_last_error = "read_dense_vector: grid has an unsupported leaf value type";
+        return false;
+    }
+
+    out.assign(static_cast<size_t>(resolution.x) * resolution.y * resolution.z, background);
+
+    DenseVectorCtx ctx {};
+    ctx.region_min = region_min;
+    ctx.region_max = region_min + glm::ivec3(resolution);
+    ctx.vt = vt;
+    ctx.elem_size = elem_size;
+    ctx.out = &out;
+
+    tvdb_grid_visit_leaves(&grid, dense_vector_visit, &ctx);
     return true;
 }
 

--- a/src/MayaFlux/IO/VDBArchive.hpp
+++ b/src/MayaFlux/IO/VDBArchive.hpp
@@ -30,21 +30,66 @@ struct VDBGridSpec {
 };
 
 /**
+ * @struct VDBGridSummary
+ * @brief What a reader needs to know about one grid in an opened file,
+ *        before deciding how to materialize it.
+ *
+ * voxel_size and translation come from the grid's own transform, read
+ * per-axis for SCALE_TRANSLATE (what VDBArchive::add_grid writes) and
+ * approximated for the rarer transform kinds a foreign file may carry — see
+ * the .cpp for the per-type fallback. active_min/active_max are the voxel-
+ * index bounding box of every leaf the tree holds, max exclusive, matching
+ * tinyvdb's own tvdb_grid_active_bbox convention. has_active is false, and
+ * the bbox members are unset, for a grid with no leaves at all.
+ *
+ * narrowed is true when the grid's leaf value type is something other than
+ * float (scalar) or vec3f (vector) — double, int32, int64, bool, vec3d,
+ * vec3i, or half — meaning VDBArchive::read_dense_scalar/read_dense_vector
+ * will convert every value to the representable type rather than reject it.
+ *
+ * background_scalar/background_vector are the root tile's fill value,
+ * narrowed the same way leaf values are. Only the one matching is_vector is
+ * meaningful; the other holds its default. This is the value every cell
+ * outside the tree takes — pass it to read_dense_scalar/read_dense_vector
+ * as the background argument to reproduce that.
+ */
+struct VDBGridSummary {
+    std::string name;
+    bool is_vector { false };
+    bool narrowed { false };
+    glm::vec3 voxel_size { 1.0F };
+    glm::vec3 translation { 0.0F };
+    bool has_active { false };
+    glm::ivec3 active_min { 0 };
+    glm::ivec3 active_max { 0 }; ///< Exclusive.
+    float background_scalar { 0.0F };
+    glm::vec3 background_vector { 0.0F };
+};
+
+/**
  * @class VDBArchive
- * @brief RAII boundary around tinyvdb's C write path.
+ * @brief RAII boundary around tinyvdb's C read and write paths.
  *
  * Every tvdb_ symbol, every manual allocation and every C-interop lint
  * suppression in MayaFlux lives behind this class. Nothing above it includes
  * a tinyvdb header, so a future change of backing library touches one
  * translation unit.
  *
- * Grids accumulate through add_grid and are written together by a single
- * save, producing one .vdb carrying every field as a separately named grid.
- * The destructor releases whatever was built regardless of whether save ran,
- * so an abandoned archive and a failed one clean up identically.
+ * Write path: grids accumulate through add_grid and are written together by
+ * a single save, producing one .vdb carrying every field as a separately
+ * named grid. The destructor releases whatever was built regardless of
+ * whether save ran, so an abandoned archive and a failed one clean up
+ * identically.
+ *
+ * Read path: open() parses a file and reads every grid's tree into memory.
+ * grid_summary(), grid_metadata() and read_dense_scalar/read_dense_vector
+ * then address grids by index, in file order. An instance used for reading
+ * is not also used for writing; the two paths share the class only because
+ * they share the C boundary they hide.
  *
  * Not copyable and not movable: the underlying file struct holds a pointer
- * into this object's own grid storage.
+ * into this object's own grid storage on the write side, and open() leaves
+ * live pointers into mapped file data on the read side.
  */
 class VDBArchive {
 public:
@@ -82,10 +127,83 @@ public:
     [[nodiscard]] size_t grid_count() const;
     [[nodiscard]] std::string_view last_error() const { return m_last_error; }
 
+    /**
+     * @brief Open a .vdb and read every grid's tree into memory.
+     *
+     * Replaces whatever a previous open() on this instance had loaded.
+     * Does not touch the write-side grid accumulation, so an instance is
+     * safe to open for reading even if add_grid was never called — the two
+     * are independent state.
+     *
+     * @param path Source path, already resolved by the caller.
+     * @return False on failure; call last_error() for detail.
+     */
+    bool open(const std::string& path);
+
+    /** @brief Number of grids in the opened file, or 0 if none is open. */
+    [[nodiscard]] size_t read_grid_count() const;
+
+    /**
+     * @brief Summarize one grid: name, value kind, transform, active bounds.
+     * @param index Grid index, less than read_grid_count().
+     * @return The summary, or a default-constructed one if index is out of
+     *         range or nothing is open.
+     */
+    [[nodiscard]] VDBGridSummary grid_summary(size_t index) const;
+
+    /**
+     * @brief Look up a string-typed metadata entry on a grid.
+     * @param index Grid index, less than read_grid_count().
+     * @param key   Metadata key, such as "class" or "vector_type".
+     * @return The value, or empty if absent, not a string, or index is out
+     *         of range.
+     */
+    [[nodiscard]] std::string grid_metadata(size_t index, std::string_view key) const;
+
+    /**
+     * @brief Materialize a scalar grid's cells over an explicit region.
+     *
+     * region_min and resolution are expressed in the grid's own voxel-index
+     * space — the same space active_min/active_max in grid_summary() use.
+     * A cell not covered by any active leaf, and a cell whose index falls
+     * outside the region entirely, both take @p background. Output is
+     * resized to resolution.x*y*z elements and written x-fastest,
+     * z-slowest, matching Lattice3D and VolumeField's convention.
+     *
+     * A grid whose leaf value type is not float is converted per-element;
+     * check grid_summary().narrowed beforehand to know whether that
+     * happened.
+     *
+     * @return False if index is out of range, the grid is vector-typed, or
+     *         resolution has a zero axis. Call last_error() for detail.
+     */
+    bool read_dense_scalar(
+        size_t index,
+        const glm::ivec3& region_min,
+        const glm::uvec3& resolution,
+        float background,
+        std::vector<float>& out) const;
+
+    /**
+     * @brief Materialize a vector grid's cells over an explicit region.
+     *
+     * As read_dense_scalar, for a grid whose leaf value type is vec3f,
+     * vec3d or vec3i. Non-vec3f types are converted component-wise.
+     *
+     * @return False if index is out of range, the grid is scalar-typed, or
+     *         resolution has a zero axis. Call last_error() for detail.
+     */
+    bool read_dense_vector(
+        size_t index,
+        const glm::ivec3& region_min,
+        const glm::uvec3& resolution,
+        const glm::vec3& background,
+        std::vector<glm::vec3>& out) const;
+
 private:
     struct State;
     std::unique_ptr<State> m_state;
-    std::string m_last_error;
+    mutable std::string m_last_error; ///< Set from the const read-path accessors too.
 };
 
 /**

--- a/src/MayaFlux/IO/VDBArchive.hpp
+++ b/src/MayaFlux/IO/VDBArchive.hpp
@@ -170,10 +170,18 @@ public:
      * resized to resolution.x*y*z elements and written x-fastest,
      * z-slowest, matching Lattice3D and VolumeField's convention.
      *
-     * A grid whose leaf value type is not float is converted per-element;
-     * check grid_summary().narrowed beforehand to know whether that
-     * happened.
+     * A grid whose leaf value type is not float is converted per-element via
+     * MayaFlux::try_convert; check grid_summary().narrowed beforehand to
+     * know whether that happened at all, or pass @p precision_lost to learn
+     * whether it happened losslessly. Every element that round-trips through
+     * float and back to the source type unchanged leaves it false; a single
+     * element that doesn't sets it true for the whole call. half is the one
+     * source type never marked lossy — float has strictly more precision in
+     * both exponent and mantissa, so widening it is always exact.
      *
+     * @param precision_lost Set to whether any narrowed element lost
+     *        precision. Cleared to false at the start of the call if
+     *        non-null; left untouched by a null pointer.
      * @return False if index is out of range, the grid is vector-typed, or
      *         resolution has a zero axis. Call last_error() for detail.
      */
@@ -182,13 +190,16 @@ public:
         const glm::ivec3& region_min,
         const glm::uvec3& resolution,
         float background,
-        std::vector<float>& out) const;
+        std::vector<float>& out,
+        bool* precision_lost = nullptr) const;
 
     /**
      * @brief Materialize a vector grid's cells over an explicit region.
      *
      * As read_dense_scalar, for a grid whose leaf value type is vec3f,
-     * vec3d or vec3i. Non-vec3f types are converted component-wise.
+     * vec3d or vec3i. Non-vec3f types are converted component-wise via
+     * MayaFlux::try_convert; @p precision_lost is set if any of the three
+     * components of any element lost precision.
      *
      * @return False if index is out of range, the grid is scalar-typed, or
      *         resolution has a zero axis. Call last_error() for detail.
@@ -198,7 +209,8 @@ public:
         const glm::ivec3& region_min,
         const glm::uvec3& resolution,
         const glm::vec3& background,
-        std::vector<glm::vec3>& out) const;
+        std::vector<glm::vec3>& out,
+        bool* precision_lost = nullptr) const;
 
 private:
     struct State;

--- a/src/MayaFlux/IO/VolumeReader.cpp
+++ b/src/MayaFlux/IO/VolumeReader.cpp
@@ -234,6 +234,26 @@ std::optional<Kakshya::VolumeData> VolumeReader::materialize(
     const glm::ivec3& region_min,
     const Kinesis::Lattice3D& lattice) const
 {
+    constexpr float k_transform_epsilon = 1e-5F;
+
+    const auto reference = m_archive->grid_summary(indices.front());
+    for (size_t idx : indices) {
+        if (idx == indices.front()) {
+            continue;
+        }
+        const auto summary = m_archive->grid_summary(idx);
+        const bool mismatched = glm::any(glm::greaterThan(
+                                     glm::abs(summary.voxel_size - reference.voxel_size), glm::vec3(k_transform_epsilon)))
+            || glm::any(glm::greaterThan(
+                glm::abs(summary.translation - reference.translation), glm::vec3(k_transform_epsilon)));
+        if (mismatched) {
+            MF_WARN(Journal::Component::IO, Journal::Context::FileIO,
+                "VolumeReader: grid '{}' has a different voxel size or translation than '{}', "
+                "its voxel indices are read directly against the shared region and will not be aligned",
+                summary.name, reference.name);
+        }
+    }
+
     Kakshya::VolumeData result;
     result.lattice = lattice;
     result.fields.reserve(indices.size());

--- a/src/MayaFlux/IO/VolumeReader.cpp
+++ b/src/MayaFlux/IO/VolumeReader.cpp
@@ -1,0 +1,368 @@
+#include "VolumeReader.hpp"
+
+#include "VDBArchive.hpp"
+
+#include "MayaFlux/Journal/Archivist.hpp"
+
+namespace MayaFlux::IO {
+
+namespace {
+
+    std::string extension_of(const std::string& filepath)
+    {
+        auto ext = std::filesystem::path(filepath).extension().string();
+        if (!ext.empty() && ext[0] == '.') {
+            ext = ext.substr(1);
+        }
+        std::ranges::transform(ext, ext.begin(),
+            [](unsigned char c) { return std::tolower(c); });
+        return ext;
+    }
+
+    /**
+     * @brief Resolve field_names to grid indices, in file order when empty
+     *        or in requested order otherwise.
+     *
+     * A requested name with no matching grid is logged and dropped; the
+     * rest of the selection proceeds, matching how a name that is present
+     * in field_names but absent from the data is handled elsewhere in IO.
+     */
+    std::vector<size_t> select_indices(
+        const Detail::VDBArchive& archive,
+        size_t count,
+        const std::vector<std::string>& field_names)
+    {
+        std::vector<size_t> indices;
+
+        if (field_names.empty()) {
+            indices.reserve(count);
+            for (size_t i = 0; i < count; ++i) {
+                indices.push_back(i);
+            }
+            return indices;
+        }
+
+        indices.reserve(field_names.size());
+        for (const auto& name : field_names) {
+            bool found = false;
+            for (size_t i = 0; i < count; ++i) {
+                if (archive.grid_summary(i).name == name) {
+                    indices.push_back(i);
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                MF_WARN(Journal::Component::IO, Journal::Context::FileIO,
+                    "VolumeReader: no grid named '{}', skipped", name);
+            }
+        }
+        return indices;
+    }
+
+    /**
+     * @brief Inverse of VDBWriter's class_token: metadata string to enum.
+     */
+    Kinesis::LatticeValueClass class_from_token(std::string_view token)
+    {
+        using C = Kinesis::LatticeValueClass;
+        if (token == "level set") {
+            return C::LevelSet;
+        }
+        if (token == "fog volume") {
+            return C::FogVolume;
+        }
+        if (token == "staggered") {
+            return C::Staggered;
+        }
+        return C::Unknown;
+    }
+
+    /**
+     * @brief Inverse of VDBWriter's variance_token: metadata string to enum.
+     */
+    Kinesis::VectorVariance variance_from_token(std::string_view token)
+    {
+        using V = Kinesis::VectorVariance;
+        if (token == "covariant") {
+            return V::Covariant;
+        }
+        if (token == "covariant normalize") {
+            return V::CovariantNormalize;
+        }
+        if (token == "contravariant relative") {
+            return V::ContravariantRelative;
+        }
+        if (token == "contravariant absolute") {
+            return V::ContravariantAbsolute;
+        }
+        return V::Invariant;
+    }
+
+} // namespace
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+VolumeReader::VolumeReader()
+    : m_archive(std::make_unique<Detail::VDBArchive>())
+{
+}
+
+VolumeReader::~VolumeReader()
+{
+    close();
+}
+
+// =============================================================================
+// Primary API
+// =============================================================================
+
+std::optional<Kakshya::VolumeData> VolumeReader::load(
+    const std::string& filepath, const VolumeReadOptions& options)
+{
+    if (!open(filepath)) {
+        return std::nullopt;
+    }
+    auto result = extract(options);
+    close();
+    return result;
+}
+
+std::optional<Kakshya::VolumeData> VolumeReader::load(
+    const std::string& filepath,
+    const Kinesis::Lattice3D& lattice,
+    const VolumeReadOptions& options)
+{
+    if (!open(filepath)) {
+        return std::nullopt;
+    }
+    auto result = extract(lattice, options);
+    close();
+    return result;
+}
+
+std::optional<Kakshya::VolumeData> VolumeReader::extract(
+    const VolumeReadOptions& options) const
+{
+    if (!m_is_open) {
+        set_error("No file open");
+        return std::nullopt;
+    }
+
+    const size_t count = m_archive->read_grid_count();
+    if (count == 0) {
+        set_error("No grids in file");
+        return std::nullopt;
+    }
+
+    const auto indices = select_indices(*m_archive, count, options.field_names);
+    if (indices.empty()) {
+        set_error("No matching grids");
+        return std::nullopt;
+    }
+
+    glm::ivec3 union_min { 0 };
+    glm::ivec3 union_max { 0 };
+    bool have_any = false;
+
+    for (size_t idx : indices) {
+        const auto summary = m_archive->grid_summary(idx);
+        if (!summary.has_active) {
+            continue;
+        }
+        if (!have_any) {
+            union_min = summary.active_min;
+            union_max = summary.active_max;
+            have_any = true;
+        } else {
+            union_min = glm::min(union_min, summary.active_min);
+            union_max = glm::max(union_max, summary.active_max);
+        }
+    }
+
+    if (!have_any) {
+        set_error("Selected grids have no active voxels");
+        return std::nullopt;
+    }
+
+    const auto first = m_archive->grid_summary(indices.front());
+
+    Kinesis::Lattice3D lattice;
+    lattice.resolution = glm::uvec3(union_max - union_min);
+    lattice.bounds.min = first.translation + first.voxel_size * (glm::vec3(union_min) - 0.5F);
+    lattice.bounds.max = first.translation + first.voxel_size * (glm::vec3(union_max) - 0.5F);
+
+    return materialize(indices, union_min, lattice);
+}
+
+std::optional<Kakshya::VolumeData> VolumeReader::extract(
+    const Kinesis::Lattice3D& lattice, const VolumeReadOptions& options) const
+{
+    if (!m_is_open) {
+        set_error("No file open");
+        return std::nullopt;
+    }
+
+    const size_t count = m_archive->read_grid_count();
+    if (count == 0) {
+        set_error("No grids in file");
+        return std::nullopt;
+    }
+
+    const auto indices = select_indices(*m_archive, count, options.field_names);
+    if (indices.empty()) {
+        set_error("No matching grids");
+        return std::nullopt;
+    }
+
+    const auto first = m_archive->grid_summary(indices.front());
+    if (glm::any(glm::lessThanEqual(first.voxel_size, glm::vec3(0.0F)))) {
+        set_error("First selected grid has a degenerate voxel size");
+        return std::nullopt;
+    }
+
+    const glm::vec3 region_min_f = (lattice.bounds.min - first.translation) / first.voxel_size + glm::vec3(0.5F);
+    const glm::ivec3 region_min = glm::ivec3(glm::round(region_min_f));
+
+    return materialize(indices, region_min, lattice);
+}
+
+std::optional<Kakshya::VolumeData> VolumeReader::materialize(
+    const std::vector<size_t>& indices,
+    const glm::ivec3& region_min,
+    const Kinesis::Lattice3D& lattice) const
+{
+    Kakshya::VolumeData result;
+    result.lattice = lattice;
+    result.fields.reserve(indices.size());
+
+    for (size_t idx : indices) {
+        const auto summary = m_archive->grid_summary(idx);
+
+        if (summary.narrowed) {
+            MF_WARN(Journal::Component::IO, Journal::Context::FileIO,
+                "VolumeReader: grid '{}' is not float/vec3f, narrowing to {}",
+                summary.name, summary.is_vector ? "vec3" : "float");
+        }
+
+        Kakshya::VolumeField field;
+        field.name = summary.name;
+        field.semantics.value_class = class_from_token(m_archive->grid_metadata(idx, "class"));
+
+        if (summary.is_vector) {
+            field.semantics.variance = variance_from_token(m_archive->grid_metadata(idx, "vector_type"));
+
+            std::vector<glm::vec3> values;
+            if (!m_archive->read_dense_vector(
+                    idx, region_min, lattice.resolution, summary.background_vector, values)) {
+                set_error(std::string(m_archive->last_error()));
+                return std::nullopt;
+            }
+            field.values = std::move(values);
+        } else {
+            std::vector<float> values;
+            if (!m_archive->read_dense_scalar(
+                    idx, region_min, lattice.resolution, summary.background_scalar, values)) {
+                set_error(std::string(m_archive->last_error()));
+                return std::nullopt;
+            }
+            field.values = std::move(values);
+        }
+
+        MF_DEBUG(Journal::Component::IO, Journal::Context::FileIO,
+            "VolumeReader: materialized '{}', {} cells", field.name, field.element_count());
+
+        result.fields.push_back(std::move(field));
+    }
+
+    if (result.fields.empty()) {
+        set_error("No fields materialized");
+        return std::nullopt;
+    }
+
+    if (!result.is_consistent()) {
+        set_error("Resulting VolumeData failed is_consistent()");
+        return std::nullopt;
+    }
+
+    return result;
+}
+
+// =============================================================================
+// FileReader interface
+// =============================================================================
+
+bool VolumeReader::can_read(const std::string& filepath) const
+{
+    return extension_of(filepath) == "vdb";
+}
+
+bool VolumeReader::open(const std::string& filepath, FileReadOptions /*options*/)
+{
+    close();
+
+    if (!can_read(filepath)) {
+        set_error("Unsupported volume format: " + filepath);
+        MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+            "VolumeReader: {}", m_last_error);
+        return false;
+    }
+
+    const auto resolved = resolve_path(filepath);
+
+    if (!m_archive->open(resolved)) {
+        set_error(std::string(m_archive->last_error()));
+        MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+            "VolumeReader: open failed for '{}' — {}", filepath, m_last_error);
+        return false;
+    }
+
+    m_filepath = filepath;
+    m_is_open = true;
+
+    MF_INFO(Journal::Component::IO, Journal::Context::FileIO,
+        "VolumeReader: opened '{}' — {} grid(s)",
+        std::filesystem::path(resolved).filename().string(),
+        m_archive->read_grid_count());
+
+    return true;
+}
+
+void VolumeReader::close()
+{
+    if (m_is_open) {
+        m_archive = std::make_unique<Detail::VDBArchive>();
+        m_filepath.clear();
+        m_is_open = false;
+    }
+}
+
+std::optional<FileMetadata> VolumeReader::get_metadata() const
+{
+    if (!m_is_open) {
+        return std::nullopt;
+    }
+
+    FileMetadata meta;
+    meta.format = "vdb";
+    meta.attributes["grid_count"] = static_cast<uint64_t>(m_archive->read_grid_count());
+
+    return meta;
+}
+
+std::shared_ptr<Kakshya::SignalSourceContainer> VolumeReader::create_container()
+{
+    m_last_error = "Volume data does not use SignalSourceContainer. Use load() instead.";
+    return nullptr;
+}
+
+bool VolumeReader::load_into_container(
+    std::shared_ptr<Kakshya::SignalSourceContainer> /*container*/)
+{
+    m_last_error = "Volume data does not use SignalSourceContainer. Use load() instead.";
+    return false;
+}
+
+} // namespace MayaFlux::IO

--- a/src/MayaFlux/IO/VolumeReader.cpp
+++ b/src/MayaFlux/IO/VolumeReader.cpp
@@ -241,22 +241,18 @@ std::optional<Kakshya::VolumeData> VolumeReader::materialize(
     for (size_t idx : indices) {
         const auto summary = m_archive->grid_summary(idx);
 
-        if (summary.narrowed) {
-            MF_WARN(Journal::Component::IO, Journal::Context::FileIO,
-                "VolumeReader: grid '{}' is not float/vec3f, narrowing to {}",
-                summary.name, summary.is_vector ? "vec3" : "float");
-        }
-
         Kakshya::VolumeField field;
         field.name = summary.name;
         field.semantics.value_class = class_from_token(m_archive->grid_metadata(idx, "class"));
+
+        bool precision_lost = false;
 
         if (summary.is_vector) {
             field.semantics.variance = variance_from_token(m_archive->grid_metadata(idx, "vector_type"));
 
             std::vector<glm::vec3> values;
             if (!m_archive->read_dense_vector(
-                    idx, region_min, lattice.resolution, summary.background_vector, values)) {
+                    idx, region_min, lattice.resolution, summary.background_vector, values, &precision_lost)) {
                 set_error(std::string(m_archive->last_error()));
                 return std::nullopt;
             }
@@ -264,11 +260,21 @@ std::optional<Kakshya::VolumeData> VolumeReader::materialize(
         } else {
             std::vector<float> values;
             if (!m_archive->read_dense_scalar(
-                    idx, region_min, lattice.resolution, summary.background_scalar, values)) {
+                    idx, region_min, lattice.resolution, summary.background_scalar, values, &precision_lost)) {
                 set_error(std::string(m_archive->last_error()));
                 return std::nullopt;
             }
             field.values = std::move(values);
+        }
+
+        if (precision_lost) {
+            MF_WARN(Journal::Component::IO, Journal::Context::FileIO,
+                "VolumeReader: grid '{}' is not float/vec3f, narrowing to {} lost precision in at least one value",
+                summary.name, summary.is_vector ? "vec3" : "float");
+        } else if (summary.narrowed) {
+            MF_WARN(Journal::Component::IO, Journal::Context::FileIO,
+                "VolumeReader: grid '{}' is not float/vec3f, narrowing to {} losslessly",
+                summary.name, summary.is_vector ? "vec3" : "float");
         }
 
         MF_DEBUG(Journal::Component::IO, Journal::Context::FileIO,

--- a/src/MayaFlux/IO/VolumeReader.hpp
+++ b/src/MayaFlux/IO/VolumeReader.hpp
@@ -88,12 +88,15 @@ struct VolumeReadOptions {
  *
  * VolumeData's variant holds float and glm::vec3 only. A grid whose leaf
  * value type is double, int32, int64, bool or half is narrowed to float; a
- * vec3d or vec3i grid is narrowed to glm::vec3. This is logged once per
- * grid at MF_WARN. Narrowing is lossy for a double or int64 grid whose
- * range exceeds float precision, which is uncommon for a value meant to
- * feed a float GPU field — the purpose this reader is built for — and
- * accepted as the cost of a single representable type rather than widening
- * VolumeData to carry every tinyvdb value type.
+ * vec3d or vec3i grid is narrowed to glm::vec3, via MayaFlux::try_convert
+ * per element (per component, for vectors). This is logged once per grid
+ * at MF_WARN, distinguishing a narrowing that round-tripped every element
+ * exactly from one where at least one element actually lost precision —
+ * the common case for a double or int64 grid whose range exceeds float,
+ * uncommon for a value meant to feed a float GPU field in the first place,
+ * which is the purpose this reader is built for. Accepted as the cost of a
+ * single representable type rather than widening VolumeData to carry every
+ * tinyvdb value type.
  */
 class MAYAFLUX_API VolumeReader : public FileReader {
 public:

--- a/src/MayaFlux/IO/VolumeReader.hpp
+++ b/src/MayaFlux/IO/VolumeReader.hpp
@@ -1,0 +1,241 @@
+#pragma once
+
+#include "MayaFlux/IO/FileReader.hpp"
+#include "MayaFlux/Kakshya/NDData/VolumeData.hpp"
+
+namespace MayaFlux::IO::Detail {
+class VDBArchive;
+}
+
+namespace MayaFlux::IO {
+
+/**
+ * @struct VolumeReadOptions
+ * @brief Configuration for volume reading.
+ */
+struct VolumeReadOptions {
+    /**
+     * @brief Grids to load, matched by name. Empty loads every grid in the
+     *        file, in file order.
+     *
+     * A name with no matching grid is logged and skipped; the rest of the
+     * selection proceeds.
+     */
+    std::vector<std::string> field_names;
+};
+
+/**
+ * @class VolumeReader
+ * @brief tinyvdb-backed loader for volumetric grid files.
+ *
+ * Parallels ModelReader: a FileReader subclass whose primary API is
+ * open()+extract() or the one-shot load(), producing Kakshya::VolumeData —
+ * one lattice and every selected grid as a named VolumeField over it.
+ * create_container() and load_into_container() are no-ops, as for
+ * ModelReader; volume data does not go through the SignalSourceContainer
+ * streaming path.
+ *
+ * Supported formats: .vdb, via Detail::VDBArchive's read path.
+ *
+ * ## Lattice reconstruction
+ *
+ * A .vdb carries a transform and, per grid, an active-voxel bounding box —
+ * not a resolution and world bounds the way Lattice3D wants. VolumeData
+ * needs one lattice shared by every field, so this reader offers two ways
+ * to get one:
+ *
+ * - extract()/load() with no lattice: the output lattice is the union of
+ *   every selected grid's active bbox, in voxel-index space, with voxel
+ *   size and translation taken from the first selected grid's transform.
+ *   This is what a DCC user expects — the file's own content decides the
+ *   size — and is exact when every grid in the file shares one transform,
+ *   which every file MayaFlux writes does and most single-purpose exports
+ *   from another DCC do too.
+ * - extract()/load() with a caller-supplied Lattice3D: region_min is
+ *   derived from the lattice's world bounds through the *first selected
+ *   grid's* transform, snapped to the nearest voxel index — no
+ *   interpolation. This is the only path that round-trips exactly: pass
+ *   the same Lattice3D a VDBWriter call was given and the cell values come
+ *   back unpermuted and unresampled, which is what verify_volume_export's
+ *   round-trip check exercises.
+ *
+ * Both paths assume every selected grid shares the first grid's voxel size
+ * and translation. A file with per-grid transforms that actually differ is
+ * not resampled into agreement — each grid's raw voxel indices are read
+ * directly against the shared region, which silently misplaces that grid's
+ * content relative to the others. This is a real limitation for a file
+ * assembled by hand from mismatched sources; it is not a limitation for
+ * output produced by a single simulation or DCC export, which is what this
+ * reader exists to consume.
+ *
+ * ## Inactive cells
+ *
+ * VolumeData is dense: every cell in the output lattice that is not covered
+ * by an active leaf takes the grid's own background value (root.background
+ * in exchange), narrowed the same way an active cell's value is if the
+ * grid's own type needs it — see below. This means a sparse simulation
+ * export expands to full density in host memory: six fields at 256 cubed
+ * is roughly 400 MB, before whatever the caller does with it next. A tile
+ * whose inactive fill differs from the plain background — a level set's
+ * sign-flood-filled interior/exterior tiles are the standard example — is
+ * not reconstructed; every non-leaf cell reads as the one background value
+ * regardless of which side of the surface it is on. A foreign narrow-band
+ * level set is therefore the case most likely to come back wrong; a fog
+ * volume or a carried scalar, where every non-leaf cell genuinely is the
+ * background, round-trips correctly.
+ *
+ * ## Type narrowing
+ *
+ * VolumeData's variant holds float and glm::vec3 only. A grid whose leaf
+ * value type is double, int32, int64, bool or half is narrowed to float; a
+ * vec3d or vec3i grid is narrowed to glm::vec3. This is logged once per
+ * grid at MF_WARN. Narrowing is lossy for a double or int64 grid whose
+ * range exceeds float precision, which is uncommon for a value meant to
+ * feed a float GPU field — the purpose this reader is built for — and
+ * accepted as the cost of a single representable type rather than widening
+ * VolumeData to carry every tinyvdb value type.
+ */
+class MAYAFLUX_API VolumeReader : public FileReader {
+public:
+    VolumeReader();
+    ~VolumeReader() override;
+
+    // -------------------------------------------------------------------------
+    // Primary API — use these
+    // -------------------------------------------------------------------------
+
+    /**
+     * @brief Load every selected grid from a file in one call.
+     *
+     * Opens, reads, extracts and closes in a single synchronous operation.
+     * The output lattice is the union of active bboxes; see the class docs.
+     *
+     * @param filepath Path to the .vdb file.
+     * @param options  Grid selection.
+     * @return Populated VolumeData, or nullopt on failure; check
+     *         get_last_error().
+     */
+    [[nodiscard]] std::optional<Kakshya::VolumeData> load(
+        const std::string& filepath, const VolumeReadOptions& options = {});
+
+    /**
+     * @brief Load every selected grid onto a caller-supplied lattice.
+     *
+     * As load(), but the output lattice is @p lattice rather than derived
+     * from the file. The only path that round-trips a write exactly; see
+     * the class docs.
+     *
+     * @param filepath Path to the .vdb file.
+     * @param lattice  Output lattice. Its resolution and bounds are used
+     *                 as given; nothing about it is validated against the
+     *                 file's own transform.
+     * @param options  Grid selection.
+     * @return Populated VolumeData, or nullopt on failure; check
+     *         get_last_error().
+     */
+    [[nodiscard]] std::optional<Kakshya::VolumeData> load(
+        const std::string& filepath,
+        const Kinesis::Lattice3D& lattice,
+        const VolumeReadOptions& options = {});
+
+    /**
+     * @brief Extract every selected grid after open() has already been called.
+     *
+     * As load(), but reads the currently open file rather than opening one.
+     * Does not call close().
+     *
+     * @param options Grid selection.
+     * @return Populated VolumeData, or nullopt if no file is open or on
+     *         failure; check get_last_error().
+     */
+    [[nodiscard]] std::optional<Kakshya::VolumeData> extract(
+        const VolumeReadOptions& options = {}) const;
+
+    /**
+     * @brief Extract every selected grid onto a caller-supplied lattice.
+     * @param lattice Output lattice, as in the load() overload.
+     * @param options Grid selection.
+     * @return Populated VolumeData, or nullopt if no file is open or on
+     *         failure; check get_last_error().
+     */
+    [[nodiscard]] std::optional<Kakshya::VolumeData> extract(
+        const Kinesis::Lattice3D& lattice,
+        const VolumeReadOptions& options = {}) const;
+
+    // -------------------------------------------------------------------------
+    // FileReader interface
+    // -------------------------------------------------------------------------
+
+    [[nodiscard]] bool can_read(const std::string& filepath) const override;
+
+    bool open(const std::string& filepath,
+        FileReadOptions options = FileReadOptions::ALL) override;
+
+    void close() override;
+
+    [[nodiscard]] bool is_open() const override { return m_is_open; }
+
+    [[nodiscard]] std::optional<FileMetadata> get_metadata() const override;
+
+    [[nodiscard]] std::vector<FileRegion> get_regions() const override { return {}; }
+    std::vector<Kakshya::DataVariant> read_all() override { return {}; }
+    std::vector<Kakshya::DataVariant> read_region(const FileRegion& /*region*/) override { return {}; }
+
+    /**
+     * @brief No-op. Volume data does not use SignalSourceContainer.
+     * @return nullptr always.
+     */
+    std::shared_ptr<Kakshya::SignalSourceContainer> create_container() override;
+
+    /**
+     * @brief No-op. Volume data does not use SignalSourceContainer.
+     * @return false always.
+     */
+    bool load_into_container(
+        std::shared_ptr<Kakshya::SignalSourceContainer> container) override;
+
+    [[nodiscard]] std::vector<uint64_t> get_read_position() const override { return { 0 }; }
+    bool seek(const std::vector<uint64_t>& /*position*/) override { return true; }
+    [[nodiscard]] std::vector<std::string> get_supported_extensions() const override { return { ".vdb" }; }
+
+    [[nodiscard]] std::type_index get_data_type() const override
+    {
+        return typeid(std::vector<uint8_t>);
+    }
+
+    [[nodiscard]] std::type_index get_container_type() const override
+    {
+        return typeid(void);
+    }
+
+    [[nodiscard]] std::string get_last_error() const override { return m_last_error; }
+
+    [[nodiscard]] bool supports_streaming() const override { return false; }
+    [[nodiscard]] uint64_t get_preferred_chunk_size() const override { return 0; }
+    [[nodiscard]] size_t get_num_dimensions() const override { return 0; }
+    [[nodiscard]] std::vector<uint64_t> get_dimension_sizes() const override { return {}; }
+
+private:
+    std::unique_ptr<Detail::VDBArchive> m_archive;
+
+    bool m_is_open { false };
+    std::string m_filepath;
+    mutable std::string m_last_error;
+
+    /**
+     * @brief Build VolumeData from selected grids over an explicit region.
+     * @param indices    Grid indices, in the order fields should appear.
+     * @param region_min Voxel-index origin, in the first grid's index space.
+     * @param lattice    Output lattice. Its resolution drives every
+     *                   read_dense_scalar/read_dense_vector call.
+     * @return Populated VolumeData, or nullopt on failure.
+     */
+    [[nodiscard]] std::optional<Kakshya::VolumeData> materialize(
+        const std::vector<size_t>& indices,
+        const glm::ivec3& region_min,
+        const Kinesis::Lattice3D& lattice) const;
+
+    void set_error(std::string msg) const { m_last_error = std::move(msg); }
+};
+
+} // namespace MayaFlux::IO

--- a/src/MayaFlux/IO/VolumeReader.hpp
+++ b/src/MayaFlux/IO/VolumeReader.hpp
@@ -62,11 +62,15 @@ struct VolumeReadOptions {
  * Both paths assume every selected grid shares the first grid's voxel size
  * and translation. A file with per-grid transforms that actually differ is
  * not resampled into agreement — each grid's raw voxel indices are read
- * directly against the shared region, which silently misplaces that grid's
- * content relative to the others. This is a real limitation for a file
- * assembled by hand from mismatched sources; it is not a limitation for
- * output produced by a single simulation or DCC export, which is what this
- * reader exists to consume.
+ * directly against the shared region, which misplaces that grid's content
+ * relative to the others. materialize() logs an MF_WARN naming the
+ * mismatched grid so this is a loud failure rather than a silent one, but
+ * it does not correct it — actual per-grid resampling would need to
+ * materialize the mismatched grid separately in its own index space and
+ * interpolate into the shared lattice, which is not implemented. This is a
+ * real limitation for a file assembled by hand from mismatched sources; it
+ * is not a limitation for output produced by a single simulation or DCC
+ * export, which is what this reader exists to consume.
  *
  * ## Inactive cells
  *

--- a/src/MayaFlux/IO/VolumeTransfer.cpp
+++ b/src/MayaFlux/IO/VolumeTransfer.cpp
@@ -1,4 +1,4 @@
-#include "VolumeExport.hpp"
+#include "VolumeTransfer.hpp"
 
 #include "FileWriter.hpp"
 
@@ -115,6 +115,79 @@ std::optional<Kakshya::VolumeData> download_volume(
         result.lattice.resolution.z, result.fields.size(), names.size());
 
     return result;
+}
+
+// ============================================================================
+// upload_volume
+// ============================================================================
+
+bool upload_volume(
+    const Kakshya::VolumeData& data,
+    const std::shared_ptr<Buffers::VolumeGridBuffer>& volume)
+{
+    if (!volume) {
+        MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+            "upload_volume: null volume");
+        return false;
+    }
+
+    if (!data.is_consistent()) {
+        MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+            "upload_volume: VolumeData failed is_consistent()");
+        return false;
+    }
+
+    size_t uploaded = 0;
+
+    for (const auto& field : data.fields) {
+        if (!volume->has_field(field.name)) {
+            MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+                "upload_volume: no field named '{}' on this volume, skipped", field.name);
+            continue;
+        }
+
+        const size_t stride = volume->get_field_stride(field.name);
+
+        if (const auto* scalars = field.as_scalar()) {
+            if (stride != sizeof(float)) {
+                MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+                    "upload_volume: field '{}' has stride {}, but VolumeData holds a scalar "
+                    "(expected {}), skipped",
+                    field.name, stride, sizeof(float));
+                continue;
+            }
+            volume->seed_raw(field.name, scalars->data(), scalars->size() * sizeof(float));
+            ++uploaded;
+            continue;
+        }
+
+        const auto* vectors = field.as_vector();
+        if (stride != sizeof(glm::vec4)) {
+            MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+                "upload_volume: field '{}' has stride {}, but VolumeData holds a vector "
+                "(expected {}), skipped",
+                field.name, stride, sizeof(glm::vec4));
+            continue;
+        }
+
+        std::vector<glm::vec4> padded(vectors->size());
+        for (size_t i = 0; i < vectors->size(); ++i) {
+            padded[i] = glm::vec4((*vectors)[i], 0.0F);
+        }
+        volume->seed_raw(field.name, padded.data(), padded.size() * sizeof(glm::vec4));
+        ++uploaded;
+    }
+
+    if (uploaded == 0) {
+        MF_ERROR(Journal::Component::IO, Journal::Context::FileIO,
+            "upload_volume: no field was uploaded");
+        return false;
+    }
+
+    MF_DEBUG(Journal::Component::IO, Journal::Context::FileIO,
+        "upload_volume: {} of {} fields", uploaded, data.fields.size());
+
+    return true;
 }
 
 // ============================================================================

--- a/src/MayaFlux/IO/VolumeTransfer.hpp
+++ b/src/MayaFlux/IO/VolumeTransfer.hpp
@@ -41,6 +41,43 @@ namespace MayaFlux::IO {
     const std::vector<std::string>& field_names = {});
 
 /**
+ * @brief Upload every field of a host VolumeData into a GPU-resident volume.
+ *
+ * The reverse of download_volume: for each field in @p data whose name is
+ * declared on @p volume, writes its bytes into the current write slot via
+ * VolumeGridBuffer::seed_raw. The calling thread must have command queue
+ * access, matching download_volume's requirement, since seed_raw records a
+ * transfer that must resolve before the next one can be issued.
+ *
+ * A scalar field (VolumeField holding vector<float>) uploads directly. A
+ * vector field is expanded from glm::vec3 to glm::vec4 first, zeroing the
+ * fourth component, because the GPU layout carries that padding and
+ * VolumeData does not — the inverse of the gather download_volume performs.
+ * That expansion costs an allocation at four thirds the input size.
+ *
+ * A field named in @p data but not declared on @p volume, or whose declared
+ * stride does not match what the field's variant implies (float for a
+ * scalar, vec4 for a vector), is skipped with an error; the rest of the
+ * upload proceeds. Neither VolumeData's lattice nor its cell count is
+ * checked against the volume's own — a mismatch surfaces as seed_raw's own
+ * size-mismatch error per field, not as a single upfront rejection.
+ *
+ * Each field is one seed_raw call rather than a batched transfer: simpler
+ * than building a seed_raw counterpart to read_fields' batching, at the
+ * cost of one staging round trip per field instead of one for the whole
+ * upload. Worth revisiting if upload_volume becomes a per-frame path rather
+ * than the one-shot load this exists for.
+ *
+ * @param data   Source, typically from IO::VolumeReader::load().
+ * @param volume Destination. Fields must already be declared; this call
+ *               never declares one.
+ * @return True if at least one field was uploaded.
+ */
+bool upload_volume(
+    const Kakshya::VolumeData& data,
+    const std::shared_ptr<Buffers::VolumeGridBuffer>& volume);
+
+/**
  * @brief Save a volume directly to disk via the VolumeWriter registry.
  *
  * Combines download_volume() with VolumeWriterRegistry::create_writer(). The


### PR DESCRIPTION
## Volume import

The write side shipped .vdb export. This closes the loop: VolumeReader reads a .vdb back into VolumeData, and IOManager::load_volume wraps it the same way load_image and load_model
already do.

```cpp
auto& io = get_io_manager();
auto vol = io.load_volume("smoke.0000.vdb");
```

With no lattice given, the reader reconstructs one from the union of every selected grid's active bounds, the file's own content decides the size. Pass a lattice and it round trips a
MayaFlux write exactly instead:
```cpp
auto vol = io.load_volume("smoke.0000.vdb", known_lattice);
```
Field selection works the same way image and model readers already do, matched by grid name:
```cpp
auto vol = io.load_volume("smoke.0000.vdb", {}, { .field_names = { "density", "velocity" } });
```
A grid typed outside float or vec3 narrows through MayaFlux::try_convert, and now actually reports when that narrowing lost precision rather than narrowing blindly.

## Reconciling a loaded file with fields

A loaded file only declares the fields it reported. A caller wanting to run a simulation over that data, not just display it, needs more than the file gave it, and declaring those blind
risks colliding with a name the file also used. VolumeGridBuffer::ensure_fields checks first:

```cpp
using namespace Kinesis;

auto buffer = /* built from vol->lattice */;

auto declared = buffer->ensure_fields({
    { "velocity", sizeof(glm::vec4), true, { .variance = VectorVariance::ContravariantRelative } },
    { "velocity_prev", sizeof(glm::vec4), true },
    { "divergence", sizeof(float), false },
    { "pressure", sizeof(float), true },
    { "temperature", sizeof(float), true, { .value_class = LatticeValueClass::FogVolume } },
});
```

fire.vdb already reports a real "temperature" grid, so that entry is left alone and only the rest come back in declared. Seed exactly those, everything the file already populated stays
untouched.

## Verification

Verified against a real foreign file, OpenVDB's fire.vdb sample, not just MayaFlux's own writer. That caught a genuine bug: AFFINE transforms were reading translation from the wrong part
of the matrix, which any non uniform scale from another DCC would have hit. Fixed, with a test that would have caught it. fire.vdb also became a real demo, a buoyancy sim seeded from the
loaded density rather than a camera trick over a static load.

## Known limitation

A file with grids that genuinely differ in voxel size or translation isn't resampled into agreement, each grid reads against the shared region as is. That used to be silent, it now logs a
warning naming the mismatched grid. Real per-grid resampling is buildable on what's already here but deferred until a file that actually needs it shows up.
